### PR TITLE
Change default Linux path to a generic and standard name

### DIFF
--- a/neo/framework/Licensee.h
+++ b/neo/framework/Licensee.h
@@ -66,7 +66,7 @@ If you have questions concerning this license or the applicable additional terms
 #ifdef __APPLE__
 #define DEFAULT_BASEPATH				"/Applications/RBDOOM-3-BFG.app/Contents/Resources"
 #else
-#define DEFAULT_BASEPATH				"/usr/local/games/rbdoom-3-bfg"
+#define DEFAULT_BASEPATH				"/usr/share/games/doom3bfg"
 #endif
 // RB end
 


### PR DESCRIPTION
While the game so far has no official release on Linux, we cannot
depend on any pre-installed path for the game.  Even if it were, it
would likely be a steam exclusive and constrained to
$HOME/.local/share/Steam ...

Instead, this adopts a more typical Debian-style path used for game
data, that is putting it into /usr/share/games. This is already the
path I have chosen when making the doom3bfg-data package[1] for the
Arch Linux AUR, and currently both packages for RBDOOM-3-BFG patch
this file in order to use this path. The more generic path name can
facilitate the use of any other forks of BFG Edition that may come
along, and everyone will benefit by sharing the same data path.

[1] https://aur.archlinux.org/packages/doom3bfg-data/
