### PR TITLE
Update RenderBackend.cpp

### DIFF
--- a/neo/renderer/RenderBackend.cpp
+++ b/neo/renderer/RenderBackend.cpp
@@ -3609,7 +3609,7 @@ idRenderBackend::DrawInteractions
 */
 void idRenderBackend::DrawInteractions( const viewDef_t* _viewDef )
 {
-	if( r_skipInteractions.GetBool() || viewDef->viewLights == NULL )
+	if( r_skipInteractions.GetBool() || viewDef->viewLights == NULL || viewDef->renderView.rdflags & RDF_NODIRECT )
 	{
 		return;
 	}


### PR DESCRIPTION
added a way to skip the interactions via flag in the viewDef, for rendering the light grid bounces.