### PR TITLE
Build fixes for OpenBSD

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -1322,7 +1322,7 @@ else()
 		${SYS_INCLUDES} ${SYS_SOURCES})
 	
 	find_package(OpenGL REQUIRED)
-	include_directories(${OPENGL_INCLUDE_DIRS})
+	include_directories(${OPENGL_INCLUDE_DIR})
 
 	if(UNIX)
 		if(FFMPEG)

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -1449,11 +1449,13 @@ else()
 	
 
 	if(NOT WIN32)
-		if(NOT "${CMAKE_SYSTEM}" MATCHES "Darwin")
+		if(NOT ("${CMAKE_SYSTEM}" MATCHES "Darwin" OR
+			"${CMAKE_SYSTEM}" MATCHES "OpenBSD"))
 			set(RT_LIBRARY rt)
 		endif()
 
-		if(NOT "${CMAKE_SYSTEM}" MATCHES "FreeBSD")
+		if(NOT ("${CMAKE_SYSTEM}" MATCHES "FreeBSD" OR
+			"${CMAKE_SYSTEM}" MATCHES "OpenBSD"))
 			set(DL_LIBRARY dl)
 		endif()
 

--- a/neo/idlib/CMakeLists.txt
+++ b/neo/idlib/CMakeLists.txt
@@ -112,6 +112,8 @@ else()
 			)
 	endforeach()
 	
+	find_package(OpenGL REQUIRED)
+	include_directories(${OPENGL_INCLUDE_DIR})
 	include_directories(.)
 	
 	# precompiled magic for GCC/clang, adapted from https://gist.github.com/573926

--- a/neo/idlib/ParallelJobList_JobHeaders.h
+++ b/neo/idlib/ParallelJobList_JobHeaders.h
@@ -62,7 +62,7 @@ If you have questions concerning this license or the applicable additional terms
 #include <signal.h>
 // RB end
 // Yamagi begin
-#elif defined(__FreeBSD__)
+#elif defined(__unix__)
 #include <signal.h>
 #endif
 // Yamagi end

--- a/neo/idlib/math/Simd.cpp
+++ b/neo/idlib/math/Simd.cpp
@@ -61,7 +61,7 @@ idSIMD::InitProcessor
 */
 void idSIMD::InitProcessor( const char* module, bool forceGeneric )
 {
-	cpuid_t cpuid;
+	xcpuid_t cpuid;
 	idSIMDProcessor* newProcessor;
 	
 	cpuid = idLib::sys->GetProcessorId();
@@ -1384,7 +1384,7 @@ void idSIMD::Test_f( const idCmdArgs& args )
 	
 	if( idStr::Length( args.Argv( 1 ) ) != 0 )
 	{
-		cpuid_t cpuid = idLib::sys->GetProcessorId();
+		xcpuid_t cpuid = idLib::sys->GetProcessorId();
 		idStr argString = args.Args();
 		
 		argString.Replace( " ", "" );

--- a/neo/idlib/math/Simd.h
+++ b/neo/idlib/math/Simd.h
@@ -92,7 +92,7 @@ public:
 		cpuid = CPUID_NONE;
 	}
 	
-	cpuid_t							cpuid;
+	xcpuid_t							cpuid;
 	
 	virtual const char* VPCALL		GetName() const = 0;
 	

--- a/neo/idlib/sys/posix/posix_thread.cpp
+++ b/neo/idlib/sys/posix/posix_thread.cpp
@@ -38,7 +38,7 @@ If you have questions concerning this license or the applicable additional terms
 #include "../../../sys/posix/posix_public.h"
 #endif
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <pthread_np.h> // for pthread_set_name_np
 #endif
 
@@ -71,7 +71,7 @@ static int Sys_SetThreadName( pthread_t handle, const char* name )
 	ret = pthread_setname_np( handle, name );
 	if( ret != 0 )
 		idLib::common->Printf( "Setting threadname \"%s\" failed, reason: %s (%i)\n", name, strerror( errno ), errno );
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 	// according to http://www.freebsd.org/cgi/man.cgi?query=pthread_set_name_np&sektion=3
 	// the interface is void pthread_set_name_np(pthread_t tid, const char *name);
 	pthread_set_name_np( handle, name ); // doesn't return anything
@@ -94,7 +94,7 @@ static int Sys_GetThreadName( pthread_t handle, char* namebuf, size_t buflen )
 	ret = pthread_getname_np( handle, namebuf, buflen );
 	if( ret != 0 )
 		idLib::common->Printf( "Getting threadname failed, reason: %s (%i)\n", strerror( errno ), errno );
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 	// seems like there is no pthread_getname_np equivalent on FreeBSD
 	idStr::snPrintf( namebuf, buflen, "Can't read threadname on this platform!" );
 #endif

--- a/neo/idlib/sys/sys_defines.h
+++ b/neo/idlib/sys/sys_defines.h
@@ -102,7 +102,7 @@ If you have questions concerning this license or the applicable additional terms
 #endif
 
 
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
+#elif defined(__unix__)
 
 #if defined(__i386__)
 #define	CPUSTRING						"x86"
@@ -112,10 +112,14 @@ If you have questions concerning this license or the applicable additional terms
 
 #if defined(__FreeBSD__)
 #define	BUILD_STRING					"freebsd-" CPUSTRING
+#elif defined(__OpenBSD__)
+#define	BUILD_STRING					"openbsd-" CPUSTRING
 #elif defined(__linux__)
 #define	BUILD_STRING					"linux-" CPUSTRING
 #elif defined(__APPLE__)
 #define BUILD_STRING					"osx-" CPUSTRING
+#else
+#define BUILD_STRING					"unknown-" CPUSTRING
 #endif
 
 #define _alloca							alloca

--- a/neo/idlib/sys/sys_includes.h
+++ b/neo/idlib/sys/sys_includes.h
@@ -109,7 +109,7 @@ If you have questions concerning this license or the applicable additional terms
 
 #include <windows.h>						// for gl.h
 
-#elif defined(__linux__) || defined(__FreeBSD__)
+#elif defined(__unix__)
 
 #include <signal.h>
 #include <pthread.h>

--- a/neo/libs/zlib/minizip/ioapi.h
+++ b/neo/libs/zlib/minizip/ioapi.h
@@ -53,7 +53,7 @@
 #define ftello64 ftell
 #define fseeko64 fseek
 #else
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #define fopen64 fopen
 #define ftello64 ftello
 #define fseeko64 fseeko

--- a/neo/sys/common/socket_net.cpp
+++ b/neo/sys/common/socket_net.cpp
@@ -64,7 +64,7 @@ Note that other POSIX systems may need some small changes, e.g. in Sys_InitNetwo
 #include <errno.h>
 #include <sys/select.h>
 #include <net/if.h>
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <ifaddrs.h>
 #endif
 
@@ -954,7 +954,7 @@ void Sys_InitNetworking()
 	}
 	free( pAdapterInfo );
 	
