### PR TITLE
Tweak Muzzle Flashes option casing in the menus for consistency

### DIFF
--- a/neo/d3xp/menus/MenuScreen_Shell_GameOptions.cpp
+++ b/neo/d3xp/menus/MenuScreen_Shell_GameOptions.cpp
@@ -128,7 +128,7 @@ void idMenuScreen_Shell_GameOptions::Initialize( idMenuHandler* data )
 	
 	control = new( TAG_SWF )idMenuWidget_ControlButton();
 	control->SetOptionType( OPTION_SLIDER_TOGGLE );
-	control->SetLabel( "muzzle flashes" );
+	control->SetLabel( "Muzzle Flashes" );
 	control->SetDataSource( &systemData, idMenuDataSource_GameSettings::GAME_FIELD_MUZZLE_FLASHES );
 	control->SetupEvents( DEFAULT_REPEAT_TIME, options->GetChildren().Num() );
 	control->AddEventAction( WIDGET_EVENT_PRESS ).Set( WIDGET_ACTION_PRESS_FOCUSED, options->GetChildren().Num() );


### PR DESCRIPTION
Other options in the menu use Title Case. This makes the Muzzle Flashes option follow the same casing.