### PR TITLE
Replace std::auto_ptr due to deprecation in C++11.

### DIFF
--- a/neo/framework/FileSystem.cpp
+++ b/neo/framework/FileSystem.cpp
@@ -2754,13 +2754,13 @@ void idFileSystemLocal::GenerateResourceCRCs_f( const idCmdArgs& args )
 {
 	idLib::Printf( "Generating CRCs for resource files...\n" );
 	
-	std::auto_ptr<idFileList> baseResourceFileList( fileSystem->ListFiles( ".", ".resources" ) );
+	std::unique_ptr<idFileList> baseResourceFileList( fileSystem->ListFiles( ".", ".resources" ) );
 	if( baseResourceFileList.get() != NULL )
 	{
 		CreateCRCsForResourceFileList( *baseResourceFileList );
 	}
 	
-	std::auto_ptr<idFileList> mapResourceFileList( fileSystem->ListFilesTree( "maps", ".resources" ) );
+	std::unique_ptr<idFileList> mapResourceFileList( fileSystem->ListFilesTree( "maps", ".resources" ) );
 	if( mapResourceFileList.get() != NULL )
 	{
 		CreateCRCsForResourceFileList( *mapResourceFileList );
@@ -2780,7 +2780,7 @@ void idFileSystemLocal::CreateCRCsForResourceFileList( const idFileList& list )
 	{
 		idLib::Printf( " Processing %s.\n", list.GetFile( fileIndex ) );
 		
-		std::auto_ptr<idFile_Memory> currentFile( static_cast<idFile_Memory*>( fileSystem->OpenFileReadMemory( list.GetFile( fileIndex ) ) ) );
+		std::unique_ptr<idFile_Memory> currentFile( static_cast<idFile_Memory*>( fileSystem->OpenFileReadMemory( list.GetFile( fileIndex ) ) ) );
 		
 		if( currentFile.get() == NULL )
 		{
@@ -2832,7 +2832,7 @@ void idFileSystemLocal::CreateCRCsForResourceFileList( const idFileList& list )
 		// Write the .crc file corresponding to the .resources file.
 		idStr crcFilename = list.GetFile( fileIndex );
 		crcFilename.SetFileExtension( ".crc" );
-		std::auto_ptr<idFile> crcOutputFile( fileSystem->OpenFileWrite( crcFilename, "fs_basepath" ) );
+		std::unique_ptr<idFile> crcOutputFile( fileSystem->OpenFileWrite( crcFilename, "fs_basepath" ) );
 		if( crcOutputFile.get() == NULL )
 		{
 			// RB: fixed potential crash because of "cannot pass objects of non-trivially-copyable type 'class idStr' through '...'"

--- a/neo/sys/sys_profile.h
+++ b/neo/sys/sys_profile.h
@@ -62,8 +62,8 @@ private:
 	void				OnSaveSettingsCompleted( idSaveLoadParms* parms );
 	
 private:
-	std::auto_ptr< idSaveGameProcessorSaveProfile >	profileSaveProcessor;
-	std::auto_ptr< idSaveGameProcessorLoadProfile >	profileLoadProcessor;
+	std::shared_ptr< idSaveGameProcessorSaveProfile >	profileSaveProcessor;
+	std::shared_ptr< idSaveGameProcessorLoadProfile >	profileLoadProcessor;
 	
 	idLocalUser* 						user;					// reference passed in
 	idPlayerProfile* 					profile;

--- a/neo/sys/sys_session_savegames.cpp
+++ b/neo/sys/sys_session_savegames.cpp
@@ -386,7 +386,7 @@ saveGameHandle_t idSessionLocal::LoadGameSync( const char* name, saveFileEntryLi
 		
 		// Read the details file when loading games
 		saveFileEntryList_t	filesWithDetails( files );
-		std::auto_ptr< idFile_SaveGame > gameDetailsFile( new( TAG_SAVEGAMES ) idFile_SaveGame( SAVEGAME_DETAILS_FILENAME, SAVEGAMEFILE_TEXT ) );
+		std::unique_ptr< idFile_SaveGame > gameDetailsFile( new( TAG_SAVEGAMES ) idFile_SaveGame( SAVEGAME_DETAILS_FILENAME, SAVEGAMEFILE_TEXT ) );
 		filesWithDetails.Append( gameDetailsFile.get() );
 		
 		// Check the cached save details from the enumeration and make sure we don't load a save from a newer version of the game!


### PR DESCRIPTION
It's replaced with std::unique_ptr where possible, std::shared_ptr otherwise.