### PR TITLE
Make depthBounds optional for the Vulkan renderer

### DIFF
--- a/neo/renderer/Vulkan/RenderBackend_VK.cpp
+++ b/neo/renderer/Vulkan/RenderBackend_VK.cpp
@@ -714,7 +714,7 @@ static void CreateLogicalDeviceAndQueues()
 	VkPhysicalDeviceFeatures deviceFeatures = {};
 	deviceFeatures.textureCompressionBC = VK_TRUE;
 	deviceFeatures.imageCubeArray = VK_TRUE;
-	deviceFeatures.depthClamp = VK_TRUE;
+	deviceFeatures.depthClamp = VK_FALSE;
 	deviceFeatures.depthBiasClamp = VK_TRUE;
 	deviceFeatures.depthBounds = vkcontext.physicalDeviceFeatures.depthBounds;
 	deviceFeatures.fillModeNonSolid = VK_TRUE;

--- a/neo/renderer/Vulkan/RenderBackend_VK.cpp
+++ b/neo/renderer/Vulkan/RenderBackend_VK.cpp
@@ -716,7 +716,7 @@ static void CreateLogicalDeviceAndQueues()
 	deviceFeatures.imageCubeArray = VK_TRUE;
 	deviceFeatures.depthClamp = VK_TRUE;
 	deviceFeatures.depthBiasClamp = VK_TRUE;
-	deviceFeatures.depthBounds = VK_TRUE;
+	deviceFeatures.depthBounds = vkcontext.physicalDeviceFeatures.depthBounds;
 	deviceFeatures.fillModeNonSolid = VK_TRUE;
 	deviceFeatures.samplerAnisotropy = vkcontext.physicalDeviceFeatures.samplerAnisotropy; // RB
 
@@ -2279,7 +2279,7 @@ idRenderBackend::GL_DepthBoundsTest
 */
 void idRenderBackend::GL_DepthBoundsTest( const float zmin, const float zmax )
 {
-	if( zmin > zmax )
+	if( !vkcontext.physicalDeviceFeatures.depthBounds || zmin > zmax )
 	{
 		return;
 	}

--- a/neo/renderer/Vulkan/RenderProgs_VK.cpp
+++ b/neo/renderer/Vulkan/RenderProgs_VK.cpp
@@ -1236,7 +1236,7 @@ static VkPipeline CreateGraphicsPipeline(
 		depthStencilState.depthTestEnable = VK_TRUE;
 		depthStencilState.depthWriteEnable = ( stateBits & GLS_DEPTHMASK ) == 0;
 		depthStencilState.depthCompareOp = depthCompareOp;
-		depthStencilState.depthBoundsTestEnable = ( stateBits & GLS_DEPTH_TEST_MASK ) != 0;
+		depthStencilState.depthBoundsTestEnable = vkcontext.physicalDeviceFeatures.depthBounds && ( stateBits & GLS_DEPTH_TEST_MASK ) != 0;
 		depthStencilState.minDepthBounds = 0.0f;
 		depthStencilState.maxDepthBounds = 1.0f;
 		depthStencilState.stencilTestEnable = ( stateBits & ( GLS_STENCIL_FUNC_BITS | GLS_STENCIL_OP_BITS | GLS_SEPARATE_STENCIL ) ) != 0;


### PR DESCRIPTION
Note that I didn't tested this change yet (so it just compiles), so this is more about testing waters to check if the change would be accepted (that's the reason of the wip: prefix)

So giving some context, we are working on the Vulkan driver for the rpi4, and after getting it Vulkan 1.0 conformant [1], we are starting to test it with real apps, for bugfixing, performance work, and also to somehow decide which optional features we should work one. For example, we got the ports to Vulkan of the original Quake trilogy working [2] 

There are still 5 features not supported yet by the driver that are requested for RBDOOM3-BFG. 4 of them are feasible to support. But depthBounds would be more tricky, as it is not supported by the HW. So today I started to check how that feature is used here, and I found that on the OpenGL renderer it is a kind of optional requirement. So perhaps it could be the same on Vulkan?

[1] https://www.raspberrypi.org/blog/vulkan-update-were-conformant/
[2] https://blogs.igalia.com/itoral/2020/07/23/v3dv_vulkan_driver_update/