### PR TITLE
Staging: add a limit of how many commands to stage

### DIFF
--- a/neo/renderer/Vulkan/Staging_VK.h
+++ b/neo/renderer/Vulkan/Staging_VK.h
@@ -54,6 +54,8 @@ struct stagingBuffer_t
 	VkFence				fence;
 	VkDeviceSize		offset;
 	byte* 				data;
+
+	int stagedCommands;
 };
 
 class idVulkanStagingManager


### PR DESCRIPTION
Although staging commands can be a good idea from performance pov, it
also means that we are increasing the size of the command buffer,
until the queue submission is set (in most drivers).

For example, when computing the Interactions, staged command buffers
can be easily greater that 15k. This could be a problem with
low-memory devices, like rpi4.

This patch adds a new variable to configure the maximum size of staged
commands. When that limit is reached a Flush is done (similar to the
existing limit on the UploadBufferSize).