### PR TITLE
Fix for Stereoscopic 3D modes with HDR and SMAA.

### DIFF
--- a/neo/renderer/Framebuffer.cpp
+++ b/neo/renderer/Framebuffer.cpp
@@ -96,8 +96,11 @@ void Framebuffer::Init()
 	}
 	
 	// HDR
+
+	int screenWidth = renderSystem->GetWidth();
+	int screenHeight = renderSystem->GetHeight();
 	
-	globalFramebuffers.hdrFBO = new Framebuffer( "_hdr", glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+	globalFramebuffers.hdrFBO = new Framebuffer( "_hdr", screenWidth, screenHeight );
 	globalFramebuffers.hdrFBO->Bind();
 	
 #if defined(USE_HDR_MSAA)
@@ -123,7 +126,7 @@ void Framebuffer::Init()
 	
 	// HDR no MSAA
 #if defined(USE_HDR_MSAA)
-	globalFramebuffers.hdrNonMSAAFBO = new Framebuffer( "_hdrNoMSAA", glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+	globalFramebuffers.hdrNonMSAAFBO = new Framebuffer( "_hdrNoMSAA", screenWidth, screenHeight );
 	globalFramebuffers.hdrNonMSAAFBO->Bind();
 	
 	globalFramebuffers.hdrNonMSAAFBO->AddColorBuffer( GL_RGBA16F, 0 );
@@ -146,7 +149,7 @@ void Framebuffer::Init()
 	
 	for( int i = 0; i < MAX_BLOOM_BUFFERS; i++ )
 	{
-		globalFramebuffers.bloomRenderFBO[i] = new Framebuffer( va( "_bloomRender%i", i ), glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+		globalFramebuffers.bloomRenderFBO[i] = new Framebuffer( va( "_bloomRender%i", i ), screenWidth, screenHeight );
 		globalFramebuffers.bloomRenderFBO[i]->Bind();
 		globalFramebuffers.bloomRenderFBO[i]->AddColorBuffer( GL_RGBA8, 0 );
 		globalFramebuffers.bloomRenderFBO[i]->AttachImage2D( GL_TEXTURE_2D, globalImages->bloomRenderImage[i], 0 );
@@ -157,7 +160,7 @@ void Framebuffer::Init()
 	
 	for( int i = 0; i < MAX_SSAO_BUFFERS; i++ )
 	{
-		globalFramebuffers.ambientOcclusionFBO[i] = new Framebuffer( va( "_aoRender%i", i ), glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+		globalFramebuffers.ambientOcclusionFBO[i] = new Framebuffer( va( "_aoRender%i", i ), screenWidth, screenHeight );
 		globalFramebuffers.ambientOcclusionFBO[i]->Bind();
 		globalFramebuffers.ambientOcclusionFBO[i]->AddColorBuffer( GL_RGBA8, 0 );
 		globalFramebuffers.ambientOcclusionFBO[i]->AttachImage2D( GL_TEXTURE_2D, globalImages->ambientOcclusionImage[i], 0 );
@@ -168,7 +171,7 @@ void Framebuffer::Init()
 	
 	for( int i = 0; i < MAX_HIERARCHICAL_ZBUFFERS; i++ )
 	{
-		globalFramebuffers.csDepthFBO[i] = new Framebuffer( va( "_csz%i", i ), glConfig.nativeScreenWidth / ( 1 << i ), glConfig.nativeScreenHeight / ( 1 << i ) );
+		globalFramebuffers.csDepthFBO[i] = new Framebuffer( va( "_csz%i", i ), screenWidth / ( 1 << i ), screenHeight / ( 1 << i ) );
 		globalFramebuffers.csDepthFBO[i]->Bind();
 		globalFramebuffers.csDepthFBO[i]->AddColorBuffer( GL_R32F, 0 );
 		globalFramebuffers.csDepthFBO[i]->AttachImage2D( GL_TEXTURE_2D, globalImages->hierarchicalZbufferImage, 0, i );
@@ -177,7 +180,7 @@ void Framebuffer::Init()
 	
 	// GEOMETRY BUFFER
 	
-	//globalFramebuffers.geometryBufferFBO = new Framebuffer( "_gbuffer", glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+	//globalFramebuffers.geometryBufferFBO = new Framebuffer( "_gbuffer", screenWidth, screenHeight );
 	//globalFramebuffers.geometryBufferFBO->Bind();
 	//globalFramebuffers.geometryBufferFBO->AddColorBuffer( GL_RGBA8, 0 );
 	//globalFramebuffers.geometryBufferFBO->AttachImage2D( GL_TEXTURE_2D, globalImages->currentNormalsImage, 0 );
@@ -185,13 +188,13 @@ void Framebuffer::Init()
 	
 	// SMAA
 	
-	globalFramebuffers.smaaEdgesFBO = new Framebuffer( "_smaaEdges", glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+	globalFramebuffers.smaaEdgesFBO = new Framebuffer( "_smaaEdges", screenWidth, screenHeight );
 	globalFramebuffers.smaaEdgesFBO->Bind();
 	globalFramebuffers.smaaEdgesFBO->AddColorBuffer( GL_RGBA8, 0 );
 	globalFramebuffers.smaaEdgesFBO->AttachImage2D( GL_TEXTURE_2D, globalImages->smaaEdgesImage, 0 );
 	globalFramebuffers.smaaEdgesFBO->Check();
 	
-	globalFramebuffers.smaaBlendFBO = new Framebuffer( "_smaaBlend", glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+	globalFramebuffers.smaaBlendFBO = new Framebuffer( "_smaaBlend", screenWidth, screenHeight );
 	globalFramebuffers.smaaBlendFBO->Bind();
 	globalFramebuffers.smaaBlendFBO->AddColorBuffer( GL_RGBA8, 0 );
 	globalFramebuffers.smaaBlendFBO->AttachImage2D( GL_TEXTURE_2D, globalImages->smaaBlendImage, 0 );
@@ -202,26 +205,29 @@ void Framebuffer::Init()
 
 void Framebuffer::CheckFramebuffers()
 {
-	if( globalFramebuffers.hdrFBO->GetWidth() != glConfig.nativeScreenWidth || globalFramebuffers.hdrFBO->GetHeight() != glConfig.nativeScreenHeight )
+	int screenWidth = renderSystem->GetWidth();
+	int screenHeight = renderSystem->GetHeight();
+
+	if( globalFramebuffers.hdrFBO->GetWidth() != screenWidth || globalFramebuffers.hdrFBO->GetHeight() != screenHeight )
 	{
 		Unbind();
 		
 		// HDR
-		globalImages->currentRenderHDRImage->Resize( glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
-		globalImages->currentDepthImage->Resize( glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+		globalImages->currentRenderHDRImage->Resize( screenWidth, screenHeight );
+		globalImages->currentDepthImage->Resize( screenWidth, screenHeight );
 		
 #if defined(USE_HDR_MSAA)
 		if( r_multiSamples.GetBool() )
 		{
-			globalImages->currentRenderHDRImageNoMSAA->Resize( glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+			globalImages->currentRenderHDRImageNoMSAA->Resize( screenWidth, screenHeight );
 			
 			globalFramebuffers.hdrFBO->Bind();
 			globalFramebuffers.hdrFBO->AttachImage2D( GL_TEXTURE_2D_MULTISAMPLE, globalImages->currentRenderHDRImage, 0 );
 			globalFramebuffers.hdrFBO->AttachImageDepth( GL_TEXTURE_2D_MULTISAMPLE, globalImages->currentDepthImage );
 			globalFramebuffers.hdrFBO->Check();
 			
-			globalFramebuffers.hdrNonMSAAFBO->width = glConfig.nativeScreenWidth;
-			globalFramebuffers.hdrNonMSAAFBO->height = glConfig.nativeScreenHeight;
+			globalFramebuffers.hdrNonMSAAFBO->width = screenWidth;
+			globalFramebuffers.hdrNonMSAAFBO->height = screenHeight;
 		}
 		else
 #endif
@@ -232,12 +238,12 @@ void Framebuffer::CheckFramebuffers()
 			globalFramebuffers.hdrFBO->Check();
 		}
 		
-		globalFramebuffers.hdrFBO->width = glConfig.nativeScreenWidth;
-		globalFramebuffers.hdrFBO->height = glConfig.nativeScreenHeight;
+		globalFramebuffers.hdrFBO->width = screenWidth;
+		globalFramebuffers.hdrFBO->height = screenHeight;
 		
 		// HDR quarter
 		/*
-		globalImages->currentRenderHDRImageQuarter->Resize( glConfig.nativeScreenWidth / 4, glConfig.nativeScreenHeight / 4 );
+		globalImages->currentRenderHDRImageQuarter->Resize( screenWidth / 4, screenHeight / 4 );
 		
 		globalFramebuffers.hdrQuarterFBO->Bind();
 		globalFramebuffers.hdrQuarterFBO->AttachImage2D( GL_TEXTURE_2D, globalImages->currentRenderHDRImageQuarter, 0 );
@@ -248,10 +254,10 @@ void Framebuffer::CheckFramebuffers()
 		
 		for( int i = 0; i < MAX_BLOOM_BUFFERS; i++ )
 		{
-			globalImages->bloomRenderImage[i]->Resize( glConfig.nativeScreenWidth / 4, glConfig.nativeScreenHeight / 4 );
+			globalImages->bloomRenderImage[i]->Resize( screenWidth / 4, screenHeight / 4 );
 			
-			globalFramebuffers.bloomRenderFBO[i]->width = glConfig.nativeScreenWidth / 4;
-			globalFramebuffers.bloomRenderFBO[i]->height = glConfig.nativeScreenHeight / 4;
+			globalFramebuffers.bloomRenderFBO[i]->width = screenWidth / 4;
+			globalFramebuffers.bloomRenderFBO[i]->height = screenHeight / 4;
 			
 			globalFramebuffers.bloomRenderFBO[i]->Bind();
 			globalFramebuffers.bloomRenderFBO[i]->AttachImage2D( GL_TEXTURE_2D, globalImages->bloomRenderImage[i], 0 );
@@ -262,10 +268,10 @@ void Framebuffer::CheckFramebuffers()
 		
 		for( int i = 0; i < MAX_SSAO_BUFFERS; i++ )
 		{
-			globalImages->ambientOcclusionImage[i]->Resize( glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+			globalImages->ambientOcclusionImage[i]->Resize( screenWidth, screenHeight );
 			
-			globalFramebuffers.ambientOcclusionFBO[i]->width = glConfig.nativeScreenWidth;
-			globalFramebuffers.ambientOcclusionFBO[i]->height = glConfig.nativeScreenHeight;
+			globalFramebuffers.ambientOcclusionFBO[i]->width = screenWidth;
+			globalFramebuffers.ambientOcclusionFBO[i]->height = screenHeight;
 			
 			globalFramebuffers.ambientOcclusionFBO[i]->Bind();
 			globalFramebuffers.ambientOcclusionFBO[i]->AttachImage2D( GL_TEXTURE_2D, globalImages->ambientOcclusionImage[i], 0 );
@@ -274,12 +280,12 @@ void Framebuffer::CheckFramebuffers()
 		
 		// HIERARCHICAL Z BUFFER
 		
-		globalImages->hierarchicalZbufferImage->Resize( glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+		globalImages->hierarchicalZbufferImage->Resize( screenWidth, screenHeight );
 		
 		for( int i = 0; i < MAX_HIERARCHICAL_ZBUFFERS; i++ )
 		{
-			globalFramebuffers.csDepthFBO[i]->width = glConfig.nativeScreenWidth / ( 1 << i );
-			globalFramebuffers.csDepthFBO[i]->height = glConfig.nativeScreenHeight / ( 1 << i );
+			globalFramebuffers.csDepthFBO[i]->width = screenWidth / ( 1 << i );
+			globalFramebuffers.csDepthFBO[i]->height = screenHeight / ( 1 << i );
 			
 			globalFramebuffers.csDepthFBO[i]->Bind();
 			globalFramebuffers.csDepthFBO[i]->AttachImage2D( GL_TEXTURE_2D, globalImages->hierarchicalZbufferImage, 0, i );
@@ -288,10 +294,10 @@ void Framebuffer::CheckFramebuffers()
 		
 		// GEOMETRY BUFFER
 		
-		//globalImages->currentNormalsImage->Resize( glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+		//globalImages->currentNormalsImage->Resize( screenWidth, screenHeight );
 		
-		//globalFramebuffers.geometryBufferFBO->width = glConfig.nativeScreenWidth;
-		//globalFramebuffers.geometryBufferFBO->height = glConfig.nativeScreenHeight;
+		//globalFramebuffers.geometryBufferFBO->width = screenWidth;
+		//globalFramebuffers.geometryBufferFBO->height = screenHeight;
 		
 		//globalFramebuffers.geometryBufferFBO->Bind();
 		//globalFramebuffers.geometryBufferFBO->AttachImage2D( GL_TEXTURE_2D, globalImages->currentNormalsImage, 0 );
@@ -299,19 +305,19 @@ void Framebuffer::CheckFramebuffers()
 		
 		// SMAA
 		
-		globalImages->smaaEdgesImage->Resize( glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+		globalImages->smaaEdgesImage->Resize( screenWidth, screenHeight );
 		
-		globalFramebuffers.smaaEdgesFBO->width = glConfig.nativeScreenWidth;
-		globalFramebuffers.smaaEdgesFBO->height = glConfig.nativeScreenHeight;
+		globalFramebuffers.smaaEdgesFBO->width = screenWidth;
+		globalFramebuffers.smaaEdgesFBO->height = screenHeight;
 		
 		globalFramebuffers.smaaEdgesFBO->Bind();
 		globalFramebuffers.smaaEdgesFBO->AttachImage2D( GL_TEXTURE_2D, globalImages->smaaEdgesImage, 0 );
 		globalFramebuffers.smaaEdgesFBO->Check();
 		
-		globalImages->smaaBlendImage->Resize( glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+		globalImages->smaaBlendImage->Resize( screenWidth, screenHeight );
 		
-		globalFramebuffers.smaaBlendFBO->width = glConfig.nativeScreenWidth;
-		globalFramebuffers.smaaBlendFBO->height = glConfig.nativeScreenHeight;
+		globalFramebuffers.smaaBlendFBO->width = screenWidth;
+		globalFramebuffers.smaaBlendFBO->height = screenHeight;
 		
 		globalFramebuffers.smaaBlendFBO->Bind();
 		globalFramebuffers.smaaBlendFBO->AttachImage2D( GL_TEXTURE_2D, globalImages->smaaBlendImage, 0 );

--- a/neo/renderer/Image_intrinsic.cpp
+++ b/neo/renderer/Image_intrinsic.cpp
@@ -168,7 +168,7 @@ static void R_DepthImage( idImage* image )
 #else
 	int msaaSamples = 0;
 #endif
-	image->GenerateImage( NULL, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight, TF_NEAREST, TR_CLAMP, TD_DEPTH, msaaSamples );
+	image->GenerateImage( NULL, renderSystem->GetWidth(), renderSystem->GetHeight(), TF_NEAREST, TR_CLAMP, TD_DEPTH, msaaSamples );
 	// RB end
 }
 
@@ -180,22 +180,22 @@ static void R_HDR_RGBA16FImage_ResNative( idImage* image )
 #else
 	int msaaSamples = 0;
 #endif
-	image->GenerateImage( NULL, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight, TF_NEAREST, TR_CLAMP, TD_RGBA16F, msaaSamples );
+	image->GenerateImage( NULL, renderSystem->GetWidth(), renderSystem->GetHeight(), TF_NEAREST, TR_CLAMP, TD_RGBA16F, msaaSamples );
 }
 
 static void R_HDR_RGBA16FImage_ResNative_NoMSAA( idImage* image )
 {
-	image->GenerateImage( NULL, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight, TF_NEAREST, TR_CLAMP, TD_RGBA16F );
+	image->GenerateImage( NULL, renderSystem->GetWidth(), renderSystem->GetHeight(), TF_NEAREST, TR_CLAMP, TD_RGBA16F );
 }
 
 static void R_HDR_RGBA16FImage_ResQuarter( idImage* image )
 {
-	image->GenerateImage( NULL, glConfig.nativeScreenWidth / 4, glConfig.nativeScreenHeight / 4, TF_NEAREST, TR_CLAMP, TD_RGBA16F );
+	image->GenerateImage( NULL, renderSystem->GetWidth() / 4, renderSystem->GetHeight() / 4, TF_NEAREST, TR_CLAMP, TD_RGBA16F );
 }
 
 static void R_HDR_RGBA16FImage_ResQuarter_Linear( idImage* image )
 {
-	image->GenerateImage( NULL, glConfig.nativeScreenWidth / 4, glConfig.nativeScreenHeight / 4, TF_LINEAR, TR_CLAMP, TD_LOOKUP_TABLE_RGBA );
+	image->GenerateImage( NULL, renderSystem->GetWidth() / 4, renderSystem->GetHeight() / 4, TF_LINEAR, TR_CLAMP, TD_LOOKUP_TABLE_RGBA );
 }
 
 static void R_HDR_RGBA16FImage_Res64( idImage* image )
@@ -205,12 +205,12 @@ static void R_HDR_RGBA16FImage_Res64( idImage* image )
 
 static void R_SMAAImage_ResNative( idImage* image )
 {
-	image->GenerateImage( NULL, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight, TF_LINEAR, TR_CLAMP, TD_LOOKUP_TABLE_RGBA );
+	image->GenerateImage( NULL, renderSystem->GetWidth(), renderSystem->GetHeight(), TF_LINEAR, TR_CLAMP, TD_LOOKUP_TABLE_RGBA );
 }
 
 static void R_HierarchicalZBufferImage_ResNative( idImage* image )
 {
-	image->GenerateImage( NULL, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight, TF_NEAREST_MIPMAP, TR_CLAMP, TD_R32F );
+	image->GenerateImage( NULL, renderSystem->GetWidth(), renderSystem->GetHeight(), TF_NEAREST_MIPMAP, TR_CLAMP, TD_R32F );
 }
 // RB end
 

--- a/neo/renderer/RenderSystem.cpp
+++ b/neo/renderer/RenderSystem.cpp
@@ -831,14 +831,7 @@ const emptyCommand_t* idRenderSystemLocal::SwapCommandBuffers_FinishCommandBuffe
 	
 	// possibly change the stereo3D mode
 	// PC
-	if( glConfig.nativeScreenWidth == 1280 && glConfig.nativeScreenHeight == 1470 )
-	{
-		glConfig.stereo3Dmode = STEREO3D_HDMI_720;
-	}
-	else
-	{
-		glConfig.stereo3Dmode = GetStereoScopicRenderingMode();
-	}
+	UpdateStereo3DMode();
 	
 	// prepare the new command buffer
 	guiModel->BeginFrame();

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -2790,7 +2790,9 @@ void idRenderSystemLocal::Init()
 	guiModel = new( TAG_RENDER ) idGuiModel;
 	guiModel->Clear();
 	tr_guiModel = guiModel;	// for DeviceContext fast path
-	
+
+	UpdateStereo3DMode();
+
 	globalImages->Init();
 	
 	// RB begin
@@ -3152,6 +3154,23 @@ idRenderSystemLocal::HasQuadBufferSupport
 bool idRenderSystemLocal::HasQuadBufferSupport() const
 {
 	return glConfig.stereoPixelFormatAvailable;
+}
+
+/*
+========================
+idRenderSystemLocal::UpdateStereo3DMode
+========================
+*/
+void idRenderSystemLocal::UpdateStereo3DMode()
+{
+	if( glConfig.nativeScreenWidth == 1280 && glConfig.nativeScreenHeight == 1470 )
+	{
+		glConfig.stereo3Dmode = STEREO3D_HDMI_720;
+	}
+	else
+	{
+		glConfig.stereo3Dmode = GetStereoScopicRenderingMode();
+	}
 }
 
 /*

--- a/neo/renderer/tr_backend_draw.cpp
+++ b/neo/renderer/tr_backend_draw.cpp
@@ -4804,10 +4804,10 @@ static void RB_SSAO( const viewDef_t* viewDef )
 	}
 	
 	float screenCorrectionParm[4];
-	screenCorrectionParm[0] = 1.0f / glConfig.nativeScreenWidth;
-	screenCorrectionParm[1] = 1.0f / glConfig.nativeScreenHeight;
-	screenCorrectionParm[2] = glConfig.nativeScreenWidth;
-	screenCorrectionParm[3] = glConfig.nativeScreenHeight;
+	screenCorrectionParm[0] = 1.0f / screenWidth;
+	screenCorrectionParm[1] = 1.0f / screenHeight;
+	screenCorrectionParm[2] = screenWidth;
+	screenCorrectionParm[3] = screenHeight;
 	SetFragmentParm( RENDERPARM_SCREENCORRECTIONFACTOR, screenCorrectionParm ); // rpScreenCorrectionFactor
 	
 #if 0
@@ -5054,10 +5054,10 @@ static void RB_SSGI( const viewDef_t* viewDef )
 	}
 	
 	float screenCorrectionParm[4];
-	screenCorrectionParm[0] = 1.0f / glConfig.nativeScreenWidth;
-	screenCorrectionParm[1] = 1.0f / glConfig.nativeScreenHeight;
-	screenCorrectionParm[2] = glConfig.nativeScreenWidth;
-	screenCorrectionParm[3] = glConfig.nativeScreenHeight;
+	screenCorrectionParm[0] = 1.0f / screenWidth;
+	screenCorrectionParm[1] = 1.0f / screenHeight;
+	screenCorrectionParm[2] = screenWidth;
+	screenCorrectionParm[3] = screenHeight;
 	SetFragmentParm( RENDERPARM_SCREENCORRECTIONFACTOR, screenCorrectionParm ); // rpScreenCorrectionFactor
 	
 #if 0
@@ -5429,8 +5429,8 @@ void RB_DrawViewInternal( const viewDef_t* viewDef, const int stereoEye )
 		/*
 		glBindFramebuffer( GL_READ_FRAMEBUFFER, globalFramebuffers.hdrFBO->GetFramebuffer() );
 		glBindFramebuffer( GL_DRAW_FRAMEBUFFER, globalFramebuffers.hdrQuarterFBO->GetFramebuffer() );
-		glBlitFramebuffer( 0, 0, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight,
-						   0, 0, glConfig.nativeScreenWidth * 0.25f, glConfig.nativeScreenHeight * 0.25f,
+		glBlitFramebuffer( 0, 0, renderSystem->GetWidth(), renderSystem->GetHeight(),
+						   0, 0, renderSystem->GetWidth() * 0.25f, renderSystem->GetHeight() * 0.25f,
 						   GL_COLOR_BUFFER_BIT,
 						   GL_LINEAR );
 		*/
@@ -5440,15 +5440,15 @@ void RB_DrawViewInternal( const viewDef_t* viewDef, const int stereoEye )
 		{
 			glBindFramebuffer( GL_READ_FRAMEBUFFER, globalFramebuffers.hdrFBO->GetFramebuffer() );
 			glBindFramebuffer( GL_DRAW_FRAMEBUFFER, globalFramebuffers.hdrNonMSAAFBO->GetFramebuffer() );
-			glBlitFramebuffer( 0, 0, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight,
-							   0, 0, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight,
+			glBlitFramebuffer( 0, 0, renderSystem->GetWidth(), renderSystem->GetHeight(),
+							   0, 0, renderSystem->GetWidth(), renderSystem->GetHeight(),
 							   GL_COLOR_BUFFER_BIT,
 							   GL_LINEAR );
 							   
 			// TODO resolve to 1x1
 			glBindFramebuffer( GL_READ_FRAMEBUFFER_EXT, globalFramebuffers.hdrNonMSAAFBO->GetFramebuffer() );
 			glBindFramebuffer( GL_DRAW_FRAMEBUFFER_EXT, globalFramebuffers.hdr64FBO->GetFramebuffer() );
-			glBlitFramebuffer( 0, 0, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight,
+			glBlitFramebuffer( 0, 0, renderSystem->GetWidth(), renderSystem->GetHeight(),
 							   0, 0, 64, 64,
 							   GL_COLOR_BUFFER_BIT,
 							   GL_LINEAR );
@@ -5458,7 +5458,7 @@ void RB_DrawViewInternal( const viewDef_t* viewDef, const int stereoEye )
 		{
 			glBindFramebuffer( GL_READ_FRAMEBUFFER_EXT, globalFramebuffers.hdrFBO->GetFramebuffer() );
 			glBindFramebuffer( GL_DRAW_FRAMEBUFFER_EXT, globalFramebuffers.hdr64FBO->GetFramebuffer() );
-			glBlitFramebuffer( 0, 0, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight,
+			glBlitFramebuffer( 0, 0, renderSystem->GetWidth(), renderSystem->GetHeight(),
 							   0, 0, 64, 64,
 							   GL_COLOR_BUFFER_BIT,
 							   GL_LINEAR );
@@ -5757,14 +5757,14 @@ void RB_PostProcess( const void* data )
 		 *                           |output|
 		*/
 		
-		globalImages->smaaInputImage->CopyFramebuffer( 0, 0, glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
+		globalImages->smaaInputImage->CopyFramebuffer( 0, 0, screenWidth, screenHeight );
 		
 		// set SMAA_RT_METRICS = rpScreenCorrectionFactor
 		float screenCorrectionParm[4];
-		screenCorrectionParm[0] = 1.0f / glConfig.nativeScreenWidth;
-		screenCorrectionParm[1] = 1.0f / glConfig.nativeScreenHeight;
-		screenCorrectionParm[2] = glConfig.nativeScreenWidth;
-		screenCorrectionParm[3] = glConfig.nativeScreenHeight;
+		screenCorrectionParm[0] = 1.0f / screenWidth;
+		screenCorrectionParm[1] = 1.0f / screenHeight;
+		screenCorrectionParm[2] = screenWidth;
+		screenCorrectionParm[3] = screenHeight;
 		SetFragmentParm( RENDERPARM_SCREENCORRECTIONFACTOR, screenCorrectionParm ); // rpScreenCorrectionFactor
 		
 		globalFramebuffers.smaaEdgesFBO->Bind();

--- a/neo/renderer/tr_local.h
+++ b/neo/renderer/tr_local.h
@@ -851,6 +851,8 @@ public:
 	// internal functions
 	idRenderSystemLocal();
 	~idRenderSystemLocal();
+
+	void					UpdateStereo3DMode();
 	
 	void					Clear();
 	void					GetCroppedViewport( idScreenRect* viewport );


### PR DESCRIPTION
A lot of code using glConfig.nativeScreenWidth, when it should be
calling renderSystem->GetWidth() (and height equivalent) which take into
account stereoscopic 3d modes. This only occurs when screen effects like HDR and SMAA are enabled at the same time as stereoscopic 3d.

This change should have no impact when stereoscopic 3d is disabled.
