### PR TITLE
Support XDG base directory specification

### DIFF
--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -104,7 +104,15 @@ const char* Sys_DefaultSavePath()
 		SDL_free( base_path );
 	}
 #else
-	sprintf( savepath, "%s/.rbdoom3bfg", getenv( "HOME" ) );
+	const char* xdg_data_home = getenv( "XDG_DATA_HOME" );
+	if( xdg_data_home != NULL )
+	{
+		sprintf( savepath, "%s/rbdoom3bfg", xdg_data_home );
+	}
+	else
+	{
+		sprintf( savepath, "%s/.local/share/rbdoom3bfg", getenv( "HOME" ) );
+	}
 #endif
 	
 	return savepath.c_str();


### PR DESCRIPTION
Changing saves/local directory for Linux and compatible POSIX systems, to support [XDG base directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) which helps decluttering `$HOME`.