### PR TITLE
x86-64 *WindowLongPtr + cpuid detection in x86_64

### DIFF
--- a/neo/idlib/sys/sys_defines.h
+++ b/neo/idlib/sys/sys_defines.h
@@ -40,7 +40,11 @@ If you have questions concerning this license or the applicable additional terms
 // Win32
 #if defined(WIN32) || defined(_WIN32)
 
+#if defined(WIN64) || defined(_WIN64)
+#define	CPUSTRING						"x86_64"
+#else
 #define	CPUSTRING						"x86"
+#endif
 
 #define	BUILD_STRING					"win-" CPUSTRING
 
@@ -108,7 +112,7 @@ If you have questions concerning this license or the applicable additional terms
 #if defined(__i386__)
 #define	CPUSTRING						"x86"
 #elif defined(__x86_64__)
-#define CPUSTRING						"x86_86"
+#define CPUSTRING						"x86_64"
 #else
 #error unknown CPU
 #endif

--- a/neo/sys/win32/win_glimp.cpp
+++ b/neo/sys/win32/win_glimp.cpp
@@ -1406,8 +1406,8 @@ bool GLimp_SetScreenParms( glimpParms_t parms )
 		stylebits = WINDOW_STYLE | WS_SYSMENU;
 	}
 	
-	SetWindowLong( win32.hWnd, GWL_STYLE, stylebits );
-	SetWindowLong( win32.hWnd, GWL_EXSTYLE, exstyle );
+	SetWindowLongPtr( win32.hWnd, GWL_STYLE, stylebits );
+	SetWindowLongPtr( win32.hWnd, GWL_EXSTYLE, exstyle );
 	SetWindowPos( win32.hWnd, parms.fullScreen ? HWND_TOPMOST : HWND_NOTOPMOST, x, y, w, h, SWP_SHOWWINDOW );
 	
 	glConfig.isFullscreen = parms.fullScreen;

--- a/neo/sys/win32/win_syscon.cpp
+++ b/neo/sys/win32/win_syscon.cpp
@@ -428,9 +428,9 @@ void Sys_CreateConsole()
 	
 	// RB begin
 #if defined(_WIN64)
-	s_wcd.SysInputLineWndProc = ( WNDPROC ) SetWindowLong( s_wcd.hwndInputLine, GWLP_WNDPROC, ( LONG_PTR ) InputLineWndProc );
+	s_wcd.SysInputLineWndProc = ( WNDPROC ) SetWindowLongPtr( s_wcd.hwndInputLine, GWLP_WNDPROC, ( LONG_PTR ) InputLineWndProc );
 #else
-	s_wcd.SysInputLineWndProc = ( WNDPROC ) SetWindowLong( s_wcd.hwndInputLine, GWL_WNDPROC, ( LONG ) InputLineWndProc );
+	s_wcd.SysInputLineWndProc = ( WNDPROC ) SetWindowLongPtr( s_wcd.hwndInputLine, GWL_WNDPROC, ( LONG_PTR ) InputLineWndProc );
 #endif
 	// RB end
 	SendMessage( s_wcd.hwndInputLine, WM_SETFONT, ( WPARAM ) s_wcd.hfBufferFont, 0 );

--- a/neo/sys/win32/win_wndproc.cpp
+++ b/neo/sys/win32/win_wndproc.cpp
@@ -188,7 +188,7 @@ LONG WINAPI MainWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 						glConfig.nativeScreenHeight = rect.bottom - rect.top;
 						
 						// save the window size in cvars if we aren't fullscreen
-						int style = GetWindowLong( hWnd, GWL_STYLE );
+						LONG_PTR style = GetWindowLongPtr( hWnd, GWL_STYLE );
 						if( ( style & WS_POPUP ) == 0 )
 						{
 							r_windowWidth.SetInteger( glConfig.nativeScreenWidth );
@@ -204,7 +204,7 @@ LONG WINAPI MainWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 			RECT r;
 			
 			// save the window origin in cvars if we aren't fullscreen
-			int style = GetWindowLong( hWnd, GWL_STYLE );
+			LONG_PTR style = GetWindowLongPtr( hWnd, GWL_STYLE );
 			if( ( style & WS_POPUP ) == 0 )
 			{
 				xPos = ( short ) LOWORD( lParam ); // horizontal position


### PR DESCRIPTION
To be compatible with WIN64 builds should use [GetWindowLongPtr](https://msdn.microsoft.com/en-us/library/windows/desktop/ms633585%28v=vs.85%29.aspx) /
[SetWindowLongPtr](https://msdn.microsoft.com/en-us/library/windows/desktop/ms644898%28v=vs.85%29.aspx) API to access / change attributes of the window in both
modes - x86 / x86-64.

Also, show x86-64 as CPU for such arhitectures and use `__cpuid` intrinsic instead of inline
asm for Windows. 
  