### PR TITLE
Fix sprintf overflows in various locations (gcc 7)

### DIFF
--- a/doomclassic/doom/st_stuff.cpp
+++ b/doomclassic/doom/st_stuff.cpp
@@ -973,10 +973,10 @@ void ST_loadGraphics(void)
 	// Load the numbers, tall and short
 	for (i=0;i<10;i++)
 	{
-		sprintf(namebuf, "STTNUM%d", i);
+		idStr::snPrintf(namebuf, sizeof( namebuf ), "STTNUM%d", i);
 		::g->tallnum[i] = (patch_t *) W_CacheLumpName(namebuf, PU_STATIC_SHARED);
 
-		sprintf(namebuf, "STYSNUM%d", i);
+		idStr::snPrintf(namebuf, sizeof( namebuf ), "STYSNUM%d", i);
 		::g->shortnum[i] = (patch_t *) W_CacheLumpName(namebuf, PU_STATIC_SHARED);
 	}
 

--- a/doomclassic/doom/wi_stuff.cpp
+++ b/doomclassic/doom/wi_stuff.cpp
@@ -1511,7 +1511,7 @@ void WI_loadData(void)
 		// DHM - Nerve :: Use our background image
 		//strcpy(name, "DMENUPIC");
 	else 
-		sprintf(name, "WIMAP%d", ::g->wbs->epsd);
+		std::snprintf(name, sizeof( name ), "WIMAP%d", ::g->wbs->epsd);
 
 	if ( ::g->gamemode == retail )
 	{
@@ -1542,7 +1542,7 @@ void WI_loadData(void)
 		::g->lnames = (patch_t **) DoomLib::Z_Malloc(sizeof(patch_t*) * ::g->NUMCMAPS, PU_LEVEL_SHARED, 0);
 		for (i=0 ; i < ::g->NUMCMAPS ; i++)
 		{								
-			sprintf(name, "CWILV%2.2d", i);
+			idStr::snPrintf(name, sizeof( name ), "CWILV%2.2d", i);
 			::g->lnames[i] = (patch_t*)W_CacheLumpName(name, PU_LEVEL_SHARED);
 		}					
 	}
@@ -1575,7 +1575,7 @@ void WI_loadData(void)
 					if (::g->wbs->epsd != 1 || j != 8) 
 					{
 						// animations
-						sprintf(name, "WIA%d%.2d%.2d", ::g->wbs->epsd, j, i);  
+						idStr::snPrintf(name, sizeof( name ), "WIA%d%.2d%.2d", ::g->wbs->epsd, j, i);  
 						a->p[i] = (patch_t*)W_CacheLumpName(name, PU_LEVEL_SHARED);
 					}
 					else

--- a/neo/d3xp/MultiplayerGame.cpp
+++ b/neo/d3xp/MultiplayerGame.cpp
@@ -678,7 +678,7 @@ const char* idMultiplayerGame::GameTime()
 		t = s / 10;
 		s -= t * 10;
 		
-		sprintf( buff, "%i:%i%i", m, t, s );
+		idStr::snPrintf( buff, sizeof( buff ), "%i:%i%i", m, t, s );
 	}
 	return &buff[0];
 }

--- a/neo/idlib/StrStatic.h
+++ b/neo/idlib/StrStatic.h
@@ -97,7 +97,7 @@ public:
 	{
 		buffer[ 0 ] = '\0';
 		SetStaticBuffer( buffer, _size_ );
-		idStr::operator=( b );
+		idStr::operator=( idStr( b ) );
 	}
 	
 	ID_INLINE	explicit idStrStatic( const char c ) :
@@ -105,7 +105,7 @@ public:
 	{
 		buffer[ 0 ] = '\0';
 		SetStaticBuffer( buffer, _size_ );
-		idStr::operator=( c );
+		idStr::operator=( idStr( c ) );
 	}
 	
 	ID_INLINE	explicit idStrStatic( const int i ) :
@@ -113,7 +113,7 @@ public:
 	{
 		buffer[ 0 ] = '\0';
 		SetStaticBuffer( buffer, _size_ );
-		idStr::operator=( i );
+		idStr::operator=( idStr( i ) );
 	}
 	
 	ID_INLINE	explicit idStrStatic( const unsigned u ) :
@@ -121,7 +121,7 @@ public:
 	{
 		buffer[ 0 ] = '\0';
 		SetStaticBuffer( buffer, _size_ );
-		idStr::operator=( u );
+		idStr::operator=( idStr( u ) );
 	}
 	
 	ID_INLINE	explicit idStrStatic( const float f ) :
@@ -129,7 +129,7 @@ public:
 	{
 		buffer[ 0 ] = '\0';
 		SetStaticBuffer( buffer, _size_ );
-		idStr::operator=( f );
+		idStr::operator=( idStr( f ) );
 	}
 	
 private:

--- a/neo/sys/posix/platform_linux.cpp
+++ b/neo/sys/posix/platform_linux.cpp
@@ -198,7 +198,7 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 		pos = 0;
 		while( pos < len )
 		{
-			if( !idStr::Cmpn( buf + pos, "processor", 9 ) )
+			if( !idStr::Cmpn( buf + pos, "cpu cores", 9 ) )
 			{
 				pos = strchr( buf + pos, ':' ) - buf + 2;
 				end = strchr( buf + pos, '\n' ) - buf;
@@ -210,9 +210,9 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 					
 					int processor = atoi( number );
 					
-					if( ( processor + 1 ) > s_numPhysicalCPUCores )
+					if( ( processor ) > s_numPhysicalCPUCores )
 					{
-						s_numPhysicalCPUCores = processor + 1;
+						s_numPhysicalCPUCores = processor;
 					}
 				}
 				else
@@ -221,7 +221,7 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 					break;
 				}
 			}
-			else if( !idStr::Cmpn( buf + pos, "core id", 7 ) )
+			else if( !idStr::Cmpn( buf + pos, "siblings", 8 ) )
 			{
 				pos = strchr( buf + pos, ':' ) - buf + 2;
 				end = strchr( buf + pos, '\n' ) - buf;
@@ -233,9 +233,9 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 					
 					int coreId = atoi( number );
 					
-					if( ( coreId + 1 ) > s_numLogicalCPUCores )
+					if( ( coreId ) > s_numLogicalCPUCores )
 					{
-						s_numLogicalCPUCores = coreId + 1;
+						s_numLogicalCPUCores = coreId;
 					}
 				}
 				else

--- a/neo/tools/compilers/dmap/dmap.cpp
+++ b/neo/tools/compilers/dmap/dmap.cpp
@@ -390,7 +390,7 @@ void Dmap( const idCmdArgs& args )
 	// if this isn't a regioned map, delete the last saved region map
 	if( passedName.Right( 4 ) != ".reg" )
 	{
-		sprintf( path, "%s.reg", dmapGlobals.mapFileBase );
+		idStr::snPrintf( path, sizeof( path ), "%s.reg", dmapGlobals.mapFileBase );
 		fileSystem->RemoveFile( path );
 	}
 	else
@@ -402,7 +402,7 @@ void Dmap( const idCmdArgs& args )
 	passedName = stripped;
 	
 	// delete any old line leak files
-	sprintf( path, "%s.lin", dmapGlobals.mapFileBase );
+	idStr::snPrintf( path, sizeof( path ),"%s.lin", dmapGlobals.mapFileBase );
 	fileSystem->RemoveFile( path );
 	
 	// delete any old generated binary proc files


### PR DESCRIPTION
New problem that occurs under GCC7 with regards to overflow's.

Replaced sprintf with Common->printf as used elsewhere.