### PR TITLE
Fix length error in prefix comparison

### DIFF
--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -402,7 +402,7 @@ static void R_CheckPortableExtensions()
 	}
 	
 	// RB: Mesa support
-	if( idStr::Icmpn( glConfig.renderer_string, "Mesa", 4 ) == 0 || idStr::Icmpn( glConfig.renderer_string, "X.org", 4 ) == 0 )
+	if( idStr::Icmpn( glConfig.renderer_string, "Mesa", 4 ) == 0 || idStr::Icmpn( glConfig.renderer_string, "X.org", 5 ) == 0 )
 	{
 		glConfig.driverType = GLDRV_OPENGL_MESA;
 	}


### PR DESCRIPTION
I suppose the original author intends to test for string prefixes here, but they only compare the first 4 characters of `"X.org"` instead of all 5.
