### PR TITLE
Fixed shader errors for Mesa DRI drivers on Linux

### DIFF
--- a/base/renderprogs/AmbientOcclusion_AO.pixel
+++ b/base/renderprogs/AmbientOcclusion_AO.pixel
@@ -175,8 +175,8 @@ float3 sampleNormal( sampler2D normalBuffer, int2 ssC, int mipLevel )
 float2 tapLocation( int sampleNumber, float spinAngle, out float ssR )
 {
 	// Radius relative to ssR
-	float alpha = float( sampleNumber + 0.5 ) * ( 1.0 / NUM_SAMPLES );
-	float angle = alpha * ( NUM_SPIRAL_TURNS * 6.28 ) + spinAngle;
+	float alpha = ( float( sampleNumber ) + 0.5 ) * ( 1.0 / float( NUM_SAMPLES ) );
+	float angle = alpha * ( float( NUM_SPIRAL_TURNS ) * 6.28 ) + spinAngle;
 	
 	ssR = alpha;
 	return float2( cos( angle ), sin( angle ) );
@@ -374,7 +374,7 @@ void main( PS_IN fragment, out PS_OUT result )
 #else
 	// Reconstruct normals from positions.
 	float3 n_C = reconstructNonUnitCSFaceNormal( C );
-	// Since n_C is computed from the cross product of cmaera-space edge vectors from points at adjacent pixels, its magnitude will be proportional to the square of distance from the camera
+	// Since n_C is computed from the cross product of camera-space edge vectors from points at adjacent pixels, its magnitude will be proportional to the square of distance from the camera
 	if( dot( n_C, n_C ) > ( square( C.z * C.z * 0.00006 ) ) ) // if the threshold # is too big you will see black dots where we used a bad normal at edges, too small -> white
 	{
 		// The normals from depth should be very small values before normalization,
@@ -391,11 +391,11 @@ void main( PS_IN fragment, out PS_OUT result )
 #endif
 	
 	// Hash function used in the HPG12 AlchemyAO paper
-	float randomPatternRotationAngle = ( ( ( 3 * ssP.x ) ^ ( ssP.y + ssP.x * ssP.y ) )
+	float randomPatternRotationAngle = float( ( ( 3 * ssP.x ) ^ ( ssP.y + ssP.x * ssP.y ) )
 #if TEMPORALLY_VARY_TAPS
 										 + rpJitterTexOffset.x
 #endif
-									   ) * 10;
+									   ) * 10.0;
 									   
 	// Choose the screen-space sample radius
 	// proportional to the projected area of the sphere
@@ -419,13 +419,13 @@ void main( PS_IN fragment, out PS_OUT result )
 	float sum = 0.0;
 	for( int i = 0; i < NUM_SAMPLES; ++i )
 	{
-		sum += sampleAO( ssP, C, n_C, ssDiskRadius, i, randomPatternRotationAngle, CS_Z_buffer, 1 );
+		sum += sampleAO( ssP, C, n_C, ssDiskRadius, i, randomPatternRotationAngle, CS_Z_buffer, 1.0 );
 	}
 	
 #if HIGH_QUALITY
-	float A = pow( max( 0.0, 1.0 - sqrt( sum * ( 3.0 / NUM_SAMPLES ) ) ), intensity );
+	float A = pow( max( 0.0, 1.0 - sqrt( sum * ( 3.0 / float( NUM_SAMPLES ) ) ) ), intensity );
 #else
-	float A = max( 0.0, 1.0 - sum * intensityDivR6 * ( 5.0 / NUM_SAMPLES ) );
+	float A = max( 0.0, 1.0 - sum * intensityDivR6 * ( 5.0 / float( NUM_SAMPLES ) ) );
 	// Anti-tone map to reduce contrast and drag dark region farther
 	// (x^0.2 + 1.2 * x^4)/2.2
 	//A = ( pow( A, 0.2 ) + 1.2 * A * A * A * A ) / 2.2;

--- a/base/renderprogs/DeepGBufferRadiosity_radiosity.pixel
+++ b/base/renderprogs/DeepGBufferRadiosity_radiosity.pixel
@@ -195,8 +195,8 @@ void sampleBothNormals( sampler2D normalBuffer, int2 ssC, int mipLevel, out floa
 float2 tapLocation( int sampleNumber, float spinAngle, float radialJitter, out float ssR )
 {
 	// Radius relative to ssR
-	float alpha = float( sampleNumber + radialJitter ) * ( 1.0 / NUM_SAMPLES );
-	float angle = alpha * ( NUM_SPIRAL_TURNS * 6.28 ) + spinAngle;
+	float alpha = ( float( sampleNumber ) + radialJitter) * ( 1.0 / float( NUM_SAMPLES ) );
+	float angle = alpha * ( float( NUM_SPIRAL_TURNS ) * 6.28 ) + spinAngle;
 	
 	ssR = alpha;
 	return float2( cos( angle ), sin( angle ) );
@@ -382,7 +382,7 @@ void iiValueFromPositionsAndNormalsAndLambertian( int2 ssP, float3 X, float3 n_X
 	// E = radiosity_Y * dot(w_i, n_X) * weight_Y * float(dot(YminusX, YminusX) < radius2);
 	
 	if( ( dot( YminusX, YminusX ) < radius2 ) && // Radius check
-			( weight_Y > 0 ) )
+			( weight_Y > 0.0 ) )
 	{
 		E = radiosity_Y * dot( w_i, n_X );
 	}
@@ -512,7 +512,7 @@ void main( PS_IN fragment, out PS_OUT result )
 	float ssDiskRadius = -projScale * radius / C.z;
 	
 	// Hash function used in the HPG12 AlchemyAO paper
-	float randomPatternRotationAngle = ( 3 * ssC.x ^ ssC.y + ssC.x * ssC.y ) * 10;
+	float randomPatternRotationAngle = float( 3 * ssC.x ^ ssC.y + ssC.x * ssC.y ) * 10.0;
 #if TEMPORALLY_VARY_TAPS
 	randomPatternRotationAngle += rpJitterTexOffset.x;
 #endif
@@ -532,23 +532,23 @@ void main( PS_IN fragment, out PS_OUT result )
 		sampleIndirectLight( ssC, C, n_C, C_peeled, n_C_peeled, ssDiskRadius, i, randomPatternRotationAngle, radialJitter, CS_Z_buffer, normal_buffer, colorBuffer, irradianceSum, numSamplesUsed, ii_peeled, peeledSum );
 	}
 	
-	const float solidAngleHemisphere = 2 * PI;
+	const float solidAngleHemisphere = 2.0 * PI;
 	float3 E_X = irradianceSum * solidAngleHemisphere / ( numSamplesUsed + 0.00001 );
 	
 	indirectColor = E_X;
 	//indirectColor = pow( E_X, float3( 1.0 / 2.2 ) ); // RB: to sRGB
 	
 	// What is the ambient visibility of this location
-	visibility = 1 - numSamplesUsed / float( NUM_SAMPLES );
+	visibility = 1.0 - numSamplesUsed / float( NUM_SAMPLES );
 	//visibility = clamp( 1 - numSamplesUsed / float( NUM_SAMPLES ), 0.0, 1.0 );
-	//visibility = pow( max( 0.0, 1.0 - sqrt( sum * ( 3.0 / NUM_SAMPLES ) ) ), intensity );
+	//visibility = pow( max( 0.0, 1.0 - sqrt( sum * ( 3.0 / float( NUM_SAMPLES ) ) ) ), intensity );
 	
 	//result.color = float4( visibility, visibility, visibility, 1.0 );
 	//result.color = float4( n_C * 0.5 + 0.5, 1.0 );
 	//result.color = texture( samp2, fragment.texcoord0 ).rgba;
 	
 #if COMPUTE_PEELED_LAYER
-	float A_peeled = 1 - peeledSum / float( NUM_SAMPLES );
+	float A_peeled = 1.0 - peeledSum / float( NUM_SAMPLES );
 	float3 E_X_peeled = ii_peeled * solidAngleHemisphere / ( peeledSum + 0.00001 );
 	
 	indirectPeeledResult    = E_X_peeled;


### PR DESCRIPTION
I tried to run Doom3 BFG on Arch Linux x64, but I encountered several GLSL errors. Most of them involved implicit conversions between ints and floats. Anyway, I fixed them and the game runs. However, I had to disable SSAO because otherwise the screen eventually fills up with these black artifacts. I assume they come from a buffer not being cleared. Here are some screenshots of the effect.

[Steam Pipe behind Player start](http://i68.tinypic.com/2va08lu.png)

[Glass Screen in Scanning Room](http://i63.tinypic.com/aeumhv.png)

I assume it has something to do with transparency. I do not think this was caused by my changes, but you might want to test this code first.



