### PR TITLE
Fix s_numPhysicalCPUCores

### DIFF
--- a/neo/sys/posix/platform_linux.cpp
+++ b/neo/sys/posix/platform_linux.cpp
@@ -254,7 +254,6 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 			else	// "else" is displayed here because some processors do not have information about the "siblings" in /proc/cpuinfo
 				{
 					common->Printf( "failed parsing /proc/cpuinfo\n" );
-					CPUsiblings = false;
 					break;
 				}
 

--- a/neo/sys/posix/platform_linux.cpp
+++ b/neo/sys/posix/platform_linux.cpp
@@ -41,6 +41,9 @@ If you have questions concerning this license or the applicable additional terms
 // DG: needed for Sys_ReLaunch()
 #include <dirent.h>
 
+#include <stdio.h>
+#include <cstring>
+
 static const char** cmdargv = NULL;
 static int cmdargc = 0;
 // DG end
@@ -219,13 +222,16 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 						s_numPhysicalCPUCores = processor;
 					}
 				}
-				else
+			}
+			else	// "else" is displayed here because some processors do not have information about the "cpu cores" in /proc/cpuinfo
 				{
 					common->Printf( "failed parsing /proc/cpuinfo\n" );
+					common->Printf( "Alternate method used\n" );
+					s_numPhysicalCPUCores = sysconf(_SC_NPROCESSORS_CONF);
 					break;
 				}
-			}
-			else if( !idStr::Cmpn( buf + pos, "siblings", 8 ) )
+			
+			if( !idStr::Cmpn( buf + pos, "siblings", 8 ) )
 			{
 				pos = strchr( buf + pos, ':' ) - buf + 2;
 				end = strchr( buf + pos, '\n' ) - buf;
@@ -242,12 +248,12 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 						s_numLogicalCPUCores = coreId;
 					}
 				}
-				else
+			}
+			else	// "else" is displayed here because some processors do not have information about the "siblings" in /proc/cpuinfo
 				{
 					common->Printf( "failed parsing /proc/cpuinfo\n" );
 					break;
 				}
-			}
 
 			pos = strchr( buf + pos, '\n' ) - buf + 1;
 		}

--- a/neo/sys/posix/platform_linux.cpp
+++ b/neo/sys/posix/platform_linux.cpp
@@ -176,6 +176,7 @@ numCPUPackages		- the total number of packages (physical processors)
 void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCPUPackages )
 {
 	static bool		init = false;
+	static bool		CPUCores = false;	// for alternate method
 	static double	ret;
 
 	static int		s_numLogicalCPUCores;
@@ -220,6 +221,7 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 					if( ( processor ) > s_numPhysicalCPUCores )
 					{
 						s_numPhysicalCPUCores = processor;
+						CPUcores = true;
 					}
 				}
 			}
@@ -227,7 +229,7 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 				{
 					common->Printf( "failed parsing /proc/cpuinfo\n" );
 					common->Printf( "Alternate method used\n" );
-					s_numPhysicalCPUCores = sysconf(_SC_NPROCESSORS_CONF);
+					CPUcores = false;
 					break;
 				}
 			
@@ -252,11 +254,22 @@ void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCP
 			else	// "else" is displayed here because some processors do not have information about the "siblings" in /proc/cpuinfo
 				{
 					common->Printf( "failed parsing /proc/cpuinfo\n" );
+					CPUsiblings = false;
 					break;
 				}
 
 			pos = strchr( buf + pos, '\n' ) - buf + 1;
 		}
+		if( CPUcores = false )
+		{
+			s_numPhysicalCPUCores = sysconf(_SC_NPROCESSORS_CONF);
+		}
+	}
+	else
+	{
+		common->Printf( "failed read /proc/cpuinfo\n" );
+		common->Printf( "Alternate method used\n" );
+		s_numPhysicalCPUCores = sysconf(_SC_NPROCESSORS_CONF);
 	}
 
 	common->Printf( "/proc/cpuinfo CPU processors: %d\n", s_numPhysicalCPUCores );


### PR DESCRIPTION
Corrections to the Sys_CPUCount Procedure

If cpuinfo lacks the necessary information, then s_numPhysicalCPUCores is determined by the built-in c ++ operator.
This is important on Linux processors and OS, where the proper information is missing in /proc/cpuinfo

Если в cpuinfo не хватает нужной информации, то s_numPhysicalCPUCores определяется встроенным оператором  c++ .

Это важно на процессорах и ОС Линукс, где отсутствует должная информация в /proc/cpuinfo