### PR TITLE
Prevent vanilla .resource maps to be reloaded

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -305,8 +305,8 @@ if(USE_VULKAN)
 	#option(ENABLE_NV_EXTENSIONS "Enables support of Nvidia-specific extensions" ON)
 	#option(ENABLE_OPT "Enables spirv-opt capability if present" ON)
 	
-	set(GLSLANG_DIR $ENV{VK_SDK_PATH}/glslang)
-	add_subdirectory(${GLSLANG_DIR} ${CMAKE_CURRENT_BINARY_DIR}/glslang)
+	set(GLSLANG_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs/glslang)
+	add_subdirectory(${GLSLANG_DIR})
 	
 	include_directories(${GLSLANG_DIR}/glslang)
 

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -305,8 +305,8 @@ if(USE_VULKAN)
 	#option(ENABLE_NV_EXTENSIONS "Enables support of Nvidia-specific extensions" ON)
 	#option(ENABLE_OPT "Enables spirv-opt capability if present" ON)
 	
-	set(GLSLANG_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs/glslang)
-	add_subdirectory(${GLSLANG_DIR})
+	set(GLSLANG_DIR $ENV{VK_SDK_PATH}/glslang)
+	add_subdirectory(${GLSLANG_DIR} ${CMAKE_CURRENT_BINARY_DIR}/glslang)
 	
 	include_directories(${GLSLANG_DIR}/glslang)
 

--- a/neo/framework/FileSystem.cpp
+++ b/neo/framework/FileSystem.cpp
@@ -2882,13 +2882,13 @@ int idFileSystemLocal::AddResourceFile( const char* resourceFileName )
 idFileSystemLocal::FindResourceFile
 ================
 */
-int idFileSystemLocal::FindResourceFile(const char* resourceFileName)
+int idFileSystemLocal::FindResourceFile( const char* resourceFileName )
 {
-	const char* mapFileName = va("maps/%s", resourceFileName);
-	for (int i = 0; i < resourceFiles.Num(); i++)
+	const char* mapFileName = va( "maps/%s", resourceFileName );
+	for( int i = 0; i < resourceFiles.Num(); i++ )
 	{
-
-		if (idStr::Icmp(resourceFileName, resourceFiles[i]->GetFileName()) == 0 || idStr::Icmp(mapFileName, resourceFiles[i]->GetFileName()) == 0)
+	
+		if( idStr::Icmp( resourceFileName, resourceFiles[i]->GetFileName() ) == 0 || idStr::Icmp( mapFileName, resourceFiles[i]->GetFileName() ) == 0 )
 		{
 			return i;
 		}

--- a/neo/framework/FileSystem.cpp
+++ b/neo/framework/FileSystem.cpp
@@ -2882,11 +2882,13 @@ int idFileSystemLocal::AddResourceFile( const char* resourceFileName )
 idFileSystemLocal::FindResourceFile
 ================
 */
-int idFileSystemLocal::FindResourceFile( const char* resourceFileName )
+int idFileSystemLocal::FindResourceFile(const char* resourceFileName)
 {
-	for( int i = 0; i < resourceFiles.Num(); i++ )
+	const char* mapFileName = va("maps/%s", resourceFileName);
+	for (int i = 0; i < resourceFiles.Num(); i++)
 	{
-		if( idStr::Icmp( resourceFileName, resourceFiles[ i ]->GetFileName() ) == 0 )
+
+		if (idStr::Icmp(resourceFileName, resourceFiles[i]->GetFileName()) == 0 || idStr::Icmp(mapFileName, resourceFiles[i]->GetFileName()) == 0)
 		{
 			return i;
 		}


### PR DESCRIPTION
This will allow RBDOOM to load .resource mods that affect vanilla maps like : [https://www.moddb.com/mods/classic-rbdoom-3-bfg-edition/addons/doom-3-bfg-hi-def-resource-edition](url).