### PR TITLE
Fix crash when running dmap on existing map

### DIFF
--- a/neo/cm/CollisionModel_files.cpp
+++ b/neo/cm/CollisionModel_files.cpp
@@ -642,13 +642,21 @@ bool idCollisionModelManagerLocal::LoadCollisionModelFile( const char* name, uns
 		file->ReadString( fileVersion );
 		if( fileID == CM_FILEID && fileVersion == CM_FILEVERSION && crc == mapFileCRC && numEntries > 0 )
 		{
+			loaded = true; // DG: moved this up here to prevent segfaults, see below
 			for( int i = 0; i < numEntries; i++ )
 			{
 				cm_model_t* model = LoadBinaryModelFromFile( file, currentTimeStamp );
+				// DG: handle the case that loading the binary model fails gracefully
+				//     (otherwise we'll get a segfault when someone wants to use models[numModels])
+				if( model == NULL )
+				{
+					loaded = false;
+					break;
+				}
+				// DG end
 				models[ numModels ] = model;
 				numModels++;
 			}
-			loaded = true;
 		}
 	}
 	

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -835,18 +835,6 @@ void Sys_Sleep( int msec )
 #endif
 }
 
-char* Sys_GetClipboardData()
-{
-	Sys_Printf( "TODO: Sys_GetClipboardData\n" );
-	return NULL;
-}
-
-void Sys_SetClipboardData( const char* string )
-{
-	Sys_Printf( "TODO: Sys_SetClipboardData\n" );
-}
-
-
 // stub pretty much everywhere - heavy calling
 void Sys_FlushCacheMemory( void* base, int bytes )
 {

--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -1731,6 +1731,36 @@ const char* Sys_GetKeyName( keyNum_t keynum )
 	return NULL;
 }
 
+char* Sys_GetClipboardData()
+{
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	char* txt = SDL_GetClipboardText();
+	
+	if( txt == NULL )
+	{
+		return NULL;
+	}
+	else if( txt[0] == '\0' )
+	{
+		SDL_free( txt );
+		return NULL;
+	}
+	
+	char* ret = Mem_CopyString( txt );
+	SDL_free( txt );
+	return ret;
+#else
+	return NULL; // SDL1.2 doesn't support clipboard
+#endif
+}
+
+void Sys_SetClipboardData( const char* string )
+{
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_SetClipboardText( string );
+#endif
+}
+
 
 //=====================================================================================
 //	Joystick Input Handling


### PR DESCRIPTION
Loading the collision model from binary can fail, but this wasn't
checked, so idCollisionModelManagerLocal::models[i] could contain NULL
which causes crashes later.