### PR TITLE
Fix build failure for libpng 1.6:

### DIFF
--- a/neo/renderer/Image_files.cpp
+++ b/neo/renderer/Image_files.cpp
@@ -621,6 +621,7 @@ PNG LOADING
 
 extern "C"
 {
+#include <string.h>
 #include <png.h>
 
 
@@ -636,9 +637,12 @@ extern "C"
 	
 	static void	png_ReadData( png_structp pngPtr, png_bytep data, png_size_t length )
 	{
-		memcpy( data, ( byte* )pngPtr->io_ptr, length );
-		
-		pngPtr->io_ptr = ( ( byte* ) pngPtr->io_ptr ) + length;
+
+		// There is a get_io_ptr but not a set_io_ptr.. Therefore we need some tmp storage here.
+		byte **ioptr = (byte **)png_get_io_ptr(pngPtr);
+
+		memcpy( data, *ioptr, length );
+		*ioptr += length;
 	}
 	
 }
@@ -651,6 +655,7 @@ LoadPNG
 static void LoadPNG( const char* filename, unsigned char** pic, int* width, int* height, ID_TIME_T* timestamp )
 {
 	byte*	fbuffer;
+	byte*   readptr;
 	
 	if( !pic )
 	{
@@ -683,7 +688,8 @@ static void LoadPNG( const char* filename, unsigned char** pic, int* width, int*
 		common->Error( "LoadPNG( %s ): png_create_info_struct failed", filename );
 	}
 	
-	png_set_read_fn( pngPtr, fbuffer, png_ReadData );
+	readptr = fbuffer;
+	png_set_read_fn( pngPtr, &readptr, png_ReadData );
 	
 	png_set_sig_bytes( pngPtr, 0 );
 	
@@ -770,10 +776,11 @@ extern "C"
 	static int png_compressedSize = 0;
 	static void	png_WriteData( png_structp pngPtr, png_bytep data, png_size_t length )
 	{
-		memcpy( ( byte* )pngPtr->io_ptr, data, length );
+		byte **ioptr = (byte**)png_get_io_ptr(pngPtr);
+
+		memcpy( *ioptr, data, length );
 		
-		pngPtr->io_ptr = ( ( byte* ) pngPtr->io_ptr ) + length;
-		
+		*ioptr += length;
 		png_compressedSize += length;
 	}
 	
@@ -802,7 +809,8 @@ void R_WritePNG( const char* filename, const byte* data, int bytesPerPixel, int 
 	
 	png_compressedSize = 0;
 	byte* buffer = ( byte* ) Mem_Alloc( width * height * bytesPerPixel, TAG_TEMP );
-	png_set_write_fn( pngPtr, buffer, png_WriteData, png_FlushData );
+	byte* ioptr  = buffer;
+	png_set_write_fn( pngPtr, &ioptr, png_WriteData, png_FlushData );
 	
 	if( bytesPerPixel == 4 )
 	{


### PR DESCRIPTION
Debian is going for libpng 1.6 now.
As libpng1.6 changes API (especially hiding struct members and no longer including headers like zlib.h or strings.h) the attached patch is required to compile it against it.
The patch is play-tested a bit, but please review it as well.

Thanks!

tobi

PS: The patch is backward compatible, tested also against libpng 1.2
