### PR TITLE
Fix memory corruption in timidity resampling code

### DIFF
--- a/neo/libs/timidity/resample.cpp
+++ b/neo/libs/timidity/resample.cpp
@@ -710,7 +710,7 @@ void pre_resample(Sample * sp)
 	while (--count)
 	{
 		vptr = src + (ofs >> FRACTION_BITS);
-		v1 = *(vptr - 1);
+		v1 = (vptr == src) ? *vptr : *(vptr - 1);
 		v2 = *vptr;
 		v3 = *(vptr + 1);
 		v4 = *(vptr + 2);


### PR DESCRIPTION
From Sam Lantinga in SDL_mixer 1.2.8:
http://lists.libsdl.org/pipermail/commits-libsdl.org/2007-July/008673.html

Fixes a crash on OpenBSD.

Program received signal SIGSEGV, Segmentation fault.
[Switching to thread 1018427]
0x00000883c9729019 in pre_resample (sp=0x885e9ff1a00)
    at /usr/users/jsg/src/RBDOOM-3-BFG/neo/libs/timidity/resample.cpp:713
713                     v1 = *(vptr - 1);
Current language:  auto; currently c++
(gdb) bt
#0  0x00000883c9729019 in pre_resample (sp=0x885e9ff1a00)

```
at /usr/users/jsg/src/RBDOOM-3-BFG/neo/libs/timidity/resample.cpp:713
```
#1  0x00000883c9720600 in load_instrument (name=0x8864d1ddf20 "snare2", percussion=1,

```
panning=-1, amp=-1, note_to_use=38, strip_loop=1, strip_envelope=1, strip_tail=-1)
at /usr/users/jsg/src/RBDOOM-3-BFG/neo/libs/timidity/instrum.cpp:550
```
#2  0x00000883c9720afa in fill_bank (dr=1, b=0)

```
at /usr/users/jsg/src/RBDOOM-3-BFG/neo/libs/timidity/instrum.cpp:635
```
#3  0x00000883c9720c47 in load_missing_instruments ()

```
at /usr/users/jsg/src/RBDOOM-3-BFG/neo/libs/timidity/instrum.cpp:656
```
#4  0x00000883c9725d63 in Timidity_Start (song=0x88662265990)

```
at /usr/users/jsg/src/RBDOOM-3-BFG/neo/libs/timidity/playmidi.cpp:981
```
#5  0x00000883c9a3f66e in I_LoadSong (songname=0x883c9cf17cd "intro")

```
at /usr/users/jsg/src/RBDOOM-3-BFG/doomclassic/doom/i_sound_openal.cpp:817
```
#6  0x00000883c9a3f77b in I_PlaySong (songname=0x883c9cf17cd "intro", looping=0)

```
at /usr/users/jsg/src/RBDOOM-3-BFG/doomclassic/doom/i_sound_openal.cpp:855
```
#7  0x00000883c97127b8 in S_ChangeMusic (musicnum=29, looping=0)

```
at /usr/users/jsg/src/RBDOOM-3-BFG/doomclassic/doom/s_sound.cpp:506
```
#8  0x00000883c971272d in S_StartMusic (m_id=29)

```
at /usr/users/jsg/src/RBDOOM-3-BFG/doomclassic/doom/s_sound.cpp:478
```
#9  0x00000883c96d2b3a in D_DoAdvanceDemo ()

```
at /usr/users/jsg/src/RBDOOM-3-BFG/doomclassic/doom/d_main.cpp:422
```
#10 0x00000883c96d61f8 in TryRunTics (userCmdMgr=0x883ca249654)

```
at /usr/users/jsg/src/RBDOOM-3-BFG/doomclassic/doom/d_net.cpp:802
```
#11 0x00000883c96d7188 in DoomLib::Tic (userCmdMgr=0x883ca249654)

```
at /usr/users/jsg/src/RBDOOM-3-BFG/doomclassic/doom/doomlib.cpp:318
```
#12 0x00000883c96d6785 in DoomInterface::Frame (this=0x883ca78dfc0, iTime=1,

```
userCmdMgr=0x883ca249654)
at /usr/users/jsg/src/RBDOOM-3-BFG/doomclassic/doom/doominterface.cpp:154
```
#13 0x00000883c9483b65 in idCommonLocal::RunDoomClassicFrame (this=0x883ca247880)

---Type <return> to continue, or q <return> to quit---q
 at /usr/uQuit
(gdb) p vptr 
$1 = (int16_t *) 0x886604f4000
(gdb) p *vptr 
$2 = 0
(gdb) p *(vptr - 1)
Cannot access memory at address 0x886604f3ffe
