### PR TITLE
Potential issues in Linux-specific system utilities

### DIFF
--- a/neo/sys/posix/platform_linux.cpp
+++ b/neo/sys/posix/platform_linux.cpp
@@ -169,8 +169,7 @@ numCPUPackages		- the total number of packages (physical processors)
 void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCPUPackages )
 {
 	static bool		init = false;
-	static double	ret;
-	
+
 	static int		s_numLogicalCPUCores;
 	static int		s_numPhysicalCPUCores;
 	static int		s_numCPUPackages;

--- a/neo/sys/posix/platform_linux.cpp
+++ b/neo/sys/posix/platform_linux.cpp
@@ -63,13 +63,14 @@ const char* Sys_EXEPath()
 	/*
 	 * Unfortunately procfs entries usually report to have size 0, so we cannot
 	 * lstat(2) to determine the right size and need to rely on probing with
-	 * readlink(2) until it places less than bufsize bytes in the buffer.
+	 * readlink(2) until it places strictly less than bufsize bytes in the
+	 * buffer.
 	 */
 	ssize_t len = 0;
 	for( size_t bufsize = 1 << 8; len >= 0 && bufsize <= 1 << 20; bufsize <<= 1 )
 	{
 		char *buf = new char[ bufsize ];
-		len = readlink( "/proc/self/exe", buf, bufsize );
+		len = readlink( "/proc/self/exe", buf, bufsize - 1 );
 		if( len >= 0 && static_cast<size_t>( len ) < bufsize )
 		{
 			buf[ len ] = '\0';

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -58,7 +58,6 @@ If you have questions concerning this license or the applicable additional terms
 
 #include "posix_public.h"
 
-#define					MAX_OSPATH 256
 #define					COMMAND_HISTORY 64
 
 static idStr			basepath;

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -375,13 +375,6 @@ Sys_Milliseconds
    assuming this wraps every 0x7fffffff - ~68 years since the Epoch (1970) - we're safe till 2038
    using unsigned long data type to work right with Sys_XTimeToSysTime */
 
-#ifdef CLOCK_MONOTONIC_RAW
-// use RAW monotonic clock if available (=> not subject to NTP etc)
-#define D3_CLOCK_TO_USE CLOCK_MONOTONIC_RAW
-#else
-#define D3_CLOCK_TO_USE CLOCK_MONOTONIC
-#endif
-
 // RB: changed long to int
 unsigned int sys_timeBase = 0;
 // RB end
@@ -397,7 +390,7 @@ int Sys_Milliseconds()
 	int curtime;
 	struct timespec ts;
 
-	clock_gettime( D3_CLOCK_TO_USE, &ts );
+	clock_gettime( supported_uniform_clock, &ts );
 
 	if( !sys_timeBase )
 	{
@@ -463,7 +456,7 @@ uint64 Sys_Microseconds()
 	uint64 curtime;
 	struct timespec ts;
 
-	clock_gettime( D3_CLOCK_TO_USE, &ts );
+	clock_gettime( supported_uniform_clock, &ts );
 
 	if( !sys_microTimeBase )
 	{

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -688,11 +688,7 @@ Posix_Cwd
 const char* Posix_Cwd()
 {
 	static char cwd[MAX_OSPATH];
-	
-	getcwd( cwd, sizeof( cwd ) - 1 );
-	cwd[MAX_OSPATH - 1] = 0;
-	
-	return cwd;
+	return getcwd( cwd, sizeof( cwd ) );
 }
 
 /*

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -61,6 +61,17 @@ If you have questions concerning this license or the applicable additional terms
 #define					MAX_OSPATH 256
 #define					COMMAND_HISTORY 64
 
+
+namespace
+{
+	template<typename T>
+	inline T ignore_result( T x )
+	{
+		return x;
+	}
+}
+
+
 static idStr			basepath;
 static idStr			savepath;
 
@@ -1087,24 +1098,24 @@ void tty_Del()
 {
 	char key;
 	key = '\b';
-	write( STDOUT_FILENO, &key, 1 );
+	ignore_result( write( STDOUT_FILENO, &key, 1 ) );
 	key = ' ';
-	write( STDOUT_FILENO, &key, 1 );
+	ignore_result( write( STDOUT_FILENO, &key, 1 ) );
 	key = '\b';
-	write( STDOUT_FILENO, &key, 1 );
+	ignore_result( write( STDOUT_FILENO, &key, 1 ) );
 }
 
 void tty_Left()
 {
 	char key = '\b';
-	write( STDOUT_FILENO, &key, 1 );
+	ignore_result( write( STDOUT_FILENO, &key, 1 ) );
 }
 
 void tty_Right()
 {
 	char key = 27;
-	write( STDOUT_FILENO, &key, 1 );
-	write( STDOUT_FILENO, "[C", 2 );
+	ignore_result( write( STDOUT_FILENO, &key, 1 ) );
+	ignore_result( write( STDOUT_FILENO, "[C", 2 ) );
 }
 
 // clear the display of the line currently edited
@@ -1152,8 +1163,8 @@ void tty_Show()
 		char* buf = input_field.GetBuffer();
 		if( buf[0] )
 		{
-			write( STDOUT_FILENO, buf, strlen( buf ) );
-			
+			ignore_result( write( STDOUT_FILENO, buf, strlen( buf ) ) );
+
 			// RB begin
 #if defined(__ANDROID__)
 			//__android_log_print(ANDROID_LOG_DEBUG, "RBDoom3_DEBUG", "%s", buf);
@@ -1217,7 +1228,7 @@ char* Posix_ConsoleInput()
 					idStr::Copynz( input_ret, input_field.GetBuffer(), sizeof( input_ret ) );
 					assert( hidden );
 					tty_Show();
-					write( STDOUT_FILENO, &key, 1 );
+					ignore_result( write( STDOUT_FILENO, &key, 1 ) );
 					input_field.Clear();
 					if( history_count < COMMAND_HISTORY )
 					{

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -370,19 +370,21 @@ double MeasureClockTicks()
 Sys_Milliseconds
 ================
 */
-/* base time in seconds, that's our origin
+
+int Sys_Milliseconds()
+{
+	/* base time in seconds, that's our origin
    timeval:tv_sec is an int:
    assuming this wraps every 0x7fffffff - ~68 years since the Epoch (1970) - we're safe till 2038
    using unsigned long data type to work right with Sys_XTimeToSysTime */
 
-static time_t sys_timeBase = 0;
-/* current time in ms, using sys_timeBase as origin
-   NOTE: sys_timeBase*1000 + curtime -> ms since the Epoch
-     0x7fffffff ms - ~24 days
-		 or is it 48 days? the specs say int, but maybe it's casted from unsigned int?
-*/
-int Sys_Milliseconds()
-{
+	static time_t sys_timeBase = 0;
+	/* current time in ms, using sys_timeBase as origin
+	   NOTE: sys_timeBase*1000 + curtime -> ms since the Epoch
+	     0x7fffffff ms - ~24 days
+			 or is it 48 days? the specs say int, but maybe it's casted from unsigned int?
+	*/
+
 	// DG: use clock_gettime on all platforms
 #if 1
 	int curtime;
@@ -427,10 +429,10 @@ int Sys_Milliseconds()
 Sys_Microseconds
 ================
 */
-static time_t sys_microTimeBase = 0;
-
 uint64 Sys_Microseconds()
 {
+	static time_t sys_microTimeBase = 0;
+
 #if 0
 	static uint64 ticksPerMicrosecondTimes1024 = 0;
 

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -61,17 +61,6 @@ If you have questions concerning this license or the applicable additional terms
 #define					MAX_OSPATH 256
 #define					COMMAND_HISTORY 64
 
-
-namespace
-{
-	template<typename T>
-	inline T ignore_result( T x )
-	{
-		return x;
-	}
-}
-
-
 static idStr			basepath;
 static idStr			savepath;
 
@@ -1098,24 +1087,24 @@ void tty_Del()
 {
 	char key;
 	key = '\b';
-	ignore_result( write( STDOUT_FILENO, &key, 1 ) );
+	write( STDOUT_FILENO, &key, 1 );
 	key = ' ';
-	ignore_result( write( STDOUT_FILENO, &key, 1 ) );
+	write( STDOUT_FILENO, &key, 1 );
 	key = '\b';
-	ignore_result( write( STDOUT_FILENO, &key, 1 ) );
+	write( STDOUT_FILENO, &key, 1 );
 }
 
 void tty_Left()
 {
 	char key = '\b';
-	ignore_result( write( STDOUT_FILENO, &key, 1 ) );
+	write( STDOUT_FILENO, &key, 1 );
 }
 
 void tty_Right()
 {
 	char key = 27;
-	ignore_result( write( STDOUT_FILENO, &key, 1 ) );
-	ignore_result( write( STDOUT_FILENO, "[C", 2 ) );
+	write( STDOUT_FILENO, &key, 1 );
+	write( STDOUT_FILENO, "[C", 2 );
 }
 
 // clear the display of the line currently edited
@@ -1163,8 +1152,8 @@ void tty_Show()
 		char* buf = input_field.GetBuffer();
 		if( buf[0] )
 		{
-			ignore_result( write( STDOUT_FILENO, buf, strlen( buf ) ) );
-
+			write( STDOUT_FILENO, buf, strlen( buf ) );
+			
 			// RB begin
 #if defined(__ANDROID__)
 			//__android_log_print(ANDROID_LOG_DEBUG, "RBDoom3_DEBUG", "%s", buf);
@@ -1228,7 +1217,7 @@ char* Posix_ConsoleInput()
 					idStr::Copynz( input_ret, input_field.GetBuffer(), sizeof( input_ret ) );
 					assert( hidden );
 					tty_Show();
-					ignore_result( write( STDOUT_FILENO, &key, 1 ) );
+					write( STDOUT_FILENO, &key, 1 );
 					input_field.Clear();
 					if( history_count < COMMAND_HISTORY )
 					{

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -375,9 +375,7 @@ Sys_Milliseconds
    assuming this wraps every 0x7fffffff - ~68 years since the Epoch (1970) - we're safe till 2038
    using unsigned long data type to work right with Sys_XTimeToSysTime */
 
-// RB: changed long to int
-unsigned int sys_timeBase = 0;
-// RB end
+static time_t sys_timeBase = 0;
 /* current time in ms, using sys_timeBase as origin
    NOTE: sys_timeBase*1000 + curtime -> ms since the Epoch
      0x7fffffff ms - ~24 days
@@ -398,7 +396,7 @@ int Sys_Milliseconds()
 		return ts.tv_nsec / 1000000;
 	}
 
-	curtime = ( ts.tv_sec - sys_timeBase ) * 1000 + ts.tv_nsec / 1000000;
+	curtime = ( ts.tv_sec - sys_timeBase ) * 1000L + ts.tv_nsec / 1000000;
 
 	return curtime;
 #else
@@ -429,7 +427,7 @@ int Sys_Milliseconds()
 Sys_Microseconds
 ================
 */
-static uint64 sys_microTimeBase = 0;
+static time_t sys_microTimeBase = 0;
 
 uint64 Sys_Microseconds()
 {
@@ -464,7 +462,7 @@ uint64 Sys_Microseconds()
 		return ts.tv_nsec / 1000;
 	}
 
-	curtime = ( ts.tv_sec - sys_microTimeBase ) * 1000000 + ts.tv_nsec / 1000;
+	curtime = static_cast<uint64>( ts.tv_sec - sys_microTimeBase ) * 1000000 + ts.tv_nsec / 1000;
 
 	return curtime;
 #endif
@@ -1231,7 +1229,7 @@ void tty_Show()
 		if( buf[0] )
 		{
 			write( STDOUT_FILENO, buf, strlen( buf ) );
-			
+
 			// RB begin
 #if defined(__ANDROID__)
 			//__android_log_print(ANDROID_LOG_DEBUG, "RBDoom3_DEBUG", "%s", buf);

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -105,7 +105,7 @@ const char* Sys_DefaultSavePath()
 #else
 	sprintf( savepath, "%s/.rbdoom3bfg", getenv( "HOME" ) );
 #endif
-	
+
 	return savepath.c_str();
 }
 
@@ -126,12 +126,12 @@ void Posix_Exit( int ret )
 	}
 	// at this point, too late to catch signals
 	Posix_ClearSigs();
-	
+
 	//if( asyncThread.threadHandle )
 	//{
 	//	Sys_DestroyThread( asyncThread );
 	//}
-	
+
 	// process spawning. it's best when it happens after everything has shut down
 	if( exit_spawn[0] )
 	{
@@ -185,7 +185,7 @@ void idSysLocal::StartProcess( const char* exeName, bool quit )
 		cmdSystem->BufferCommandText( CMD_EXEC_APPEND, "quit\n" );
 		return;
 	}
-	
+
 	common->DPrintf( "Sys_StartProcess %s\n", exeName );
 	Sys_DoStartProcess( exeName );
 }
@@ -241,7 +241,7 @@ double Sys_GetClockTicks()
 {
 #if defined( __i386__ )
 	unsigned long lo, hi;
-	
+
 	__asm__ __volatile__(
 		"push %%ebx\n"			\
 		"xor %%eax,%%eax\n"		\
@@ -256,9 +256,9 @@ double Sys_GetClockTicks()
 //#error unsupported CPU
 // RB begin
 	struct timespec now;
-	
+
 	clock_gettime( CLOCK_MONOTONIC, &now );
-	
+
 	return now.tv_sec * 1000000000LL + now.tv_nsec;
 // RB end
 #endif
@@ -272,7 +272,7 @@ MeasureClockTicks
 double MeasureClockTicks()
 {
 	double t0, t1;
-	
+
 	t0 = Sys_GetClockTicks( );
 	Sys_Sleep( 1000 );
 	t1 = Sys_GetClockTicks( );
@@ -310,33 +310,33 @@ int Sys_Milliseconds()
 #if 1
 	int curtime;
 	struct timespec ts;
-	
+
 	clock_gettime( D3_CLOCK_TO_USE, &ts );
-	
+
 	if( !sys_timeBase )
 	{
 		sys_timeBase = ts.tv_sec;
 		return ts.tv_nsec / 1000000;
 	}
-	
+
 	curtime = ( ts.tv_sec - sys_timeBase ) * 1000 + ts.tv_nsec / 1000000;
-	
+
 	return curtime;
 #else
 	// gettimeofday() implementation
 	int curtime;
 	struct timeval tp;
-	
+
 	gettimeofday( &tp, NULL );
-	
+
 	if( !sys_timeBase )
 	{
 		sys_timeBase = tp.tv_sec;
 		return tp.tv_usec / 1000;
 	}
-	
+
 	curtime = ( tp.tv_sec - sys_timeBase ) * 1000 + tp.tv_usec / 1000;
-	
+
 	return curtime;
 	* /
 #endif
@@ -356,37 +356,37 @@ uint64 Sys_Microseconds()
 {
 #if 0
 	static uint64 ticksPerMicrosecondTimes1024 = 0;
-	
+
 	if( ticksPerMicrosecondTimes1024 == 0 )
 	{
 		ticksPerMicrosecondTimes1024 = ( ( uint64 )Sys_ClockTicksPerSecond() << 10 ) / 1000000;
 		assert( ticksPerMicrosecondTimes1024 > 0 );
 	}
-	
+
 	return ( ( uint64 )( ( int64 )Sys_GetClockTicks() << 10 ) ) / ticksPerMicrosecondTimes1024;
 #elif 0
 	uint64 curtime;
 	struct timespec ts;
-	
+
 	clock_gettime( CLOCK_MONOTONIC, &ts );
-	
+
 	curtime = ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
-	
+
 	return curtime;
 #else
 	uint64 curtime;
 	struct timespec ts;
-	
+
 	clock_gettime( D3_CLOCK_TO_USE, &ts );
-	
+
 	if( !sys_microTimeBase )
 	{
 		sys_microTimeBase = ts.tv_sec;
 		return ts.tv_nsec / 1000;
 	}
-	
+
 	curtime = ( ts.tv_sec - sys_microTimeBase ) * 1000000 + ts.tv_nsec / 1000;
-	
+
 	return curtime;
 #endif
 }
@@ -473,7 +473,7 @@ bool Sys_IsFileWritable( const char* path )
 	{
 		return true;
 	}
-	
+
 	return ( st.st_mode & S_IWRITE ) != 0;
 }
 
@@ -485,12 +485,12 @@ Sys_IsFolder
 sysFolder_t	 Sys_IsFolder( const char* path )
 {
 	struct stat buffer;
-	
+
 	if( stat( path, &buffer ) < 0 )
 	{
 		return FOLDER_ERROR;
 	}
-	
+
 	return ( buffer.st_mode & S_IFDIR ) != 0 ? FOLDER_YES : FOLDER_NO;
 }
 
@@ -509,15 +509,15 @@ int Sys_ListFiles( const char* directory, const char* extension, idStrList& list
 	char search[MAX_OSPATH];
 	struct stat st;
 	bool debug;
-	
+
 	list.Clear();
-	
+
 	debug = cvarSystem->GetCVarBool( "fs_debug" );
 	// DG: we use fnmatch for shell-style pattern matching
 	// so the pattern should at least contain "*" to match everything,
 	// the extension will be added behind that (if !dironly)
 	idStr pattern( "*" );
-	
+
 	// passing a slash as extension will find directories
 	if( extension[0] == '/' && extension[1] == 0 )
 	{
@@ -529,7 +529,7 @@ int Sys_ListFiles( const char* directory, const char* extension, idStrList& list
 		pattern += extension;
 	}
 	// DG end
-	
+
 	// NOTE: case sensitivity of directory path can screw us up here
 	if( ( fdir = opendir( directory ) ) == NULL )
 	{
@@ -539,23 +539,23 @@ int Sys_ListFiles( const char* directory, const char* extension, idStrList& list
 		}
 		return -1;
 	}
-	
+
 	// DG: use readdir_r instead of readdir for thread safety
 	// the following lines are from the readdir_r manpage.. fscking ugly.
 	int nameMax = pathconf( directory, _PC_NAME_MAX );
 	if( nameMax == -1 )
 		nameMax = 255;
 	int direntLen = offsetof( struct dirent, d_name ) + nameMax + 1;
-	
+
 	struct dirent* entry = ( struct dirent* )Mem_Alloc( direntLen, TAG_CRAP );
-	
+
 	if( entry == NULL )
 	{
 		common->Warning( "Sys_ListFiles: Mem_Alloc for entry failed!" );
 		closedir( fdir );
 		return 0;
 	}
-	
+
 	while( readdir_r( fdir, entry, &d ) == 0 && d != NULL )
 	{
 		// DG end
@@ -575,18 +575,18 @@ int Sys_ListFiles( const char* directory, const char* extension, idStrList& list
 		if( ( dironly && !( st.st_mode & S_IFDIR ) ) ||
 				( !dironly && ( st.st_mode & S_IFDIR ) ) )
 			continue;
-			
+
 		list.Append( d->d_name );
 	}
-	
+
 	closedir( fdir );
 	Mem_Free( entry );
-	
+
 	if( debug )
 	{
 		common->Printf( "Sys_ListFiles: %d entries in %s\n", list.Num(), directory );
 	}
-	
+
 	return list.Num();
 }
 
@@ -745,7 +745,7 @@ intptr_t Sys_DLL_Load( const char* path )
 	{
 		Sys_Printf( "dlopen '%s' failed: %s\n", path, dlerror() );
 	}
-	
+
 	return ( intptr_t )handle;
 }
 // RB end
@@ -820,7 +820,7 @@ void Sys_Sleep( int msec )
 	}
 #endif // DG end
 	// use nanosleep? keep sleeping if signal interrupt?
-	
+
 	// RB begin
 #if defined(__ANDROID__)
 	usleep( msec * 1000 );
@@ -909,19 +909,19 @@ returns in megabytes
 int Sys_GetDriveFreeSpace( const char* path )
 {
 	int ret = 26;
-	
+
 	struct statvfs st;
-	
+
 	if( statvfs( path, &st ) == 0 )
 	{
 		unsigned long blocksize = st.f_bsize;
 		unsigned long freeblocks = st.f_bfree;
-		
+
 		unsigned long free = blocksize * freeblocks;
-		
+
 		ret = ( double )( free ) / ( 1024.0 * 1024.0 );
 	}
-	
+
 	return ret;
 }
 
@@ -933,19 +933,19 @@ Sys_GetDriveFreeSpaceInBytes
 int64 Sys_GetDriveFreeSpaceInBytes( const char* path )
 {
 	int64 ret = 1;
-	
+
 	struct statvfs st;
-	
+
 	if( statvfs( path, &st ) == 0 )
 	{
 		unsigned long blocksize = st.f_bsize;
 		unsigned long freeblocks = st.f_bfree;
-		
+
 		unsigned long free = blocksize * freeblocks;
-		
+
 		ret = free;
 	}
-	
+
 	return ret;
 }
 
@@ -970,13 +970,13 @@ Posix_EarlyInit
 void Posix_EarlyInit()
 {
 	//memset( &asyncThread, 0, sizeof( asyncThread ) );
-	
+
 	exit_spawn[0] = '\0';
 	Posix_InitSigs();
-	
+
 	// set the base time
 	Sys_Milliseconds();
-	
+
 	//Posix_InitPThreads();
 }
 
@@ -1007,7 +1007,7 @@ Posix_InitConsoleInput
 void Posix_InitConsoleInput()
 {
 	struct termios tc;
-	
+
 	if( in_tty.GetBool() )
 	{
 		if( isatty( STDIN_FILENO ) != 1 )
@@ -1158,7 +1158,7 @@ void tty_Show()
 			//__android_log_print(ANDROID_LOG_DEBUG, "RBDoom3_DEBUG", "%s", buf);
 #endif
 			// RB end
-			
+
 			int back = strlen( buf ) - input_field.GetCursor();
 			while( back > 0 )
 			{
@@ -1453,7 +1453,7 @@ char* Posix_ConsoleInput()
 		int				len;
 		fd_set			fdset;
 		struct timeval	timeout;
-		
+
 		FD_ZERO( &fdset );
 		FD_SET( STDIN_FILENO, &fdset );
 		timeout.tv_sec = 0;
@@ -1462,25 +1462,25 @@ char* Posix_ConsoleInput()
 		{
 			return NULL;
 		}
-		
+
 		len = read( 0, input_ret, sizeof( input_ret ) );
 		if( len == 0 )
 		{
 			// EOF
 			return NULL;
 		}
-		
+
 		if( len < 1 )
 		{
 			Sys_Printf( "read failed: %s\n", strerror( errno ) );	// something bad happened, cancel this line and print an error
 			return NULL;
 		}
-		
+
 		if( len == sizeof( input_ret ) )
 		{
 			Sys_Printf( "read overflow\n" );	// things are likely to break, as input will be cut into pieces
 		}
-		
+
 		input_ret[ len - 1 ] = '\0';		// rip off the \n and terminate
 		return input_ret;
 #endif
@@ -1521,16 +1521,16 @@ void Sys_DebugPrintf( const char* fmt, ... )
 #if defined(__ANDROID__)
 	va_list		argptr;
 	char		msg[4096];
-	
+
 	va_start( argptr, fmt );
 	idStr::vsnPrintf( msg, sizeof( msg ), fmt, argptr );
 	va_end( argptr );
 	msg[sizeof( msg ) - 1] = '\0';
-	
+
 	__android_log_print( ANDROID_LOG_DEBUG, "RBDoom3_Debug", msg );
 #else
 	va_list argptr;
-	
+
 	tty_Hide();
 	va_start( argptr, fmt );
 	vprintf( fmt, argptr );
@@ -1555,16 +1555,16 @@ void Sys_Printf( const char* fmt, ... )
 #if defined(__ANDROID__)
 	va_list		argptr;
 	char		msg[4096];
-	
+
 	va_start( argptr, fmt );
 	idStr::vsnPrintf( msg, sizeof( msg ), fmt, argptr );
 	va_end( argptr );
 	msg[sizeof( msg ) - 1] = '\0';
-	
+
 	__android_log_print( ANDROID_LOG_DEBUG, "RBDoom3", msg );
 #else
 	va_list argptr;
-	
+
 	tty_Hide();
 	va_start( argptr, fmt );
 	vprintf( fmt, argptr );
@@ -1592,13 +1592,13 @@ Sys_Error
 void Sys_Error( const char* error, ... )
 {
 	va_list argptr;
-	
+
 	Sys_Printf( "Sys_Error: " );
 	va_start( argptr, error );
 	Sys_DebugVPrintf( error, argptr );
 	va_end( argptr );
 	Sys_Printf( "\n" );
-	
+
 	Posix_Exit( EXIT_FAILURE );
 }
 
@@ -1623,19 +1623,19 @@ void idSysLocal::OpenURL( const char* url, bool quit )
 	const char*	script_path;
 	idFile*		script_file;
 	char		cmdline[ 1024 ];
-	
+
 	static bool	quit_spamguard = false;
-	
+
 	if( quit_spamguard )
 	{
 		common->DPrintf( "Sys_OpenURL: already in a doexit sequence, ignoring %s\n", url );
 		return;
 	}
-	
+
 	common->Printf( "Open URL: %s\n", url );
 	// opening an URL on *nix can mean a lot of things ..
 	// just spawn a script instead of deciding for the user :-)
-	
+
 	// look in the savepath first, then in the basepath
 	script_path = fileSystem->BuildOSPath( cvarSystem->GetCVarString( "fs_savepath" ), "", "openurl.sh" );
 	script_file = fileSystem->OpenExplicitFileRead( script_path );
@@ -1651,15 +1651,15 @@ void idSysLocal::OpenURL( const char* url, bool quit )
 		return;
 	}
 	fileSystem->CloseFile( script_file );
-	
+
 	// if we are going to quit, only accept a single URL before quitting and spawning the script
 	if( quit )
 	{
 		quit_spamguard = true;
 	}
-	
+
 	common->Printf( "URL script: %s\n", script_path );
-	
+
 	// StartProcess is going to execute a system() call with that - hence the &
 	idStr::snPrintf( cmdline, 1024, "%s '%s' &",  script_path, url );
 	sys->StartProcess( cmdline, quit );


### PR DESCRIPTION
I fixed some potential issues in the Linux-specific system utilities and refactored some of the surrounding code on the way:
- Check return values of system calls
- Allocate buffers for return values dynamically with the necessary size instead of statically
- Pass correct buffer size to system calls (with or without final null character)
- Avoid `system(3)`
