### PR TITLE
Fix crash when launching doom classic game

### DIFF
--- a/doomclassic/doom/i_sound_win32.cpp
+++ b/doomclassic/doom/i_sound_win32.cpp
@@ -957,7 +957,7 @@ void I_PlaySong( const char *songname, int looping)
 	bool isStopped = false;
 	int d = 0;
 	while ( !isStopped ) {
-		XAUDIO2_VOICE_STATE test;
+		XAUDIO2_VOICE_STATE test = {};
 
 		if ( pMusicSourceVoice != NULL ) {
 			pMusicSourceVoice->GetState( &test );


### PR DESCRIPTION
Nulling XAUDIO2_VOICE_STATE struct before using, so it's eliminate "uninitialized variable" crash when pMusicSourceVoice is NULL.

It happens when game is compiled with v140 x64 (Windows 10.0.10240.0) toolset.