-#elif defined(__APPLE__) || defined(__FreeBSD__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 	// haven't been able to clearly pinpoint which standards or RFCs define SIOCGIFCONF, SIOCGIFADDR, SIOCGIFNETMASK ioctls
 	// it seems fairly widespread, in Linux kernel ioctl, and in BSD .. so let's assume it's always available on our targets
 	
@@ -1013,7 +1013,7 @@ void Sys_InitNetworking()
 		// DG end
 		num_interfaces++;
 	}
-#else // not _WIN32, OSX or FreeBSD
+#else // not _WIN32, OSX, FreeBSD or OpenBSD
 	int		s;
 	char	buf[ MAX_INTERFACES * sizeof( ifreq ) ];
 	ifconf	ifc;

--- a/neo/sys/posix/platform_linux.cpp
+++ b/neo/sys/posix/platform_linux.cpp
@@ -78,7 +78,7 @@ const char* Sys_EXEPath()
 Sys_GetProcessorId
 ===============
 */
-cpuid_t Sys_GetProcessorId()
+xcpuid_t Sys_GetProcessorId()
 {
 	return CPUID_GENERIC;
 }

--- a/neo/sys/posix/platform_osx.cpp
+++ b/neo/sys/posix/platform_osx.cpp
@@ -73,7 +73,7 @@ const char* Sys_EXEPath()
 Sys_GetProcessorId
 ===============
 */
-cpuid_t Sys_GetProcessorId()
+xcpuid_t Sys_GetProcessorId()
 {
 	return CPUID_GENERIC;
 }

--- a/neo/sys/sdl/sdl_cpu.cpp
+++ b/neo/sys/sdl/sdl_cpu.cpp
@@ -182,7 +182,7 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 Sys_GetCPUId
 ================
 */
-cpuid_t Sys_GetCPUId()
+xcpuid_t Sys_GetCPUId()
 {
 	int flags;
 	
@@ -241,7 +241,7 @@ cpuid_t Sys_GetCPUId()
 	}
 	*/
 	
-	return ( cpuid_t )flags;
+	return ( xcpuid_t )flags;
 }
 
 

--- a/neo/sys/sys_local.cpp
+++ b/neo/sys/sys_local.cpp
@@ -66,7 +66,7 @@ double idSysLocal::ClockTicksPerSecond()
 	return Sys_ClockTicksPerSecond();
 }
 
-cpuid_t idSysLocal::GetProcessorId()
+xcpuid_t idSysLocal::GetProcessorId()
 {
 	return Sys_GetProcessorId();
 }

--- a/neo/sys/sys_local.h
+++ b/neo/sys/sys_local.h
@@ -45,7 +45,7 @@ public:
 	
 	virtual double			GetClockTicks();
 	virtual double			ClockTicksPerSecond();
-	virtual cpuid_t			GetProcessorId();
+	virtual xcpuid_t			GetProcessorId();
 	virtual const char* 	GetProcessorString();
 	virtual const char* 	FPU_GetState();
 	virtual bool			FPU_StackIsEmpty();

