### PR TITLE
Initial Nvidia jetson nano with Vulkan Support

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -62,7 +62,9 @@ option(USE_SYSTEM_RAPIDJSON
 
 set(CPU_TYPE "" CACHE STRING "When set, passes this string as CPU-ID which will be embedded into the binary.")
 
-set(CPU_OPTIMIZATION "-mmmx -msse -msse2" CACHE STRING "Which CPU specific optimitations should be used beside the compiler's default?")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+	set(CPU_OPTIMIZATION "-mmmx -msse -msse2" CACHE STRING "Which CPU specific optimitations should be used beside the compiler's default?")
+endif()
 
 option(USE_INTRINSICS "Compile using intrinsics (e.g mmx, sse, msse2)" ON)
 

--- a/neo/cmake-linux-nvidia-jetson-vulkan-release.sh
+++ b/neo/cmake-linux-nvidia-jetson-vulkan-release.sh
@@ -1,0 +1,5 @@
+cd ..
+rm -rf build
+mkdir build
+cd build
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DSDL2=ON -DONATIVE=ON -DUSE_INTRINSICS=OFF -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF ../neo

--- a/neo/idlib/sys/sys_defines.h
+++ b/neo/idlib/sys/sys_defines.h
@@ -111,7 +111,9 @@ If you have questions concerning this license or the applicable additional terms
 			#define CPUSTRING						"x86_64"
 		#elif defined(__e2k__)
 			#define CPUSTRING						"e2k"
-		#else
+		#elif defined(__aarch64__) || defined(__ARM64__) || defined(_M_ARM64)
+			#define CPUSTRING 						"aarch64"
+                #else
 			#error unknown CPU
 		#endif
 	#endif


### PR DESCRIPTION
It is to support this board https://developer.nvidia.com/embedded/jetson-nano-developer-kit
Cpu aarch64 64bits 4GB with  vulkan 1.2 support :)

![Image Vulkan rendering 4K nVIDIA jetson nano](https://u.cubeupload.com/mrcmunir/0e9ffce9ee84ba5a6928.jpg)

It has a bug with the letters position i.e in terminals  but I do not know if it is normal or it is a specific bug of the device except that the performance is not bad running ~45-60fps on 1080p
on 4K arround 20fps sometimes up to 25-30fps.