### PR TITLE
Fix Classic Doom Music playback with XAudio2 backend

### DIFF
--- a/doomclassic/doom/i_sound_win32.cpp
+++ b/doomclassic/doom/i_sound_win32.cpp
@@ -833,9 +833,7 @@ void I_InitMusic(void)
 		voiceFormat.cbSize = 0;
 
 // RB: XAUDIO2_VOICE_MUSIC not available on Windows 8 SDK
-#if !defined(USE_WINRT) //(_WIN32_WINNT < 0x0602 /*_WIN32_WINNT_WIN8*/)
-		soundSystemLocal.hardware.GetIXAudio2()->CreateSourceVoice( &pMusicSourceVoice, (WAVEFORMATEX *)&voiceFormat, XAUDIO2_VOICE_MUSIC );
-#endif
+		soundSystemLocal.hardware.GetIXAudio2()->CreateSourceVoice( &pMusicSourceVoice, (WAVEFORMATEX *)&voiceFormat/*, XAUDIO2_VOICE_MUSIC*/ );
 // RB end
 
 		Music_initialized = true;

--- a/doomclassic/doom/mus2midi.cpp
+++ b/doomclassic/doom/mus2midi.cpp
@@ -165,6 +165,10 @@ int Mus2Midi(unsigned char* bytes, unsigned char* out, int* len)
 	
 	// current position in read buffer
 	unsigned char* cur = bytes,* end;
+	if( cur[0] != 'M' || cur[1] != 'U' || cur[2] != 'S' )
+	{
+		return 0;
+	}
 
 	// Midi header(format 0)
 	MidiHeaderChunk_t midiHeader;


### PR DESCRIPTION
Fixes classic Doom music playback when compiling with WINDOWS10=ON