### PR TITLE
Treat unused function result as an error for gcc and clang...

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -37,6 +37,7 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 	add_definitions(-pipe)
+	add_definitions(-Werror=unused-result)
 	#add_definitions(-Wall)
 	add_definitions(-mmmx -msse -msse2)
 	if(WIN32)

--- a/neo/idlib/Heap.cpp
+++ b/neo/idlib/Heap.cpp
@@ -59,7 +59,9 @@ void* Mem_Alloc16( const size_t size, const memTag_t tag )
 #else // not _WIN32
 	// DG: the POSIX solution for linux etc
 	void* ret;
-	posix_memalign( &ret, 16, paddedSize );
+	int result = posix_memalign( &ret, 16, paddedSize );
+	if( result != 0 )
+		idLib::FatalError( "%s failed at %s with result %d", "Mem_Alloc16", "posix_memalign", result );
 	return ret;
 	// DG end
 #endif // _WIN32

--- a/neo/sys/linux/linux_main.cpp
+++ b/neo/sys/linux/linux_main.cpp
@@ -476,7 +476,9 @@ void Sys_DoStartProcess( const char* exeName, bool dofork )
 				if( use_system )
 				{
 					printf( "system %s\n", exeName );
-					system( exeName );
+					int result = system( exeName );
+					if( result < 0 )
+						printf( "%s failed at %s with return status %d", "Sys_DoStartProcess", "system", result );
 					_exit( 0 );
 				}
 				else
@@ -494,7 +496,9 @@ void Sys_DoStartProcess( const char* exeName, bool dofork )
 		if( use_system )
 		{
 			printf( "system %s\n", exeName );
-			system( exeName );
+			int result = system( exeName );
+			if( result < 0 )
+				printf( "%s failed at %s with return status %d", "Sys_DoStartProcess", "system", result );
 			sleep( 1 );	// on some systems I've seen that starting the new process and exiting this one should not be too close
 		}
 		else


### PR DESCRIPTION
... and handle them accordingly.
