### PR TITLE
doomclassic/doom/wi_stuff.cpp:  Fix snprintf compilation error

### DIFF
--- a/doomclassic/doom/wi_stuff.cpp
+++ b/doomclassic/doom/wi_stuff.cpp
@@ -1511,7 +1511,7 @@ void WI_loadData(void)
 		// DHM - Nerve :: Use our background image
 		//strcpy(name, "DMENUPIC");
 	else 
-		std::snprintf(name, sizeof( name ), "WIMAP%d", ::g->wbs->epsd);
+		idStr::snPrintf(name, sizeof( name ), "WIMAP%d", ::g->wbs->epsd);
 
 	if ( ::g->gamemode == retail )
 	{


### PR DESCRIPTION
introduced in commit c8e3cd9fe2f4d3e7604f0ca1ead51a3b2a91ca79

Simple replacement of std:snprintf with idStr:snPrintf, to match all
other instances introduced in the noted commit.  This fixes compilation
on g++.