### PR TITLE
backporting travis-ci.org continuous integration from OpenTechEngine w/o README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: cpp
+os:
+  - linux
+  - osx
+matrix:
+  allow_failures:
+    - os: osx  
+compiler:
+  - gcc
+  - clang
+#  - CXX=g++-mingw-w64-x86-64; g++ # disabled, does not work with RBDOOM-3-BFG build system
+install:
+ - if [ "$CXX" = "g++" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
+ - if [ "$CXX" = "g++-mingw-w64-x86-64" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
+ - sudo apt-get update -qq
+ - sudo apt-get install libsdl1.2-dev libopenal-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
+ - if [ "$CXX" = "g++" ]; then sudo apt-get install -qqy gcc g++; fi
+ - if [ "$CXX" = "g++-mingw-w64-x86-64" ]; then sudo apt-get install -qqy g++-mingw-w64-x86-64; fi
+script: mkdir build && cd build &&  if [ "$CXX" = "g++-mingw-w64-x86-64" ]; then cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=../neo/mingw32.toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -DSDL2=OFF ../neo ;else cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DSDL2=OFF ../neo;fi && make 


### PR DESCRIPTION
We have setup continuous integration (CI) for OpenTechEngine on travis-ci.org. I think you would like to do the same. The setup only requires this file to be in the repo root and it will provide nice build-status image on the MD too if one likes.

Travis-ci.org does not require exclusive access on the repository unlike drone.io so it's non-obscure to implement.

It requires you to just sign-up and enable the RBDOOM-3-BFG repo there.

Here is a live sample what it does: https://travis-ci.org/OpenTechEngine/OpenTechBFG/builds/40454843
GCC build: https://travis-ci.org/OpenTechEngine/OpenTechBFG/jobs/40454845
Clang build: https://travis-ci.org/OpenTechEngine/OpenTechBFG/jobs/40454845
