### PR TITLE
Steam and GOG.com base path support for Windows

### DIFF
--- a/neo/framework/Licensee.h
+++ b/neo/framework/Licensee.h
@@ -74,4 +74,9 @@ If you have questions concerning this license or the applicable additional terms
 #endif
 // RB end
 
+// raynorpat: Steam AppID and Steam App Name for figuring out Steam base path
+#define STEAMPATH_APPID					"208200"
+#define STEAMPATH_NAME					"DOOM 3 BFG Edition"
 
+// raynorpat: GOG.com Galaxy Launcher Game ID for figuring out Steam base path
+#define GOGPATH_ID						"1733124578"


### PR DESCRIPTION
This uses the registry unfortunately, but is fairly clean. Uses the Wide char to ASCI conversion from dhwem3.

This will check the Steam App ID first, then the Steam install path, then finally will check the GOG.com App ID, otherwise it will fallback to the plain old current working directory check.