### PR TITLE
Do use CMAKE_DL_LIBS to determine the linkerflags needed to link against libdl

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -1404,6 +1404,7 @@ if(MSVC)
         ${PNG_LIBRARY}
         ${JPEG_LIBRARY}
         ${GLEW_LIBRARY}
+	${CMAKE_DL_LIBS}
 		)
 		
 	#CMAKE_BINARY_DIR
@@ -1552,15 +1553,10 @@ else()
 			set(RT_LIBRARY rt)
 		endif()
 
-		if(NOT "${CMAKE_SYSTEM}" MATCHES "FreeBSD")
-			set(DL_LIBRARY dl)
-		endif()
-
 		target_link_libraries(RBDoom3BFG
 			idlib
 			${OPENGL_LIBRARIES}
 			pthread
-			${DL_LIBRARY}
 			${RT_LIBRARY}
 			${SDLx_LIBRARY}
 			${OPENAL_LIBRARY}
@@ -1569,6 +1565,7 @@ else()
             ${PNG_LIBRARY}
             ${JPEG_LIBRARY}
             ${GLEW_LIBRARY}
+	    ${CMAKE_DL_LIBS}
 			)
 	endif()
     

--- a/neo/idlib/sys/sys_defines.h
+++ b/neo/idlib/sys/sys_defines.h
@@ -102,7 +102,7 @@ If you have questions concerning this license or the applicable additional terms
 #endif
 
 
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) || defined(__GNUC__) || defined(__clang__)
 
 #if defined(__i386__)
 #define	CPUSTRING						"x86"
@@ -116,6 +116,8 @@ If you have questions concerning this license or the applicable additional terms
 #define	BUILD_STRING					"linux-" CPUSTRING
 #elif defined(__APPLE__)
 #define BUILD_STRING					"osx-" CPUSTRING
+#else
+#define BUILD_STRING					"other-" CPUSTRING
 #endif
 
 #define _alloca							alloca
@@ -146,6 +148,8 @@ If you have questions concerning this license or the applicable additional terms
 #define CALLBACK
 #define __cdecl
 
+#else
+#error unknown build enviorment
 #endif
 // RB end
 


### PR DESCRIPTION
(on kfreebsd I get a linker error, it seems that cmake provides this variable already:
http://www.cmake.org/cmake/help/v3.0/variable/CMAKE_DL_LIBS.html)

and
- For !WINDOWS, add sys_defines based on compiler instead based on system. (enabled compilation e.g on hurd and kfreebsd)

I wonder if generally this should be split in two sections: One defining the compiler dependent flags and one defining the architecture dependent ones?

--
tobi