### PR TITLE
Fix white soft shadows glitch

### DIFF
--- a/base/renderprogs/interactionSM.ps.hlsl
+++ b/base/renderprogs/interactionSM.ps.hlsl
@@ -368,7 +368,7 @@ void main( PS_IN fragment, out PS_OUT result )
 	//float vogelPhi = InterleavedGradientNoiseAnim( fragment.position.xy, rpJitterTexOffset.w );
 
 	float shadowTexelSize = rpScreenCorrectionFactor.z * rpJitterTexScale.x;
-	for( float i = 0; i < numSamples; i += 1.0 )
+	for( float i = 0.0; i < numSamples; i += 1.0 )
 	{
 		float2 jitter = VogelDiskSample( i, numSamples, vogelPhi );
 

--- a/neo/renderer/RenderProgs_embedded.h
+++ b/neo/renderer/RenderProgs_embedded.h
@@ -10316,7 +10316,7 @@ static const cgShaderDef_t cg_renderprogs[] =
 		"	//float vogelPhi = InterleavedGradientNoiseAnim( fragment.position.xy, rpJitterTexOffset.w );\n"
 		"\n"
 		"	float shadowTexelSize = rpScreenCorrectionFactor.z * rpJitterTexScale.x;\n"
-		"	for( float i = 0; i < numSamples; i += 1.0 )\n"
+		"	for( float i = 0.0; i < numSamples; i += 1.0 )\n"
 		"	{\n"
 		"		float2 jitter = VogelDiskSample( i, numSamples, vogelPhi );\n"
 		"\n"


### PR DESCRIPTION
Assigning an integer to a float variable in HLSL causes undefined behaviour in RadeonSI/MESA.

Before:
![before](https://user-images.githubusercontent.com/2345745/90441366-7f866900-e0e1-11ea-8ac9-f3475508f492.jpg)

After:
![after](https://user-images.githubusercontent.com/2345745/90441371-80b79600-e0e1-11ea-8841-2b34e0094126.jpg)

