### PR TITLE
rbdoom3: Option to set CPU_ID and to specify CPU Features to be used.

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -40,6 +40,8 @@ set(CPU_TYPE "" CACHE STRING "When set, passes this string as CPU-ID which will 
 
 set(CPU_OPTIMIZATION "-mmmx -msse -msse2" CACHE STRING "Which CPU specific optimitations should be used beside the compiler's default?")
 
+option(USE_INTRINSICS "Compile using intrinsics (e.g mmx, sse, msse2)" ON)
+
 if(UNIX)
 	set(OPENAL TRUE)
 endif()
@@ -70,6 +72,9 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 	endif()
 	if (CPU_OPTIMIZATION)
 		add_definitions(${CPU_OPTIMIZATION})
+	endif()
+	if (USE_INTRINSICS)
+		add_definitions(-DUSE_INTRINSICS)
 	endif()
 	if(WIN32)
 		# require msvcr70.dll or newer for _aligned_malloc etc

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -36,6 +36,10 @@ option(USE_SYSTEM_LIBJPEG
 option(USE_SYSTEM_LIBGLEW
                 "Use the system libglew instead of the bundled one" OFF)
 
+set(CPU_TYPE "" CACHE STRING "When set, passes this string as CPU-ID and disables CPU specific optimizatin which are not default for the compiler")
+
+set(CPU_OPTIMIZATION "-mmmx -msse -msse2" CACHE STRING "Which CPU specific optimitations should be used beside the compiler's default?")
+
 if(UNIX)
 	set(OPENAL TRUE)
 endif()
@@ -61,7 +65,12 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 	#add_definitions(-Wall)
 	add_definitions(-Werror=format-security)
 	add_definitions(-Werror=format)
-	add_definitions(-mmmx -msse -msse2)
+	if(CPU_TYPE)
+		add_definitions(-DCPUSTRING="${CPU_TYPE}")
+	endif()
+	if (CPU_OPTIMIZATION)
+		add_definitions(${CPU_OPTIMIZATION})
+	endif()
 	if(WIN32)
 		# require msvcr70.dll or newer for _aligned_malloc etc
 		# I think it is from Visual C++ .NET 2002, so it should be available on any remotely modern system.

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -36,7 +36,7 @@ option(USE_SYSTEM_LIBJPEG
 option(USE_SYSTEM_LIBGLEW
                 "Use the system libglew instead of the bundled one" OFF)
 
-set(CPU_TYPE "" CACHE STRING "When set, passes this string as CPU-ID and disables CPU specific optimizatin which are not default for the compiler")
+set(CPU_TYPE "" CACHE STRING "When set, passes this string as CPU-ID which will be embedded into the binary.")
 
 set(CPU_OPTIMIZATION "-mmmx -msse -msse2" CACHE STRING "Which CPU specific optimitations should be used beside the compiler's default?")
 

--- a/neo/idlib/sys/sys_defines.h
+++ b/neo/idlib/sys/sys_defines.h
@@ -104,10 +104,14 @@ If you have questions concerning this license or the applicable additional terms
 
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
 
+#ifndef CPUSTRING
 #if defined(__i386__)
 #define	CPUSTRING						"x86"
 #elif defined(__x86_64__)
 #define CPUSTRING						"x86_86"
+#else
+#error unknown CPU
+#endif
 #endif
 
 #if defined(__FreeBSD__)

--- a/neo/idlib/sys/sys_intrinsics.h
+++ b/neo/idlib/sys/sys_intrinsics.h
@@ -29,11 +29,6 @@ If you have questions concerning this license or the applicable additional terms
 #ifndef __SYS_INTRIINSICS_H__
 #define __SYS_INTRIINSICS_H__
 
-#if defined(__x86_64__)
-// Enable this only on amd64
-#define USE_INTRINSICS
-#endif
-
 #if defined(USE_INTRINSICS)
 #include <emmintrin.h>
 #endif

--- a/neo/idlib/sys/sys_intrinsics.h
+++ b/neo/idlib/sys/sys_intrinsics.h
@@ -29,7 +29,10 @@ If you have questions concerning this license or the applicable additional terms
 #ifndef __SYS_INTRIINSICS_H__
 #define __SYS_INTRIINSICS_H__
 
+#if defined(__x86_64__)
+// Enable this only on amd64
 #define USE_INTRINSICS
+#endif
 
 #if defined(USE_INTRINSICS)
 #include <emmintrin.h>


### PR DESCRIPTION
The goal for those patches is again for Debian :) To honour the baseline CPU functions we are allowed to use and also allow to compile on other architectures.

The pull requests adds two options to the build-system:
CPU_TYPE -- When set, passes this string as CPU-ID, which will be embedded into the binary. If unset, the code decides (but only for i386 and amd64).

In Debian I will set it to $(DEB_BUILD_ARCH_CPU) 

CPU_OPTIMIZATION Which CPU specific optimitations should be used beside the compiler's default?
default: "-mmmx -msse -msse2" (defaults to the same as your repository)

For Debian I will use the compiler's default, means setting this to an empty string.

USE_INTRINSICS will be progated to the build system only if explictly disabled -- this will disable usage of the intrinsics which are not available on most archs.mmx

For Debian I will use the intrinsics only on amd64.

-- 
tobi