--- a/neo/sys/sys_public.h
+++ b/neo/sys/sys_public.h
@@ -40,7 +40,7 @@ If you have questions concerning this license or the applicable additional terms
 ===============================================================================
 */
 
-enum cpuid_t
+enum xcpuid_t
 {
 	CPUID_NONE							= 0x00000,
 	CPUID_UNSUPPORTED					= 0x00001,	// unsupported (386/486)
@@ -471,7 +471,7 @@ double			Sys_GetClockTicks();
 double			Sys_ClockTicksPerSecond();
 
 // returns a selection of the CPUID_* flags
-cpuid_t			Sys_GetProcessorId();
+xcpuid_t			Sys_GetProcessorId();
 const char* 	Sys_GetProcessorString();
 
 // returns true if the FPU stack is empty
@@ -761,7 +761,7 @@ public:
 	
 	virtual double			GetClockTicks() = 0;
 	virtual double			ClockTicksPerSecond() = 0;
-	virtual cpuid_t			GetProcessorId() = 0;
+	virtual xcpuid_t			GetProcessorId() = 0;
 	virtual const char* 	GetProcessorString() = 0;
 	virtual const char* 	FPU_GetState() = 0;
 	virtual bool			FPU_StackIsEmpty() = 0;

--- a/neo/sys/win32/win_cpu.cpp
+++ b/neo/sys/win32/win_cpu.cpp
@@ -769,7 +769,7 @@ void Sys_CPUCount( int & numLogicalCPUCores, int & numPhysicalCPUCores, int & nu
 Sys_GetCPUId
 ================
 */
-cpuid_t Sys_GetCPUId()
+xcpuid_t Sys_GetCPUId()
 {
 	// RB: we assume a modern x86 chip
 #if defined(_WIN64)
@@ -778,7 +778,7 @@ cpuid_t Sys_GetCPUId()
 	flags |= CPUID_SSE;
 	flags |= CPUID_SSE2;
 
-	return (cpuid_t)flags;
+	return (xcpuid_t)flags;
 #else
 	int flags;
 
@@ -834,7 +834,7 @@ cpuid_t Sys_GetCPUId()
 		flags |= CPUID_DAZ;
 	}
 
-	return (cpuid_t)flags;
+	return (xcpuid_t)flags;
 #endif
 }
 

--- a/neo/sys/win32/win_local.h
+++ b/neo/sys/win32/win_local.h
@@ -50,7 +50,7 @@ char*	Sys_GetCurrentUser();
 
 void	Win_SetErrorText( const char* text );
 
-cpuid_t	Sys_GetCPUId();
+xcpuid_t	Sys_GetCPUId();
 
 // Input subsystem
 
@@ -85,7 +85,7 @@ typedef struct
 	
 	OSVERSIONINFOEX	osversion;
 	
-	cpuid_t			cpuid;
+	xcpuid_t			cpuid;
 	
 	// when we get a windows message, we store the time off so keyboard processing
 	// can know the exact time of an event (not really needed now that we use async direct input)

--- a/neo/sys/win32/win_main.cpp
+++ b/neo/sys/win32/win_main.cpp
@@ -1245,7 +1245,7 @@ void Sys_Init() {
 			common->Printf( "WARNING: unknown sys_cpustring '%s'\n", win32.sys_cpustring.GetString() );
 			id = CPUID_GENERIC;
 		}
-		win32.cpuid = (cpuid_t) id;
+		win32.cpuid = (xcpuid_t) id;
 	}
 
 	common->Printf( "%s\n", win32.sys_cpustring.GetString() );
@@ -1272,7 +1272,7 @@ void Sys_Shutdown() {
 Sys_GetProcessorId
 ================
 */
-cpuid_t Sys_GetProcessorId() {
+xcpuid_t Sys_GetProcessorId() {
     return win32.cpuid;
 }
 


### PR DESCRIPTION
The commits here lets everything build and run on OpenBSD.  There is no /proc on OpenBSD so Sys_CPUCount() thinks there is one processor.  This could be later changed to use sysctl (hw.ncpu) similiar to platform_osx, or perhaps a sysconf(3) fallback with _SC_NPROCESSORS_ONLN could be used.  The cpu frequency could also be pulled from sysctl, but these changes don't seem to be strictly required to get things running.

And though there is an bug report open on Mesa, Mesa seems to work here:

OpenGL vendor string: Intel Open Source Technology Center
OpenGL renderer string: Mesa DRI Intel(R) Ivybridge Mobile
OpenGL core profile version string: 3.2 (Core Profile) Mesa 10.2.3
OpenGL core profile shading language version string: 3.30
OpenGL core profile context flags: (none)
OpenGL core profile profile mask: core profile

OpenGL version string: 3.0 Mesa 10.2.3
OpenGL shading language version string: 1.30
OpenGL context flags: (none)

OpenGL ES profile version string: OpenGL ES 3.0 Mesa 10.2.3
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.0

apart from some shader related errors printed to the console along the
lines of:

0:150(19): error: could not implicitly convert operands to arithmetic operator
While compiling fragment program renderprogs/interactionSM.pixel

There is nothing that visually sticks out as wrong when playing.
