### PR TITLE
SDL: Unicode input and more then 3 mouse buttons, fixes issue #89

### DIFF
--- a/neo/framework/KeyInput.cpp
+++ b/neo/framework/KeyInput.cpp
@@ -204,6 +204,17 @@ keyname_t keynames[] =
 	NAMEKEY( MOUSE7, "#str_07060" ),
 	NAMEKEY( MOUSE8, "#str_07061" ),
 	
+	// DG: some more mouse buttons
+	NAMEKEY2( MOUSE9 ),
+	NAMEKEY2( MOUSE10 ),
+	NAMEKEY2( MOUSE11 ),
+	NAMEKEY2( MOUSE12 ),
+	NAMEKEY2( MOUSE13 ),
+	NAMEKEY2( MOUSE14 ),
+	NAMEKEY2( MOUSE15 ),
+	NAMEKEY2( MOUSE16 ),
+	// DG end
+
 	NAMEKEY( MWHEELDOWN, "#str_07132" ),
 	NAMEKEY( MWHEELUP, "#str_07131" ),
 	

--- a/neo/framework/UsercmdGen.cpp
+++ b/neo/framework/UsercmdGen.cpp
@@ -1360,6 +1360,16 @@ void idUsercmdGenLocal::Mouse()
 			case M_ACTION6:
 			case M_ACTION7:
 			case M_ACTION8:
+
+			// DG: support some more mouse buttons
+			case M_ACTION9:
+			case M_ACTION10:
+			case M_ACTION11:
+			case M_ACTION12:
+			case M_ACTION13:
+			case M_ACTION14:
+			case M_ACTION15:
+			case M_ACTION16: // DG end
 				mouseButton = K_MOUSE1 + ( action - M_ACTION1 );
 				mouseDown = ( value != 0 );
 				Key( mouseButton, mouseDown );

--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -170,7 +170,7 @@ static void ConvertUTF8toUTF32(const char* utf8str, int32* utf32buf)
 
 	if( cd == SDL_iconv_t(-1) )
 	{
-		const char* toFormat = "UTF-32LE"; // TODO: what does CEGUI expect on big endian machines?
+		const char* toFormat = "UTF-32LE"; // TODO: what does d3bfg expect on big endian machines?
 		cd = SDL_iconv_open(toFormat, "UTF-8");
 		if( cd == SDL_iconv_t(-1) )
 		{
@@ -917,6 +917,11 @@ sysEvent_t Sys_GetEvent()
 						cvarSystem->SetCVarBool( "com_pause", true );
 						// DG end
 						break;
+
+					case SDL_WINDOWEVENT_LEAVE:
+						// mouse has left the window
+						res.evType = SE_MOUSE_LEAVE;
+						return res;
 						
 					// DG: handle resizing and moving of window
 					case SDL_WINDOWEVENT_RESIZED:
@@ -939,7 +944,6 @@ sysEvent_t Sys_GetEvent()
 						r_windowY.SetInteger( y );
 						break;
 					}
-						// DG end
 				}
 				
 				continue; // handle next event
@@ -965,6 +969,14 @@ sysEvent_t Sys_GetEvent()
 				}
 			
 				cvarSystem->SetCVarBool( "com_pause", pause );
+
+				if( ev.active.state == SDL_APPMOUSEFOCUS && !ev.active.gain )
+				{
+					// the mouse has left the window.
+					res.evType = SE_MOUSE_LEAVE;
+					return res;
+				}
+
 			}
 			
 			continue; // handle next event
@@ -982,6 +994,7 @@ sysEvent_t Sys_GetEvent()
 			
 				glConfig.nativeScreenWidth = w;
 				glConfig.nativeScreenHeight = h;
+
 				// for some reason this needs a vid_restart in SDL1 but not SDL2 so GLimp_SetScreenParms() is called
 				PushConsoleEvent( "vid_restart" );
 				continue; // handle next event

--- a/neo/sys/sys_public.h
+++ b/neo/sys/sys_public.h
@@ -119,6 +119,16 @@ enum sys_mEvents
 	M_ACTION6,
 	M_ACTION7,
 	M_ACTION8,
