### PR TITLE
Fix or silence some compiler warning

### DIFF
--- a/doomclassic/doom/mus2midi.cpp
+++ b/doomclassic/doom/mus2midi.cpp
@@ -101,7 +101,10 @@ unsigned char* WriteInt(void* b, unsigned int i)
 // Format - 0(1 track only), 1(1 or more tracks, each play same time), 2(1 or more, each play seperatly)
 void Midi_CreateHeader(MidiHeaderChunk_t* header, short format, short track_count,  short division)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmultichar"
 	WriteInt(header->name, 'MThd');
+#pragma GCC diagnostic pop
 	WriteInt(&header->length, 6);
 	WriteShort(&header->format, format);
 	WriteShort(&header->ntracks, track_count);
@@ -341,7 +344,10 @@ int Mus2Midi(unsigned char* bytes, unsigned char* out, int* len)
 	}
 
 	// Write out track header
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmultichar"
 	WriteInt(midiTrackHeader.name, 'MTrk');
+#pragma GCC diagnostic pop
 	WriteInt(&midiTrackHeader.length, out - midiTrackHeaderOut - sizeof(midiTrackHeader));
 	memcpy(midiTrackHeaderOut, &midiTrackHeader, sizeof(midiTrackHeader));
 	
@@ -354,4 +360,3 @@ int Mus2Midi(unsigned char* bytes, unsigned char* out, int* len)
 	}*/
 	return 1;
 }
-

--- a/neo/idlib/Heap.cpp
+++ b/neo/idlib/Heap.cpp
@@ -59,7 +59,7 @@ void* Mem_Alloc16( const size_t size, const memTag_t tag )
 #else // not _WIN32
 	// DG: the POSIX solution for linux etc
 	void* ret;
-	posix_memalign( &ret, 16, paddedSize );
+	verify( posix_memalign( &ret, 16, paddedSize ) == 0 );
 	return ret;
 	// DG end
 #endif // _WIN32
@@ -109,4 +109,3 @@ char* Mem_CopyString( const char* in )
 	strcpy( out, in );
 	return out;
 }
-

--- a/neo/idlib/math/Simd_Generic.cpp
+++ b/neo/idlib/math/Simd_Generic.cpp
@@ -41,10 +41,12 @@ If you have questions concerning this license or the applicable additional terms
 #define UNROLL4(Y) { int _IX, _NM = count&0xfffffffc; for (_IX=0;_IX<_NM;_IX+=4){Y(_IX+0);Y(_IX+1);Y(_IX+2);Y(_IX+3);}for(;_IX<count;_IX++){Y(_IX);}}
 #define UNROLL8(Y) { int _IX, _NM = count&0xfffffff8; for (_IX=0;_IX<_NM;_IX+=8){Y(_IX+0);Y(_IX+1);Y(_IX+2);Y(_IX+3);Y(_IX+4);Y(_IX+5);Y(_IX+6);Y(_IX+7);} _NM = count&0xfffffffe; for(;_IX<_NM;_IX+=2){Y(_IX); Y(_IX+1);} if (_IX < count) {Y(_IX);} }
 
+#ifndef NODEFAULT
 #ifdef _DEBUG
 #define NODEFAULT	default: assert( 0 )
 #else
 #define NODEFAULT	default: __assume( 0 )
+#endif
 #endif
 
 

--- a/neo/idlib/sys/sys_assert.h
+++ b/neo/idlib/sys/sys_assert.h
@@ -100,12 +100,16 @@ bool AssertFailed( const char* file, int line, const char* expression );
 
 #if !defined( __TYPEINFOGEN__ ) && !defined( _lint )	// pcLint has problems with assert_offsetof()
 
+#if defined(__GXX_EXPERIMENTAL_CXX0X) || __cplusplus >= 201103L
+	#define compile_time_assert(x) static_assert(x, "")
+#else
 template<bool> struct compile_time_assert_failed;
 template<> struct compile_time_assert_failed<true> {};
 template<int x> struct compile_time_assert_test {};
 #define compile_time_assert_join2( a, b )	a##b
 #define compile_time_assert_join( a, b )	compile_time_assert_join2(a,b)
 #define compile_time_assert( x )			typedef compile_time_assert_test<sizeof(compile_time_assert_failed<(bool)(x)>)> compile_time_assert_join(compile_time_assert_typedef_, __LINE__)
+#endif
 
 #define assert_sizeof( type, size )						compile_time_assert( sizeof( type ) == size )
 #define assert_sizeof_8_byte_multiple( type )			compile_time_assert( ( sizeof( type ) &  7 ) == 0 )

