### PR TITLE
Fix build on macOS for latest Vulkan SDK 1.2.176.1

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -350,6 +350,16 @@ if(USE_VULKAN)
 
 	# RB: moved this above the general Vulkan part so glslang does not include Vulkan SDK headers
 	# which causes all kinds of weird segmentation faults because struct sizes don't match
+ 
+    # SRS - Set default VULKAN_SDK location if environment variable not defined on OSX
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT DEFINED ENV{VULKAN_SDK})
+        if(NOT USE_MoltenVK)
+            # SRS - Vulkan SDK installer copies standard vulkan headers and libs to /usr/local on OSX
+            set(ENV{VULKAN_SDK} /usr/local)
+        else()
+            message(FATAL_ERROR "Must define VULKAN_SDK location if USE_MoltenVK option enabled!")
+        endif()
+    endif()
 
 	if(SPIRV_SHADERC)
 		add_definitions(-DSPIRV_SHADERC)

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -399,7 +399,6 @@ if(USE_VULKAN)
         add_definitions(-DUSE_VULKAN)
         include_directories($ENV{VULKAN_SDK}/include)
 
-        # SRS - Locate this after Vulkan SDK include path, otherwise issues with precompiled headers
 		if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             # SRS - Enable Beta extensions for VULKAN_SDK portability subset features on OSX
             add_definitions(-DVK_ENABLE_BETA_EXTENSIONS)

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -396,18 +396,23 @@ if(USE_VULKAN)
 	if(NOT Vulkan_FOUND)
 		message(FATAL_ERROR "Could not find Vulkan library!")
 	else()
-		# SRS - Optionally use MoltenVK headers/library for runtime config functions on OSX
-		if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND USE_MoltenVK)
-			add_definitions(-DUSE_MoltenVK)
-			include_directories($ENV{VULKAN_SDK}/../MoltenVK/include)
-			set(Vulkan_LIBRARY $ENV{VULKAN_SDK}/lib/libMoltenVK.dylib)
+        add_definitions(-DUSE_VULKAN)
+        include_directories($ENV{VULKAN_SDK}/include)
+
+        # SRS - Locate this after Vulkan SDK include path, otherwise issues with precompiled headers
+		if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            # SRS - Enable Beta extensions for VULKAN_SDK portability subset features on OSX
+            add_definitions(-DVK_ENABLE_BETA_EXTENSIONS)
+            # SRS - Optionally use MoltenVK headers/library for runtime config functions on OSX
+            if(USE_MoltenVK)
+                add_definitions(-DUSE_MoltenVK)
+                include_directories($ENV{VULKAN_SDK}/../MoltenVK/include)
+                set(Vulkan_LIBRARY $ENV{VULKAN_SDK}/lib/libMoltenVK.dylib)
+            endif()
 		endif()
 		message(STATUS "Using Vulkan: " ${Vulkan_LIBRARY})
 	endif()
 	
-	add_definitions(-DUSE_VULKAN)
-	include_directories($ENV{VULKAN_SDK}/include)
-
 	# Eric: For use with SDL2/Vulkan
 	if(UNIX)
 		find_package(X11_XCB)

--- a/neo/cmake-macos-opengl-debug.sh
+++ b/neo/cmake-macos-opengl-debug.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf build
 mkdir build
 cd build
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON  -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON  -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-macos-opengl-release.sh
+++ b/neo/cmake-macos-opengl-release.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf build
 mkdir build
 cd build
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-macos-opengl-retail.sh
+++ b/neo/cmake-macos-opengl-retail.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf build
 mkdir build
 cd build
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="-DID_RETAIL" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="-DID_RETAIL" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-xcode-opengl-debug.sh
+++ b/neo/cmake-xcode-opengl-debug.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf xcode-opengl-debug
 mkdir xcode-opengl-debug
 cd xcode-opengl-debug
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Debug -DSDL2=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Debug -DSDL2=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-xcode-opengl-release.sh
+++ b/neo/cmake-xcode-opengl-release.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf xcode-opengl-release
 mkdir xcode-opengl-release
 cd xcode-opengl-release
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-xcode-vulkan-debug.sh
+++ b/neo/cmake-xcode-vulkan-debug.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf xcode-vulkan-debug
 mkdir xcode-vulkan-debug
 cd xcode-vulkan-debug
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Debug -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G Xcode -DCMAKE_SUPPRESS_REGENERATION=ON -DCMAKE_BUILD_TYPE=Debug -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-xcode-vulkan-debug.sh
+++ b/neo/cmake-xcode-vulkan-debug.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf xcode-vulkan-debug
 mkdir xcode-vulkan-debug
 cd xcode-vulkan-debug