+	// DG: support some more mouse buttons
+	M_ACTION9,
+	M_ACTION10,
+	M_ACTION11,
+	M_ACTION12,
+	M_ACTION13,
+	M_ACTION14,
+	M_ACTION15,
+	M_ACTION16,
+	// DG end
 	M_DELTAX,
 	M_DELTAY,
 	M_DELTAZ,
@@ -390,6 +400,17 @@ enum keyNum_t
 	K_MOUSE7,
 	K_MOUSE8,
 	
+	// DG: add some more mouse buttons
+	K_MOUSE9,
+	K_MOUSE10,
+	K_MOUSE11,
+	K_MOUSE12,
+	K_MOUSE13,
+	K_MOUSE14,
+	K_MOUSE15,
+	K_MOUSE16,
+	// DG end
+
 	K_MWHEELDOWN,
 	K_MWHEELUP,
 	

--- a/neo/sys/sys_public.h
+++ b/neo/sys/sys_public.h
@@ -101,11 +101,11 @@ enum sysEventType_t
 {
 	SE_NONE,				// evTime is still valid
 	SE_KEY,					// evValue is a key code, evValue2 is the down flag
-	SE_CHAR,				// evValue is an ascii char FIXME: not really ascii, supports umlauts...
-	SE_MOUSE,				// evValue and evValue2 are reletive signed x / y moves
+	SE_CHAR,				// evValue is an Unicode UTF-32 char (or non-surrogate UTF-16)
+	SE_MOUSE,				// evValue and evValue2 are relative signed x / y moves
 	SE_MOUSE_ABSOLUTE,		// evValue and evValue2 are absolute coordinates in the window's client area.
 	SE_MOUSE_LEAVE,			// evValue and evValue2 are meaninless, this indicates the mouse has left the client area.
-	SE_JOYSTICK,		// evValue is an axis number and evValue2 is the current state (-127 to 127)
+	SE_JOYSTICK,			// evValue is an axis number and evValue2 is the current state (-127 to 127)
 	SE_CONSOLE				// evPtr is a char*, from typing something at a non-game console
 };
 

--- a/neo/sys/win32/win_wndproc.cpp
+++ b/neo/sys/win32/win_wndproc.cpp
@@ -338,6 +338,7 @@ LONG WINAPI MainWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 				key = K_NUMLOCK;
 			}
 			Sys_QueEvent( SE_KEY, key, true, 0, NULL, 0 );
+
 			break;
 			
 		case WM_SYSKEYUP:
@@ -359,8 +360,20 @@ LONG WINAPI MainWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 			break;
 			
 		case WM_CHAR:
+			// DG: make sure it's an utf-16 non-surrogate character (and thus a valid utf-32 character as well)
+			// TODO: will there ever be two messages with surrogate characters that should be combined?
+			//       (probably not, some people claim it's actually UCS-2, not UTF-16)
+			if( wParam < 0xD800 || wParam > 0xDFFF )
+			{
+				Sys_QueEvent( SE_CHAR, wParam, 0, 0, NULL, 0 );
+			}
+			break;
+
+		// DG: support utf-32 input via WM_UNICHAR
+		case WM_UNICHAR:
 			Sys_QueEvent( SE_CHAR, wParam, 0, 0, NULL, 0 );
 			break;
+		// DG end
 			
 		case WM_NCLBUTTONDOWN:
 //			win32.movingWindow = true;


### PR DESCRIPTION
SE_CHAR events actually contain UTF-16 (or at least UCS-2) characters from windows WM_CHAR events.
The SDL backend now also puts unicode characters into SE_CHAR events and now Umlauts work in the console \o/

Furthermore, on Linux only three mouse buttons were supported up to now.  
I just wanted to add support for X1 and X2, but unfortunately, SDL has a bug (see https://bugzilla.libsdl.org/show_bug.cgi?id=2310 which also happens in SDL1) on Linux/X11 that sends button number 8 and 9 for X1/X2. Because of that, the 8 mouse buttons supported by D3BFG weren't enough anymore..  
So I added support for up to 16 mouse buttons into the engine (unfortunately, this doesn't change anything for windows, because directinput seems to support "only" 8 buttons) and pass those mouse buttons from SDL events to the engine accordingly.

So pressing button X1/X2 on Linux will somehow unexpectedly result in a MOUSE_8/9  events, but at least the buttons are bindable and usable now.

This should fix #89 
