### PR TITLE
make a shader work with Mesa by avoiding an implicit type conversion

### DIFF
--- a/base/renderprogs/interactionSM.pixel
+++ b/base/renderprogs/interactionSM.pixel
@@ -249,7 +249,7 @@ void main( PS_IN fragment, out PS_OUT result )
 	float shadow = 0.0;
 	
 	// RB: casting a float to int and using it as index can really kill the performance ...
-	int numSamples = 12; //int(rpScreenCorrectionFactor.w);
+	float numSamples = 12.0; //int(rpScreenCorrectionFactor.w);
 	float stepSize = 1.0 / numSamples;
 	
 	float4 jitterTC = ( fragment.position * rpScreenCorrectionFactor ) + rpJitterTexOffset;

--- a/neo/renderer/RenderProgs_embedded.h
+++ b/neo/renderer/RenderProgs_embedded.h
@@ -4424,7 +4424,7 @@ static const cgShaderDef_t cg_renderprogs[] =
 		"	float shadow = 0.0;\n"
 		"	\n"
 		"	// RB: casting a float to int and using it as index can really kill the performance ...\n"
-		"	int numSamples = 12; //int(rpScreenCorrectionFactor.w);\n"
+		"	float numSamples = 12.0; //int(rpScreenCorrectionFactor.w);\n"
 		"	float stepSize = 1.0 / numSamples;\n"
 		"	\n"
 		"	float4 jitterTC = ( fragment.position * rpScreenCorrectionFactor ) + rpJitterTexOffset;\n"


### PR DESCRIPTION
renderprogs/interactionSM.pixel does not compile with the Mesa 10.2.3
shader compiler due to a an implicit type conversion.

This gives a console warning on a release build and fatally
asserts on an debug build:

0:135(19): error: could not implicitly convert operands to arithmetic operator

Avoid this by changing an int declaration to a float.

 ----- R_InitOpenGL -----
Initializing OpenGL subsystem
Using 8 color bits, 24 depth, 8 stencil display
Using GLEW 1.10.0
OpenGL Version  : 3.0
OpenGL Vendor   : Intel Open Source Technology Center
OpenGL Renderer : Mesa DRI Intel(R) Ivybridge Mobile 
OpenGL GLSL     : 1.3
   maxTextureAnisotropy: 16.000000