-cmake -G Xcode -DCMAKE_SUPPRESS_REGENERATION=ON -DCMAKE_BUILD_TYPE=Debug -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Debug -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_XCODE_SCHEME_ENVIRONMENT="MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1" -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-xcode-vulkan-release.sh
+++ b/neo/cmake-xcode-vulkan-release.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf xcode-vulkan-release
 mkdir xcode-vulkan-release
 cd xcode-vulkan-release
-cmake -G Xcode -DCMAKE_SUPPRESS_REGENERATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-xcode-vulkan-release.sh
+++ b/neo/cmake-xcode-vulkan-release.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf xcode-vulkan-release
 mkdir xcode-vulkan-release
 cd xcode-vulkan-release
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G Xcode -DCMAKE_SUPPRESS_REGENERATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/renderer/Vulkan/RenderBackend_VK.cpp
+++ b/neo/renderer/Vulkan/RenderBackend_VK.cpp
@@ -74,14 +74,9 @@ static const char* g_instanceExtensions[ g_numInstanceExtensions ] =
 };
 #endif
 
-// SRS - needed for MoltenVK portability implementation on OSX
-#if defined(__APPLE__)
-	// required for VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME visibility (as of SDK 1.2.170.0)
-	#include <vulkan/vulkan_beta.h>
-	#if defined(USE_MoltenVK)
-		// optionally needed for runtime access to fullImageViewSwizzle (instead of env var MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE = 1)
-		#include <MoltenVK/vk_mvk_moltenvk.h>
-	#endif
+// SRS - optionally needed for runtime access to fullImageViewSwizzle (instead of env var MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE = 1)
+#if defined(__APPLE__) && defined(USE_MoltenVK)
+#include <MoltenVK/vk_mvk_moltenvk.h>
 #endif
 
 static const int g_numDebugInstanceExtensions = 1;
@@ -1508,7 +1503,7 @@ void idRenderBackend::Init()
 
 	// DG: make sure SDL has setup video so getting supported modes in R_SetNewMode() works
 	// SRS - Add OSX case
-#if ( defined(__linux__) || defined(__APPLE__) ) && defined(USE_VULKAN)
+#if defined(__linux__) || defined(__APPLE__)
 	VKimp_PreInit();
 #else
 	GLimp_PreInit();
@@ -1704,7 +1699,7 @@ void idRenderBackend::Shutdown()
 
 	// destroy main window
 	// SRS - Add OSX case
-#if ( defined(__linux__) || defined(__APPLE__) ) && defined(USE_VULKAN)
+#if defined(__linux__) || defined(__APPLE__)
 	VKimp_Shutdown();
 #else
 	GLimp_Shutdown();


### PR DESCRIPTION
macOS build breaks with latest Vulkan SDK 1.2.176.1, due to new protection of some portability subset feature definitions by the VK_ENABLE_BETA_EXTENSIONS flag.  Changed CMakeLists.txt to enable this flag for macOS and be more independent of Vulkan SDK version.  Also removed explicit reference to vulkan_beta.h inside RendererBackend_VK.cpp - explicit #include no longer required when VK_ENABLE_BETA_EXTENSIONS flag is defined.

Added ability to use default location for Vulkan SDK on macOS (/usr/local) if VULKAN_SDK environment variable not defined.  Also disabled ZERO_CHECK target for Xcode Vulkan builds - otherwise edits to CMakeLists.txt will cause Xcode build to fail due to broken Vulkan SDK paths caused by cmake ZERO_CHECK regeneration.

Updated cmake shell scripts for improved Xcode integration.  The RBDoom3BFG target is now selected vs. ALL_BUILD on Xcode launch, the correct build configuration is selected in Xcode scheme for the RBDoom3BFG target (debug or release), the executable is set by default, and the Vulkan environment variable (MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1) is defined for Vulkan debug builds where the Vulkan loader is used (vs MoltenVK where it is not required).  Although the implementation is quite different vs. Visual Studio, thanks to raynorpat's pull request #567 for the inspiration!

Changes are limited to macOS, other than small cleanup of redundant USE_VULKAN tests in RendererBackend_VK.