### PR TITLE
Do not force USE_INTRINISCS to be set via source-code

### DIFF
--- a/neo/idlib/sys/sys_intrinsics.h
+++ b/neo/idlib/sys/sys_intrinsics.h
@@ -29,12 +29,6 @@ If you have questions concerning this license or the applicable additional terms
 #ifndef __SYS_INTRIINSICS_H__
 #define __SYS_INTRIINSICS_H__
 
-#if !defined(USE_INTRINSICS)
-#if defined(WIN32) || defined(__i386__) || defined(__x86_64__)
-#define USE_INTRINSICS
-#endif
-#endif
-
 #if defined(USE_INTRINSICS)
 #include <emmintrin.h>
 #endif


### PR DESCRIPTION
One important part of #228 was unfortunatly reverted one commit later :(
 
The problem is, that without those line USE_INTRINSICS cannot be "unset" via the CMake option; If unset, it will be set by the code, which leads bottom line the option always set and not configurable by CMake on 

Please note that USE_INTRINSICS defaults to "defined" (see CMakeLists.txt), so the behaviour is the same unless the user overrides this (and with the lines in the code he cannot override it)

Tobi