### PR TITLE
Fix com_smp = -1 logic error in Frame() if com_editors active

### DIFF
--- a/neo/framework/common_frame.cpp
+++ b/neo/framework/common_frame.cpp
@@ -871,7 +871,8 @@ void idCommonLocal::Frame()
 		gameReturn_t ret = gameThread.RunGameAndDraw( numGameFrames, userCmdMgr, IsClient(), gameFrame - numGameFrames );
 
 		// foresthale 2014-05-12: also check com_editors as many of them are not particularly thread-safe (editLights for example)
-		if( com_smp.GetInteger() == 0 || com_editors != 0 )
+        // SRS - if com_editors is active make sure com_smp != -1, otherwise skip and call SwapCommandBuffers_FinishRendering later
+		if( com_smp.GetInteger() == 0 || ( com_smp.GetInteger() > 0 && com_editors != 0 ) )
 		{
 			// in non-smp mode, run the commands we just generated, instead of
 			// frame-delayed ones from a background thread


### PR DESCRIPTION
Fix logic error in rendering when com_editors is active and com_smp = -1 .  In this situation SwapCommandBuffers_FinishCommandBuffers() and SwapCommandBuffers_FinishRendering() would erroneously be called back to back at the end of a frame.  The fix corrects this case so that only SwapCommandBuffers_FinishRendering() will be called at the end of a frame.