### PR TITLE
Fix for #184 -- make it possible to use system\'s libGLEW

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -30,6 +30,9 @@ option(USE_SYSTEM_LIBPNG
 option(USE_SYSTEM_LIBJPEG
                 "Use the system libjpeg instead of the bundled one" OFF)
 
+option(USE_SYSTEM_LIBGLEW
+                "Use the system libglew instead of the bundled one" OFF)
+
 if(UNIX)
 	set(OPENAL TRUE)
 endif()
@@ -229,6 +232,19 @@ else (JPEG_FOUND)
     include_directories("libs/jpeg-6")
     set(JPEG_LIBRARY "" )
 endif (JPEG_FOUND)
+
+if (USE_SYSTEM_LIBGLEW)
+find_package(GLEW)
+endif(USE_SYSTEM_LIBGLEW)
+
+if (GLEW_FOUND)
+    include_directories(${GLEW_INCLUDE_DIRS})
+    set(GLEW_LIBRARY ${GLEW_LIBRARIES})
+else (GLEW_FOUND)
+    include_directories("libs/glew/include")
+    set(GLEW_LIBRARY "" )
+    add_definitions(-DGLEW_STATIC)
+endif (GLEW_FOUND)
 
 add_subdirectory(idlib)
 
@@ -452,17 +468,19 @@ endif (NOT ZLIB_FOUND)
 file(GLOB MINIZIP_INCLUDES libs/zlib/minizip/*.h)
 file(GLOB MINIZIP_SOURCES libs/zlib/minizip/*.c libs/zlib/minizip/*.cpp)
 	
-set(GLEW_INCLUDES
-	libs/glew/include/GL/glew.h)
-	
-if(WIN32)
-	set(GLEW_INCLUDES ${GLEW_INCLUDES} libs/glew/include/GL/wglew.h)
-else()
-	set(GLEW_INCLUDES ${GLEW_INCLUDES} libs/glew/include/GL/glxew.h)
-endif()
-	
-set(GLEW_SOURCES
-	libs/glew/src/glew.c)
+if (NOT GLEW_FOUND)
+    set(GLEW_INCLUDES libs/glew/include/GL/glew.h)
+    set(GLEW_SOURCES libs/glew/src/glew.c)
+
+    if(WIN32)
+        set(GLEW_INCLUDES ${GLEW_INCLUDES} libs/glew/include/GL/wglew.h)
+    else(WIN32)
+        set(GLEW_INCLUDES ${GLEW_INCLUDES} libs/glew/include/GL/glxew.h)
+    endif(WIN32)
+else (NOT GLEW_FOUND)
+    set(GLEW_INCLUDES "")
+    set(GLEW_SOURCES "")
+endif (NOT GLEW_FOUND)
 	
 set(FREETYPE_SOURCES
 	libs/freetype/src/autofit/autofit.c
@@ -1167,7 +1185,6 @@ set(RBDOOM3_SOURCES
 add_definitions(-DUSE_DOOMCLASSIC)
 
 add_definitions(-D__DOOM__
-				-DGLEW_STATIC
 				#-DBUILD_FREETYPE
 				#-DFT2_BUILD_LIBRARY
 				)
@@ -1199,7 +1216,6 @@ include_directories(
 			idlib
 			#libs/curl/include
 			#libs/openal/include
-			libs/glew/include
 			#libs/freetype/include
             )
 			
@@ -1384,6 +1400,7 @@ if(MSVC)
         ${ZLIB_LIBRARY}
         ${PNG_LIBRARY}
         ${JPEG_LIBRARY}
+        ${GLEW_LIBRARY}
 		)
 		
 	#CMAKE_BINARY_DIR
@@ -1548,6 +1565,7 @@ else()
             ${ZLIB_LIBRARY}
             ${PNG_LIBRARY}
             ${JPEG_LIBRARY}
+            ${GLEW_LIBRARY}
 			)
 	endif()
     

--- a/neo/idlib/precompiled.h
+++ b/neo/idlib/precompiled.h
@@ -86,7 +86,7 @@ const int MAX_EXPRESSION_REGISTERS = 4096;
 // renderer
 
 // RB: replaced QGL with GLEW
-#include "../libs/glew/include/GL/glew.h"
+#include <GL/glew.h>
 // RB end
 #include "../renderer/Cinematic.h"
 #include "../renderer/Material.h"

--- a/neo/sys/sdl/sdl_glimp.cpp
+++ b/neo/sys/sdl/sdl_glimp.cpp
@@ -187,32 +187,6 @@ bool GLimp_Init( glimpParms_t parms )
 		
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		
-#ifdef __APPLE__
-		r_useOpenGL32.SetInteger( 2 ); // only core profile is supported on OS X
-#endif
-		
-		// RB begin
-		if( r_useOpenGL32.GetInteger() > 0 )
-		{
-			glConfig.driverType = GLDRV_OPENGL32_COMPATIBILITY_PROFILE;
-			
-			SDL_GL_SetAttribute( SDL_GL_CONTEXT_MAJOR_VERSION, 3 );
-			SDL_GL_SetAttribute( SDL_GL_CONTEXT_MINOR_VERSION, 2 );
-			
-			if( r_debugContext.GetBool() )
-			{
-				SDL_GL_SetAttribute( SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG );
-			}
-		}
-		
-		if( r_useOpenGL32.GetInteger() > 1 )
-		{
-			glConfig.driverType = GLDRV_OPENGL32_CORE_PROFILE;
-			
-			SDL_GL_SetAttribute( SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE );
-		}
-		// RB end
-		
 		// DG: set display num for fullscreen
 		int windowPos = SDL_WINDOWPOS_UNDEFINED;
 		if( parms.fullScreen > 0 )
@@ -234,23 +208,50 @@ bool GLimp_Init( glimpParms_t parms )
 		 * "do fullscreen, but I don't care on what monitor", at least on my box it's the monitor with
 		 * the mouse cursor.
 		 */
-		
-		
+
 		window = SDL_CreateWindow( GAME_NAME,
 								   windowPos,
 								   windowPos,
 								   parms.width, parms.height, flags );
 		// DG end
-		
+
+        if( !window )
+        {
+            common->DPrintf( "Couldn't set GL mode %d/%d/%d: %s",
+                             channelcolorbits, tdepthbits, tstencilbits, SDL_GetError() );
+            continue;
+        }
+
 		context = SDL_GL_CreateContext( window );
-		
-		if( !window )
-		{
-			common->DPrintf( "Couldn't set GL mode %d/%d/%d: %s",
-							 channelcolorbits, tdepthbits, tstencilbits, SDL_GetError() );
-			continue;
-		}
-		
+        SDL_GL_MakeCurrent(window, context);
+
+#ifdef __APPLE__
+        r_useOpenGL32.SetInteger( 2 ); // only core profile is supported on OS X
+#endif
+
+        // RB begin
+        if( r_useOpenGL32.GetInteger() > 0 )
+        {
+            glConfig.driverType = GLDRV_OPENGL32_COMPATIBILITY_PROFILE;
+
+            SDL_GL_SetAttribute( SDL_GL_CONTEXT_MAJOR_VERSION, 3 );
+            SDL_GL_SetAttribute( SDL_GL_CONTEXT_MINOR_VERSION, 2 );
+
+            if( r_debugContext.GetBool() )
+            {
+                SDL_GL_SetAttribute( SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG );
+            }
+        }
+        // Is a else required here for OPENGL 2.0?
+
+
+        if( r_useOpenGL32.GetInteger() > 1 )
+        {
+            glConfig.driverType = GLDRV_OPENGL32_CORE_PROFILE;
+            SDL_GL_SetAttribute( SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE );
+        }
+        // RB end
+
 		if( SDL_GL_SetSwapInterval( r_swapInterval.GetInteger() ) < 0 )
 			common->Warning( "SDL_GL_SWAP_CONTROL not supported" );
 			


### PR DESCRIPTION
Same as already merged for the other libraries...
At least here, the patch for neo/sys/sdl/sdl_glimp.cpp is needed to avoid the symtoms\* as described in #189

(\* I won't say that its the same cause -- I just say it looks similar)