--- a/neo/renderer/ModelDecal.cpp
+++ b/neo/renderer/ModelDecal.cpp
@@ -678,7 +678,10 @@ static void R_CopyDecalSurface( idDrawVert* verts, int numVerts, triIndex_t* ind
 	const __m128i vector_color_mask = _mm_set_epi32( 0, -1, 0, 0 );
 	
 	// copy vertices and apply depth/time based fading
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
 	assert_offsetof( idDrawVert, color, 6 * 4 );
+#pragma GCC diagnostic pop
 	for( int i = 0; i < decal->numVerts; i++ )
 	{
 		const idDrawVert& srcVert = decal->verts[i];

--- a/neo/sound/WaveFile.cpp
+++ b/neo/sound/WaveFile.cpp
@@ -36,6 +36,8 @@ Contains the WaveFile implementation.
 
 #include "WaveFile.h"
 
+#pragma GCC diagnostic ignored "-Wmultichar"
+
 /*
 ========================
 idWaveFile::Open

--- a/neo/sound/WaveFile.h
+++ b/neo/sound/WaveFile.h
@@ -106,6 +106,9 @@ public:
 		FORMAT_EXTENSIBLE	= 0xFFFF,
 	};
 	
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmultichar"
+
 #pragma pack( push, 1 )
 	struct waveFmt_t
 	{
@@ -241,6 +244,7 @@ private:
 	
 	
 };
+#pragma GCC diagnostic pop
 
 /*
 ========================

--- a/neo/sys/posix/platform_linux.cpp
+++ b/neo/sys/posix/platform_linux.cpp
@@ -319,7 +319,7 @@ void Sys_DoStartProcess( const char* exeName, bool dofork )
 		if( use_system )
 		{
 			printf( "system %s\n", exeName );
-			system( exeName );
+			verify( system( exeName ) != -1 );
 			sleep( 1 );	// on some systems I've seen that starting the new process and exiting this one should not be too close
 		}
 		else

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -1086,29 +1086,33 @@ void Posix_InitConsoleInput()
 terminal support utilities
 ================
 */
+static void verified_write( int fn, const void *buf, size_t count )
+{
+	verify( write( fn, buf, count ) == count );
+}
 
 void tty_Del()
 {
 	char key;
 	key = '\b';
-	write( STDOUT_FILENO, &key, 1 );
+	verified_write( STDOUT_FILENO, &key, 1 );
 	key = ' ';
-	write( STDOUT_FILENO, &key, 1 );
+	verified_write( STDOUT_FILENO, &key, 1 );
 	key = '\b';
-	write( STDOUT_FILENO, &key, 1 );
+	verified_write( STDOUT_FILENO, &key, 1 );
 }
 
 void tty_Left()
 {
 	char key = '\b';
-	write( STDOUT_FILENO, &key, 1 );
+	verified_write( STDOUT_FILENO, &key, 1 );
 }
 
 void tty_Right()
 {
 	char key = 27;
-	write( STDOUT_FILENO, &key, 1 );
-	write( STDOUT_FILENO, "[C", 2 );
+	verified_write( STDOUT_FILENO, &key, 1 );
+	verified_write( STDOUT_FILENO, "[C", 2 );
 }
 
 // clear the display of the line currently edited
@@ -1156,7 +1160,7 @@ void tty_Show()
 		char* buf = input_field.GetBuffer();
 		if( buf[0] )
 		{
-			write( STDOUT_FILENO, buf, strlen( buf ) );
+			verified_write( STDOUT_FILENO, buf, strlen( buf ) );
 			
 			// RB begin
 #if defined(__ANDROID__)
@@ -1221,7 +1225,7 @@ char* Posix_ConsoleInput()
 					idStr::Copynz( input_ret, input_field.GetBuffer(), sizeof( input_ret ) );
 					assert( hidden );
 					tty_Show();
-					write( STDOUT_FILENO, &key, 1 );
+					verified_write( STDOUT_FILENO, &key, 1 );
 					input_field.Clear();
 					if( history_count < COMMAND_HISTORY )
 					{

--- a/neo/tools/compilers/aas/Brush.cpp
+++ b/neo/tools/compilers/aas/Brush.cpp
@@ -44,7 +44,7 @@ If you have questions concerning this license or the applicable additional terms
 DisplayRealTimeString
 ============
 */
-void DisplayRealTimeString( char* string, ... )
+void DisplayRealTimeString( const char* string, ... )
 {
 	va_list argPtr;
 	char buf[MAX_STRING_CHARS];

--- a/neo/tools/compilers/aas/Brush.h
+++ b/neo/tools/compilers/aas/Brush.h
@@ -46,7 +46,7 @@ If you have questions concerning this license or the applicable additional terms
 class idBrush;
 class idBrushList;
 
-void DisplayRealTimeString( char* string, ... ) ID_STATIC_ATTRIBUTE_PRINTF( 1, 2 );
+void DisplayRealTimeString( const char* string, ... ) ID_STATIC_ATTRIBUTE_PRINTF( 1, 2 );
 
 
 //===============================================================


### PR DESCRIPTION
I fixed or silenced a few compiler warnings I get with G++ 4.9.2:
- Multi-character constants
- Verify return values of functions that mandate it
- Macro re-definitions
- Use `static_assert` for compile-time assertions
