### PR TITLE
Fix for ASE meshes without materials.

### DIFF
--- a/neo/renderer/Model.cpp
+++ b/neo/renderer/Model.cpp
@@ -2272,8 +2272,12 @@ bool idRenderModelStatic::ConvertASEToModelSurfaces( const struct aseModel_s* as
 	{
 		object = ase->objects[objectNum];
 		mesh = &object->mesh;
-		material = ase->materials[object->materialRef];
-		im1 = declManager->FindMaterial( material->name );
+		//material = ase->materials[object->materialRef];
+		//im1 = declManager->FindMaterial( material->name );
+		// 
+		// caedes dhewm3 fix for ASE meshes without materials (a lot of Doom 3 mods have this issue) 05-18-2021
+		material = (ase->materials.Num() > object->materialRef) ? ase->materials[object->materialRef] : NULL;
+		im1 = declManager->FindMaterial(material ? material->name : NULL);
 
 		bool normalsParsed = mesh->normalsParsed;
 


### PR DESCRIPTION
I had to patch RBdoom3BFG because the engine crashed due to an ASE model with no materials while testing  "a Place of Malice" custom map by Garth `` Zombie '' Hendy (aka Z0mbie13). I think other maps could benefit since a lot of Doom 3 mods have this issue. This also contribute to make the engine more reliable with ASE model compatibility. This fix was suggested by caedes of Dhewm3 dev team. I tested this patch for RBdoom3 and I found is stable.