### PR TITLE
SDL2: SDL_GetWindowDisplay got renamed to SDL_GetWindowDisplayIndex

### DIFF
--- a/neo/sys/sdl/sdl_glimp.cpp
+++ b/neo/sys/sdl/sdl_glimp.cpp
@@ -319,7 +319,7 @@ static int ScreenParmsHandleDisplayIndex( glimpParms_t parms )
 	}
 	else // -2 == use current display
 	{
-		displayIdx = SDL_GetWindowDisplay( window );
+		displayIdx = SDL_GetWindowDisplayIndex( window );
 		if( displayIdx < 0 ) // for some reason the display for the window couldn't be detected
 			displayIdx = 0;
 	}


### PR DESCRIPTION
Adapt to new (5 weeks old) naming of the  function.

SDL2 commit: http://hg.libsdl.org/SDL/rev/7174fb08017a
