### PR TITLE
Add cmake files for VS 2017 support

### DIFF
--- a/neo/cmake-vs2017-32bit-windows10.bat
+++ b/neo/cmake-vs2017-32bit-windows10.bat
@@ -1,0 +1,6 @@
+cd ..
+del /s /q build
+mkdir build
+cd build
+cmake -G "Visual Studio 15" -DCMAKE_INSTALL_PREFIX=../bin/windows10-32 -DWINDOWS10=ON ../neo
+pause

--- a/neo/cmake-vs2017-32bit.bat
+++ b/neo/cmake-vs2017-32bit.bat
@@ -1,0 +1,6 @@
+cd ..
+del /s /q build
+mkdir build
+cd build
+cmake -G "Visual Studio 15" -DCMAKE_INSTALL_PREFIX=../bin/windows7-32 -DWINDOWS10=OFF ../neo
+pause

--- a/neo/cmake-vs2017-64bit-windows10.bat
+++ b/neo/cmake-vs2017-64bit-windows10.bat
@@ -1,0 +1,6 @@
+cd ..
+del /s /q build
+mkdir build
+cd build
+cmake -G "Visual Studio 15 Win64" -DCMAKE_INSTALL_PREFIX=../bin/windows10-64 -DWINDOWS10=ON ../neo
+pause

--- a/neo/cmake-vs2017-64bit.bat
+++ b/neo/cmake-vs2017-64bit.bat
@@ -1,0 +1,6 @@
+cd ..
+del /s /q build
+mkdir build
+cd build
+cmake -G "Visual Studio 15 Win64" -DCMAKE_INSTALL_PREFIX=../bin/windows7-64 ../neo
+pause


### PR DESCRIPTION
Win10 solutions are likely needed to be used if you don't want to depend on the DXSDK same as 2015.