### PR TITLE
Fix openSUSE reqs command not rendering correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Existing repositories can be updated manually:
 		> sudo pacman -S sdl2 cmake openal ffmpeg
 
 	On openSUSE
+	
 		> sudo zypper install cmake libSDL2-devel openal-soft-devel
 
 	You don't need FFmpeg to be installed. You can also turn it off by add -DFFMPEG=OFF to the CMake options.


### PR DESCRIPTION
At line `270`, It needed a line break in order to render the codeblock properly.

*Just something I noticed while reading the README*