### PR TITLE
Implement Sys_ReLaunch() for Linux, refactor it

### DIFF
--- a/neo/d3xp/menus/MenuScreen_Shell_Stereoscopics.cpp
+++ b/neo/d3xp/menus/MenuScreen_Shell_Stereoscopics.cpp
@@ -219,12 +219,10 @@ void idMenuScreen_Shell_Stereoscopics::HideScreen( const mainMenuTransition_t tr
 				common->Dialog().ClearDialog( msg );
 				if( restart )
 				{
-					idStr cmdLine = Sys_GetCmdLine();
-					if( cmdLine.Find( "com_skipIntroVideos" ) < 0 )
-					{
-						cmdLine.Append( " +set com_skipIntroVideos 1" );
-					}
-					Sys_ReLaunch( ( void* )cmdLine.c_str(), cmdLine.Length() );
+					// DG: Sys_ReLaunch() doesn't need any options anymore
+					//     (the old way would have been unnecessarily painful on POSIX systems)
+					Sys_ReLaunch();
+					// DG end
 				}
 				return idSWFScriptVar();
 			}

--- a/neo/d3xp/menus/MenuScreen_Shell_SystemOptions.cpp
+++ b/neo/d3xp/menus/MenuScreen_Shell_SystemOptions.cpp
@@ -232,12 +232,10 @@ void idMenuScreen_Shell_SystemOptions::HideScreen( const mainMenuTransition_t tr
 				common->Dialog().ClearDialog( msg );
 				if( restart )
 				{
-					idStr cmdLine = Sys_GetCmdLine();
-					if( cmdLine.Find( "com_skipIntroVideos" ) < 0 )
-					{
-						cmdLine.Append( " +set com_skipIntroVideos 1" );
-					}
-					Sys_ReLaunch( ( void* )cmdLine.c_str(), cmdLine.Length() );
+					// DG: Sys_ReLaunch() doesn't need any options anymore
+					//     (the old way would have been unnecessarily painful on POSIX systems)
+					Sys_ReLaunch();
+					// DG end
 				}
 				return idSWFScriptVar();
 			}

--- a/neo/sys/sys_public.h
+++ b/neo/sys/sys_public.h
@@ -432,7 +432,9 @@ void			Sys_Init();
 void			Sys_Shutdown();
 void			Sys_Error( const char* error, ... );
 const char* 	Sys_GetCmdLine();
-void			Sys_ReLaunch( void* launchData, unsigned int launchDataSize );
+// DG: Sys_ReLaunch() doesn't need any options (and the old way is painful for POSIX systems)
+void			Sys_ReLaunch();
+// DG end
 void			Sys_Launch( const char* path, idCmdArgs& args,  void* launchData, unsigned int launchDataSize );
 void			Sys_SetLanguageFromSystem();
 const char* 	Sys_DefaultLanguage();

--- a/neo/sys/win32/win_main.cpp
+++ b/neo/sys/win32/win_main.cpp
@@ -290,7 +290,7 @@ const char * Sys_GetCmdLine() {
 Sys_ReLaunch
 ========================
 */
-void Sys_ReLaunch( void * data, const unsigned int dataSize ) {
+void Sys_ReLaunch() {
 	TCHAR				szPathOrig[MAX_PRINT_MSG];
 	STARTUPINFO			si;
 	PROCESS_INFORMATION	pi;
@@ -298,7 +298,17 @@ void Sys_ReLaunch( void * data, const unsigned int dataSize ) {
 	ZeroMemory( &si, sizeof(si) );
 	si.cb = sizeof(si);
 
-	strcpy( szPathOrig, va( "\"%s\" %s", Sys_EXEPath(), (const char *)data ) );
+	// DG: we don't have function arguments in Sys_ReLaunch() anymore, everyone only passed
+	//     the command-line +" +set com_skipIntroVideos 1" anyway and it was painful on POSIX systems
+	//     so let's just add it here.
+	idStr cmdLine = Sys_GetCmdLine();
+	if( cmdLine.Find( "com_skipIntroVideos" ) < 0 )
+	{
+		cmdLine.Append( " +set com_skipIntroVideos 1" );
+	}
+
+	strcpy( szPathOrig, va( "\"%s\" %s", Sys_EXEPath(), cmdLine.c_str() ) );
+	// DG end
 
 	CloseHandle( hProcessMutex );
 


### PR DESCRIPTION
It now works on Linux so executing it doesn't freeze the game
like described in
https://github.com/RobertBeckebans/RBDOOM-3-BFG/issues/33

Furthermore, this function doesn't have any parameters anymore
(on any platform) because the only thing supplied was the original
program arguments +"+set com_skipIntroVideos 1" anyway - this is now
done in Sys_ReLaunch() (also on Windows).
Having the program arguments as one string is bad on Linux/POSIX
because there it's expected that the program arguments are one
C-string per argument.
