### PR TITLE
Fix detection of Mesa >= 17.2.

### DIFF
--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -390,7 +390,9 @@ static void R_CheckPortableExtensions()
 	}
 	
 	// RB: Mesa support
-	if( idStr::Icmpn( glConfig.renderer_string, "Mesa", 4 ) == 0 || idStr::Icmpn( glConfig.renderer_string, "X.org", 4 ) == 0 || idStr::Icmpn( glConfig.renderer_string, "Gallium", 7 ) == 0 )
+	if( idStr::Icmpn( glConfig.renderer_string, "Mesa", 4 ) == 0 || idStr::Icmpn( glConfig.renderer_string, "X.org", 5 ) == 0 || idStr::Icmpn( glConfig.renderer_string, "Gallium", 7 ) == 0 ||
+	    strcmp( glConfig.vendor_string, "X.Org" ) == 0 ||
+	    idStr::Icmpn( glConfig.renderer_string, "llvmpipe", 8 ) == 0 )
 	{
 		if( glConfig.driverType == GLDRV_OPENGL32_CORE_PROFILE )
 		{


### PR DESCRIPTION
This handles accelerated drivers (vendor == "X.Org") and software rendering (llvmpipe).