### PR TITLE
Static cvars incorrectly checking against wrong size on 64

### DIFF
--- a/neo/framework/CVarSystem.h
+++ b/neo/framework/CVarSystem.h
@@ -366,7 +366,7 @@ ID_INLINE void idCVar::Init( const char* name, const char* value, int flags, con
 	this->integerValue = 0;
 	this->floatValue = 0.0f;
 	this->internalVar = this;
-	if( staticVars != ( idCVar* )0xFFFFFFFF )
+	if( staticVars != ( idCVar* )UINTPTR_MAX )
 	{
 		this->next = staticVars;
 		staticVars = this;
@@ -379,13 +379,13 @@ ID_INLINE void idCVar::Init( const char* name, const char* value, int flags, con
 
 ID_INLINE void idCVar::RegisterStaticVars()
 {
-	if( staticVars != ( idCVar* )0xFFFFFFFF )
+	if( staticVars != ( idCVar* )UINTPTR_MAX )
 	{
 		for( idCVar* cvar = staticVars; cvar; cvar = cvar->next )
 		{
 			cvarSystem->Register( cvar );
 		}
-		staticVars = ( idCVar* )0xFFFFFFFF;
+		staticVars = ( idCVar* )UINTPTR_MAX;
 	}
 }
 


### PR DESCRIPTION
On 64-bit arch these checks are incorrect. the `0xFFFFFFFF` is effectively `UINT32_MAX` rather than the pointer size. Changing to the unsigned integral pointer maximum seems like a better idea.

Fixes the warning, and corrects the code.