### PR TITLE
Handle st_lwPolygon::surf for 64bit.

### DIFF
--- a/neo/renderer/Model.cpp
+++ b/neo/renderer/Model.cpp
@@ -1799,7 +1799,7 @@ bool idRenderModelStatic::ConvertLWOToModelSurfaces( const struct st_lwObject* l
 		{
 			lwPolygon* poly = &layer->polygon.pol[j];
 			
-			if( poly->surf != lwoSurf )
+			if( poly->surf.ptr != lwoSurf )
 			{
 				continue;
 			}
@@ -2070,7 +2070,7 @@ struct aseModel_s* idRenderModelStatic::ConvertLWOToASE( const struct st_lwObjec
 		{
 			lwPolygon* poly = &layer->polygon.pol[j];
 			
-			if( poly->surf != surf )
+			if( poly->surf.ptr != surf )
 			{
 				continue;
 			}

--- a/neo/renderer/Model_lwo.cpp
+++ b/neo/renderer/Model_lwo.cpp
@@ -2311,7 +2311,7 @@ int lwGetPolygons5( idFile* fp, int cksize, lwPolygonList* plist, int ptoffset )
 			bp += 2;
 		}
 		j -= 1;
-		pp->surf = ( lwSurface* ) j; // DG: FIXME: cast int to pointer?!
+		pp->surf.index = j;
 		
 		pp++;
 		pv += nv;
@@ -2855,12 +2855,11 @@ int lwResolvePolySurfaces( lwPolygonList* polygon, lwTagList* tlist,
 			st = st->next;
 		}
 	}
-	// RB: 64 bit fixes
-	uintptr_t index;
+
+	intptr_t index;
 	for( i = 0; i < polygon->count; i++ )
 	{
-		index = ( uintptr_t ) polygon->pol[ i ].surf;
-		// RB end
+		index = polygon->pol[ i ].surf.index;
 		
 		if( index < 0 || index > tlist->count ) return 0;
 		if( !s[ index ] )
@@ -2873,7 +2872,7 @@ int lwResolvePolySurfaces( lwPolygonList* polygon, lwTagList* tlist,
 			lwListAdd( ( void** )surf, s[ index ] );
 			*nsurfs = *nsurfs + 1;
 		}
-		polygon->pol[ i ].surf = s[ index ];
+		polygon->pol[ i ].surf.ptr = s[ index ];
 	}
 	
 	Mem_Free( s );
@@ -2908,7 +2907,7 @@ void lwGetVertNormals( lwPointList* point, lwPolygonList* polygon )
 			for( k = 0; k < 3; k++ )
 				polygon->pol[ j ].v[ n ].norm[ k ] = polygon->pol[ j ].norm[ k ];
 				
-			if( polygon->pol[ j ].surf->smooth <= 0 ) continue;
+			if( polygon->pol[ j ].surf.ptr->smooth <= 0 ) continue;
 			
 			p = polygon->pol[ j ].v[ n ].index;
 			
@@ -2920,7 +2919,7 @@ void lwGetVertNormals( lwPointList* point, lwPolygonList* polygon )
 				if( polygon->pol[ j ].smoothgrp != polygon->pol[ h ].smoothgrp )
 					continue;
 				a = vecangle( polygon->pol[ j ].norm, polygon->pol[ h ].norm );
-				if( a > polygon->pol[ j ].surf->smooth ) continue;
+				if( a > polygon->pol[ j ].surf.ptr->smooth ) continue;
 				
 				for( k = 0; k < 3; k++ )
 					polygon->pol[ j ].v[ n ].norm[ k ] += polygon->pol[ h ].norm[ k ];
@@ -3054,7 +3053,7 @@ int lwGetPolygonTags( idFile* fp, int cksize, lwTagList* tlist, lwPolygonList* p
 		switch( type )
 		{
 			case ID_SURF:
-				plist->pol[ i ].surf = ( lwSurface* ) j; // DG: FIXME: cast int to pointer?!
+				plist->pol[ i ].surf.index = j;
 				break;
 			case ID_PART:
 				plist->pol[ i ].part = j;

--- a/neo/renderer/Model_lwo.h
+++ b/neo/renderer/Model_lwo.h
@@ -532,7 +532,10 @@ typedef struct st_lwPolVert
 
 typedef struct st_lwPolygon
 {
-	lwSurface*     surf;
+	union {
+		intptr_t   index;
+		lwSurface* ptr;
+	}              surf;
 	int            part;                /* part index */
 	int            smoothgrp;           /* smoothing group */
 	int            flags;


### PR DESCRIPTION
Fix multiple compiler warnings and properly handle st_lwPolygon::surf for 64bit.

Changed surf member to now be a union of a intptr_t index and a lwSurface_.
Index member has to be signed to prevent overflow (by assigning a possibly negative short).
For most platforms, sizeof(int_) should be the same as sizeof(lwSurface_), though this might still be a race condition/annoyance when sizeof(int_) > sizeof(lwSurface*).
