### PR TITLE
Fix issue #373

### DIFF
--- a/doomclassic/doom/r_segs.cpp
+++ b/doomclassic/doom/r_segs.cpp
@@ -368,7 +368,11 @@ R_StoreWallRange
     
     // calculate ::g->rw_distance for scale calculation
     ::g->rw_normalangle = ::g->curline->angle + ANG90;
-	offsetangle = abs((long)(::g->rw_normalangle-::g->rw_angle1));
+	if(!idStr::Icmp(CPUSTRING,"x86_64")){ //GK: One single cast to the wrong OS and CPU type can make all the graphical glitches 
+		offsetangle = abs((int)(::g->rw_normalangle-::g->rw_angle1)); 
+	}else{ 
+		offsetangle = abs((long)(::g->rw_normalangle-::g->rw_angle1)); 
+	} 
     
     if (offsetangle > ANG90)
 	offsetangle = ANG90;


### PR DESCRIPTION
 Classic Doom graphical artifacts on 64-bit Linux.
NOTE: It also requires pull request #420 in order to check the CPU