### PR TITLE
Fix loading saved game prior to commit 7e21048 crash.

### DIFF
--- a/neo/d3xp/Game_local.cpp
+++ b/neo/d3xp/Game_local.cpp
@@ -1454,11 +1454,19 @@ bool idGameLocal::InitFromSaveGame( const char* mapName, idRenderWorld* renderWo
 	
 	// FIXME: save smoke particles
 	
-	savegame.ReadInt( cinematicSkipTime );
-	savegame.ReadInt( cinematicStopTime );
-	savegame.ReadInt( cinematicMaxSkipTime );
+	if( saveGameVersion > BUILD_NUMBER_SAVE_VERSION_BEFORE_SKIP_CINEMATIC )
+	{
+		savegame.ReadInt( cinematicSkipTime );
+		savegame.ReadInt( cinematicStopTime );
+		savegame.ReadInt( cinematicMaxSkipTime );
+	}
+	
 	savegame.ReadBool( inCinematic );
-	savegame.ReadBool( skipCinematic );
+	
+	if( saveGameVersion > BUILD_NUMBER_SAVE_VERSION_BEFORE_SKIP_CINEMATIC )
+	{
+		savegame.ReadBool( skipCinematic );
+	}
 	
 	savegame.ReadInt( ( int& )gameType );
 	

--- a/neo/framework/BuildVersion.h
+++ b/neo/framework/BuildVersion.h
@@ -26,7 +26,8 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 
-const int BUILD_NUMBER_SAVE_VERSION_CHANGE			= 1400;		// Altering saves so that the version goes in the Details file that we read in during the enumeration phase
+const int BUILD_NUMBER_SAVE_VERSION_BEFORE_SKIP_CINEMATIC = 1400;
+const int BUILD_NUMBER_SAVE_VERSION_CHANGE			= 1401;		// Altering saves so that the version goes in the Details file that we read in during the enumeration phase
 
 const int BUILD_NUMBER = BUILD_NUMBER_SAVE_VERSION_CHANGE;
 const int BUILD_NUMBER_MINOR = 0;


### PR DESCRIPTION
Commit 7e21048 introduced a change in the save game files strutcure.
This makes the game crash whenever you load saved games created with a prior version of the code.
This commit tends to fix this issue.
However, save game files created between commit 7e21048 and the current one will not load correclty.
Unless the user change the saved game's saveVersion number in game.details.
