### PR TITLE
Update RenderWorld_lightgrid.cpp

### DIFF
--- a/neo/renderer/RenderWorld_lightgrid.cpp
+++ b/neo/renderer/RenderWorld_lightgrid.cpp
@@ -1240,6 +1240,10 @@ CONSOLE_COMMAND( bakeLightGrids, "Bake irradiance/vis light grid data", NULL )
 							{
 								ref.rdflags |= RDF_NOAMBIENT;
 							}
+							else if( bounce == 1 )
+							{
+								ref.rdflags |= RDF_NODIRECT;
+							}
 
 							ref.fov_x = ref.fov_y = 90;
 


### PR DESCRIPTION
added the skip of the direct lighting when doing the second bounce.