...using GL_EXT_texture_lod_bias
X..GL_GREMEDY_string_marker not found
...using GL_EXT_framebuffer_object
...using GL_EXT_framebuffer_blit
----- Initializing Render Shaders -----
While compiling fragment program renderprogs/interactionSM.pixel

  1: #version 300 es
  2: #define PC
  3: precision mediump float;
  4: 
  5: void clip( float v ) { if ( v < 0.0 ) { discard; } }
  6: void clip( vec2 v ) { if ( any( lessThan( v, vec2( 0.0 ) ) ) ) { discard; } }
  7: void clip( vec3 v ) { if ( any( lessThan( v, vec3( 0.0 ) ) ) ) { discard; } }
  8: void clip( vec4 v ) { if ( any( lessThan( v, vec4( 0.0 ) ) ) ) { discard; } }
  9: 
 10: float saturate( float v ) { return clamp( v, 0.0, 1.0 ); }
 11: vec2 saturate( vec2 v ) { return clamp( v, 0.0, 1.0 ); }
 12: vec3 saturate( vec3 v ) { return clamp( v, 0.0, 1.0 ); }
 13: vec4 saturate( vec4 v ) { return clamp( v, 0.0, 1.0 ); }
 14: 
 15: vec4 tex2D( sampler2D sampler, vec2 texcoord ) { return texture( sampler, texcoord.xy ); }
 16: vec4 tex2D( sampler2DShadow sampler, vec3 texcoord ) { return vec4( texture( sampler, texcoord.xyz ) ); }
 17: 
 18: vec4 tex2D( sampler2D sampler, vec2 texcoord, vec2 dx, vec2 dy ) { return textureGrad( sampler, texcoord.xy, dx, dy ); }
 19: vec4 tex2D( sampler2DShadow sampler, vec3 texcoord, vec2 dx, vec2 dy ) { return vec4( textureGrad( sampler, texcoord.xyz, dx, dy ) ); }
 20: 
 21: vec4 texCUBE( samplerCube sampler, vec3 texcoord ) { return texture( sampler, texcoord.xyz ); }
 22: vec4 texCUBE( samplerCubeShadow sampler, vec4 texcoord ) { return vec4( texture( sampler, texcoord.xyzw ) ); }
 23: 
 24: vec4 tex2Dproj( sampler2D sampler, vec3 texcoord ) { return textureProj( sampler, texcoord ); }
 25: vec4 tex3Dproj( sampler3D sampler, vec4 texcoord ) { return textureProj( sampler, texcoord ); }
 26: 
 27: vec4 tex2Dbias( sampler2D sampler, vec4 texcoord ) { return texture( sampler, texcoord.xy, texcoord.w ); }
 28: vec4 tex3Dbias( sampler3D sampler, vec4 texcoord ) { return texture( sampler, texcoord.xyz, texcoord.w ); }
 29: vec4 texCUBEbias( samplerCube sampler, vec4 texcoord ) { return texture( sampler, texcoord.xyz, texcoord.w ); }
 30: 
 31: vec4 tex2Dlod( sampler2D sampler, vec4 texcoord ) { return textureLod( sampler, texcoord.xy, texcoord.w ); }
 32: vec4 tex3Dlod( sampler3D sampler, vec4 texcoord ) { return textureLod( sampler, texcoord.xyz, texcoord.w ); }
 33: vec4 texCUBElod( samplerCube sampler, vec4 texcoord ) { return textureLod( sampler, texcoord.xyz, texcoord.w ); }
 34: 
 35: 
 36: uniform vec4 _fa_[30];
 37: 
 38: float dot3 (vec3 a , vec3 b ) {return dot ( a , b ) ; }
 39: float dot3 (vec3 a , vec4 b ) {return dot ( a , b. xyz ) ; }
 40: float dot3 (vec4 a , vec3 b ) {return dot ( a. xyz , b ) ; }
 41: float dot3 (vec4 a , vec4 b ) {return dot ( a. xyz , b. xyz ) ; }
 42: float dot4 (vec4 a , vec4 b ) {return dot ( a , b ) ; }
 43: float dot4 (vec2 a , vec4 b ) {return dot ( vec4 ( a , 0 , 1 ) , b ) ; }
 44: const vec4 matrixCoCg1YtoRGB1X = vec4( 1.0, -1.0, 0.0, 1.0 );
 45: const vec4 matrixCoCg1YtoRGB1Y = vec4( 0.0, 1.0, -0.50196078, 1.0 );
 46: const vec4 matrixCoCg1YtoRGB1Z = vec4( -1.0, -1.0, 1.00392156, 1.0 );
 47: vec3 ConvertYCoCgToRGB (vec4 YCoCg ) {
 48:    vec3 rgbColor ;
 49:    YCoCg. z = ( YCoCg. z \* 31.875 ) + 1.0 ;
 50:    YCoCg. z = 1.0 / YCoCg. z ;
 51:    YCoCg. xy _= YCoCg. z ;
 52:    rgbColor. x = dot4 ( YCoCg , matrixCoCg1YtoRGB1X ) ;
 53:    rgbColor. y = dot4 ( YCoCg , matrixCoCg1YtoRGB1Y ) ;
 54:    rgbColor. z = dot4 ( YCoCg , matrixCoCg1YtoRGB1Z ) ;
 55:    return rgbColor ;
 56: }
 57: vec4 idtex2Dproj (sampler2D samp , vec4 texCoords ) {return tex2Dproj ( samp , texCoords. xyw ) ; }
 58: uniform sampler2D samp0;
 59: uniform sampler2D samp1;
 60: uniform sampler2D samp2;
 61: uniform sampler2D samp3;
 62: uniform sampler2D samp4;
 63: uniform sampler2DArrayShadow samp5;
 64: uniform sampler2D samp6;
 65: 
 66: in vec4 vofi_TexCoord0;
 67: in vec4 vofi_TexCoord1;
 68: in vec4 vofi_TexCoord2;
 69: in vec4 vofi_TexCoord3;
 70: in vec4 vofi_TexCoord4;
 71: in vec4 vofi_TexCoord5;
 72: in vec4 vofi_TexCoord6;
 73: in vec4 vofi_TexCoord7;
 74: in vec4 vofi_TexCoord8;
 75: in vec4 vofi_TexCoord9;
 76: in vec4 vofi_Color;
 77: 
 78: out vec4 fo_FragColor;
 79: 
 80: void main() {
 81:    vec4 bumpMap = tex2D ( samp0 , vofi_TexCoord1 . xy ) ;
 82:    vec4 lightFalloff = idtex2Dproj ( samp1 , vofi_TexCoord2 ) ;
 83:    vec4 lightProj = idtex2Dproj ( samp2 , vofi_TexCoord3 ) ;
 84:    vec4 YCoCG = tex2D ( samp3 , vofi_TexCoord4 . xy ) ;
 85:    vec4 specMap = tex2D ( samp4 , vofi_TexCoord5 . xy ) ;
 86:    vec3 lightVector = normalize ( vofi_TexCoord0 . xyz ) ;
 87:    vec3 diffuseMap = ConvertYCoCgToRGB ( YCoCG ) ;
 88:    vec3 localNormal ;
 89:    localNormal. xy = bumpMap. wy - 0.5 ;
 90:    localNormal. z = sqrt ( abs ( dot ( localNormal. xy , localNormal. xy ) - 0.25 ) ) ;
 91:    localNormal = normalize ( localNormal ) ;
 92:    float ldotN = dot3 ( localNormal , lightVector ) ;
 93:    float halfLdotN = dot3 ( localNormal , lightVector ) \* 0.5 + 0.5 ;
 94:    halfLdotN *= halfLdotN ;
 95:    float lambert = halfLdotN ;
 96:    float specularPower = 10.0 ;
 97:    float hDotN = dot3 ( normalize ( vofi_TexCoord6 . xyz ) , localNormal ) ;
 98:    vec3 specularContribution = vec3 ( pow ( abs ( hDotN ) , specularPower ) ) ;
 99:    vec3 diffuseColor = diffuseMap \* _fa_[1 /_ rpDiffuseModifier _/] . xyz ;
100:    vec3 specularColor = specMap. xyz \* specularContribution \* _fa_[2 /_ rpSpecularModifier _/] . xyz ;
101:    vec3 lightColor = lightProj. xyz \* lightFalloff. xyz ;
102:    float rim = 1.0 - saturate ( hDotN ) ;
103:    float rimPower = 16.0 ;
104:    vec3 rimColor = diffuseColor \* lightProj. xyz \* lightFalloff. xyz \* 1.0 \* pow ( rim , rimPower ) \* vofi_Color . rgb ;
105:    int shadowIndex = 0 ;
106:    vec4 shadowMatrixX = _fa_[/_ rpShadowMatrices _/ 5 + int ( shadowIndex \* 4 + 0 ) ] ;
107:    vec4 shadowMatrixY = _fa_[/_ rpShadowMatrices _/ 5 + int ( shadowIndex \* 4 + 1 ) ] ;
108:    vec4 shadowMatrixZ = _fa_[/_ rpShadowMatrices _/ 5 + int ( shadowIndex \* 4 + 2 ) ] ;
109:    vec4 shadowMatrixW = _fa_[/_ rpShadowMatrices _/ 5 + int ( shadowIndex \* 4 + 3 ) ] ;
110:    vec4 modelPosition = vec4 ( vofi_TexCoord7 . xyz , 1.0 ) ;
111:    vec4 shadowTexcoord ;
112:    shadowTexcoord. x = dot4 ( modelPosition , shadowMatrixX ) ;
113:    shadowTexcoord. y = dot4 ( modelPosition , shadowMatrixY ) ;
114:    shadowTexcoord. z = dot4 ( modelPosition , shadowMatrixZ ) ;
115:    shadowTexcoord. w = dot4 ( modelPosition , shadowMatrixW ) ;
116:    float bias = 0.001 ;
117:    shadowTexcoord. xyz /= shadowTexcoord. w ;
118:    shadowTexcoord. z = shadowTexcoord. z - bias ;
119:    shadowTexcoord. w = float ( shadowIndex ) ;
120:    vec2 poissonDisk [ 12 ] = vec2 [ ](121:    vec2 %28 0.6111618 , 0.1050905 %29 ,
122:    vec2 %28 0.1088336 , 0.1127091 %29 ,
123:    vec2 %28 0.3030421 , - 0.6292974 %29 ,
124:    vec2 %28 0.4090526 , 0.6716492 %29 ,
125:    vec2 %28 - 0.1608387 , - 0.3867823 %29 ,
126:    vec2 %28 0.7685862 , - 0.6118501 %29 ,
127:    vec2 %28 - 0.1935026 , - 0.856501 %29 ,
128:    vec2 %28 - 0.4028573 , 0.07754025 %29 ,
129:    vec2 %28 - 0.6411021 , - 0.4748057 %29 ,
130:    vec2 %28 - 0.1314865 , 0.8404058 %29 ,
131:    vec2 %28 - 0.7005203 , 0.4596822 %29 ,
132:    vec2 %28 - 0.9713828 , - 0.06329931 %29) ;
133:    float shadow = 0.0 ;
134:    int numSamples = 12 ;
135:    float stepSize = 1.0 / numSamples ;
136:    vec4 jitterTC = ( gl_FragCoord \* _fa_[0 /_ rpScreenCorrectionFactor _/] ) + _fa_[4 /_ rpJitterTexOffset _/] ;
137:    vec4 random = tex2D ( samp6 , jitterTC. xy ) \* 3.14159265358979323846 ;
138:    vec2 rot ;
139:    rot. x = cos ( random. x ) ;
140:    rot. y = sin ( random. x ) ;
141:    float shadowTexelSize = _fa_[0 /_ rpScreenCorrectionFactor _/] . z \* _fa_[3 /_ rpJitterTexScale */] . x ;
142:    for ( int i = 0 ; i < 12 ; i ++ )
143:    {
144:        vec2 jitter = poissonDisk [ i ] ;
145:        vec2 jitterRotated ;
146:        jitterRotated. x = jitter. x \* rot. x - jitter. y \* rot. y ;
147:        jitterRotated. y = jitter. x \* rot. y + jitter. y \* rot. x ;
148:        vec4 shadowTexcoordJittered = vec4 ( shadowTexcoord. xy + jitterRotated \* shadowTexelSize , shadowTexcoord. z , shadowTexcoord. w ) ;
149:        shadow += texture ( samp5 , shadowTexcoordJittered. xywz ) ;
150:    }
151:    shadow *= stepSize ;
152:    fo_FragColor . xyz = ( diffuseColor + specularColor ) \* lambert \* lightColor \* vofi_Color . rgb \* shadow ;
153:    fo_FragColor . w = 1.0 ;
154: }

0:135(19): error: could not implicitly convert operands to arithmetic operator

WARNING: ASSERTION FAILED! /usr/users/jsg/src/RBDOOM-3-BFG/neo/renderer/RenderProgs_GLSL.cpp(2163): 'prog.fragmentUniformArray != -1 || fragmentShaderIndex < 0 || fragmentShaders[fragmentShaderIndex].uniforms.Num() == 0'
signal caught: Trace/BPT trap
si_code 0
Trying to exit gracefully..
