### PR TITLE
Fix cpu clock-hz inaccuracy on linux

### DIFF
--- a/neo/sys/posix/platform_linux.cpp
+++ b/neo/sys/posix/platform_linux.cpp
@@ -112,57 +112,15 @@ double Sys_ClockTicksPerSecond()
 	static bool		init = false;
 	static double	ret;
 
-	int		fd, len, pos, end;
-	char	buf[ 4096 ];
-
 	if( init )
 	{
 		return ret;
 	}
 
-	fd = open( "/proc/cpuinfo", O_RDONLY );
-	if( fd == -1 )
-	{
-		common->Printf( "couldn't read /proc/cpuinfo\n" );
-		ret = MeasureClockTicks();
-		init = true;
-		common->Printf( "measured CPU frequency: %g MHz\n", ret / 1000000.0 );
-		return ret;
-	}
-	len = read( fd, buf, 4096 );
-	close( fd );
-	pos = 0;
-	while( pos < len )
-	{
-		if( !idStr::Cmpn( buf + pos, "cpu MHz", 7 ) )
-		{
-			pos = strchr( buf + pos, ':' ) - buf + 2;
-			end = strchr( buf + pos, '\n' ) - buf;
-			if( pos < len && end < len )
-			{
-				buf[end] = '\0';
-				ret = atof( buf + pos );
-			}
-			else
-			{
-				common->Printf( "failed parsing /proc/cpuinfo\n" );
-				ret = MeasureClockTicks();
-				init = true;
-				common->Printf( "measured CPU frequency: %g MHz\n", ret / 1000000.0 );
-				return ret;
-			}
-			common->Printf( "/proc/cpuinfo CPU frequency: %g MHz\n", ret );
-			ret *= 1000000;
-			init = true;
-			return ret;
-		}
-		pos = strchr( buf + pos, '\n' ) - buf + 1;
-	}
-	common->Printf( "failed parsing /proc/cpuinfo\n" );
 	ret = MeasureClockTicks();
 	init = true;
-	common->Printf( "measured CPU frequency: %g MHz\n", ret / 1000000.0 );
-	return ret;
+    common->Printf( "measured CPU frequency: %g MHz\n", ret / 1000000.0 );
+    return ret;
 }
 
 /*

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -264,11 +264,9 @@ double Sys_GetClockTicks()
 #else
 //#error unsupported CPU
 // RB begin
-	struct timespec now;
-
-	clock_gettime( CLOCK_MONOTONIC, &now );
-
-	return now.tv_sec * 1000000000LL + now.tv_nsec;
+    uint32_t lo, hi;
+    __asm__ __volatile__ ( "rdtsc" : "=a" (lo), "=d" (hi));
+    return ( ( ( uint64_t )hi ) << 32 ) | lo;
 // RB end
 #endif
 }

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -261,14 +261,20 @@ double Sys_GetClockTicks()
 		"pop %%ebx\n"
 		: "=r"( lo ), "=r"( hi ) );
 	return ( double ) lo + ( double ) 0xFFFFFFFF * hi;
-#else
-//#error unsupported CPU
 // RB begin
+#elif defined( __x86_64__ )
     uint32_t lo, hi;
     __asm__ __volatile__ ( "rdtsc" : "=a" (lo), "=d" (hi));
     return ( ( ( uint64_t )hi ) << 32 ) | lo;
-// RB end
+#else
+    //#error unsupported CPU
+    struct timespec now;
+
+    clock_gettime( CLOCK_MONOTONIC, &now );
+
+    return now.tv_sec * 1000000000LL + now.tv_nsec;
 #endif
+// RB end
 }
 
 /*


### PR DESCRIPTION
Hi Robert, long time fan here. 

One thing that's slightly bugged me when using your fork is that it registers my CPU frequency wrong. I have an AMD 2950x that runs at 3.5Ghz base clock but the game would always pick up 1900-2100Mhz from the /proc/cpuinfo file because some of my threads will clock down when not in use. I don't think this is super important since it's only used really for timers?

Anyway, I went ahead and fixed it.

Standalone Test: https://pastebin.com/9B9g8BCc

