### PR TITLE
Fix console-input in SDL1.2 for lots of unmapped keys

### DIFF
--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -853,6 +853,16 @@ sysEvent_t Sys_GetEvent()
 				}
 				// DG end
 				
+#if ! SDL_VERSION_ATLEAST(2, 0, 0)
+				// DG: only do this for key-down, don't care about isChar from SDL_KeyToDoom3Key.
+				//     if unicode is not 0 and is translatable to ASCII it should work..
+				if( ev.key.state == SDL_PRESSED && ( ev.key.keysym.unicode & 0xff80 ) == 0 )
+				{
+					c = ev.key.keysym.unicode & 0x7f;
+				}
+				// DG end
+#endif
+				
 				// fall through
 			case SDL_KEYUP:
 			{
@@ -883,7 +893,7 @@ sysEvent_t Sys_GetEvent()
 						}
 						else
 						{
-							if( ev.type == SDL_KEYDOWN )
+							if( ev.type == SDL_KEYDOWN ) // FIXME: don't complain if this was an ASCII char and the console is open?
 								common->Warning( "unmapped SDL key %d (0x%x) scancode %d", ev.key.keysym.sym, ev.key.keysym.unicode, ev.key.keysym.scancode );
 							return res_none;
 						}
@@ -898,13 +908,7 @@ sysEvent_t Sys_GetEvent()
 				
 				if( key == K_BACKSPACE && ev.key.state == SDL_PRESSED )
 					c = key;
-#if ! SDL_VERSION_ATLEAST(2, 0, 0)
-				if( ev.key.state == SDL_PRESSED && isChar && ( ev.key.keysym.unicode & 0xff00 ) == 0 )
-				{
-					c = ev.key.keysym.unicode & 0xff;
-				}
-#endif
-				
+					
 				return res;
 			}
 			


### PR DESCRIPTION
A lot of keys (especially keys not available on US keyboards) just weren't
supported for console input with SDL1.2 (SDL2 uses a different mechanism for
that).

This is fixed now by reordering a few lines in sdl_events.cpp

Please note that still only ASCII characters are supported and those keys
still can not be used in bindings - only for text input!

Fixes https://github.com/RobertBeckebans/RBDOOM-3-BFG/issues/34

**This needs testing before it can be merged!**
