### PR TITLE
Fix openal-soft includes on macOS; fix default sysroot for cmd line builds

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -183,9 +183,9 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 	# SRS - Make sure OSX can find system headers and add support for minimum OSX runtime version
 	if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 		# SRS - Also add -fasm-blocks otherwise Xcode complains
-		add_definitions(-fasm-blocks -isysroot "${CMAKE_OSX_SYSROOT}")
-		if("${CMAKE_OSX_DEPLOYMENT_TARGET}")
-			add_definitions(-mmacosx-version-min="${CMAKE_OSX_DEPLOYMENT_TARGET}")
+		add_definitions(-fasm-blocks)
+		if(CMAKE_OSX_DEPLOYMENT_TARGET)
+			add_definitions(-isysroot "${CMAKE_OSX_SYSROOT}" -mmacosx-version-min="${CMAKE_OSX_DEPLOYMENT_TARGET}")
 		endif()
 	endif()
 
@@ -1700,6 +1700,12 @@ else()
 		if(OPENAL)
 			find_package(OpenAL REQUIRED)
 			add_definitions(-DUSE_OPENAL)
+   
+            # SRS - Added support for OpenAL Soft headers on OSX (vs default macOS SDK headers)
+            if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND OPENAL_INCLUDE_DIR MATCHES "openal-soft")
+                include_directories(${OPENAL_INCLUDE_DIR})
+                add_definitions(-DUSE_OPENAL_SOFT_INCLUDES)
+            endif()
 
 			list(APPEND RBDOOM3_INCLUDES ${OPENAL_INCLUDES})
 			list(APPEND RBDOOM3_SOURCES

--- a/neo/cmake-macos-opengl-debug.sh
+++ b/neo/cmake-macos-opengl-debug.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf build
 mkdir build
 cd build
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON  -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DSDL2=ON  -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-macos-opengl-release.sh
+++ b/neo/cmake-macos-opengl-release.sh
@@ -2,4 +2,5 @@ cd ..
 rm -rf build
 mkdir build
 cd build
+# change or remove -DCMAKE_OSX_DEPLOYMENT_TARGET=<version> to match supported runtime targets
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-macos-opengl-retail.sh
+++ b/neo/cmake-macos-opengl-retail.sh
@@ -2,4 +2,5 @@ cd ..
 rm -rf build
 mkdir build
 cd build
+# change or remove -DCMAKE_OSX_DEPLOYMENT_TARGET=<version> to match supported runtime targets
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="-DID_RETAIL" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-macos-vulkan-debug.sh
+++ b/neo/cmake-macos-vulkan-debug.sh
@@ -3,3 +3,4 @@ rm -rf build
 mkdir build
 cd build
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+echo "** NOTE: For this build type must set environment variable MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1 at runtime **"

--- a/neo/cmake-macos-vulkan-debug.sh
+++ b/neo/cmake-macos-vulkan-debug.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf build
 mkdir build
 cd build
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-macos-vulkan-release.sh
+++ b/neo/cmake-macos-vulkan-release.sh
@@ -2,4 +2,5 @@ cd ..
 rm -rf build
 mkdir build
 cd build
+# change or remove -DCMAKE_OSX_DEPLOYMENT_TARGET=<version> to match supported runtime targets
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-macos-vulkan-retail.sh
+++ b/neo/cmake-macos-vulkan-retail.sh
@@ -2,4 +2,5 @@ cd ..
 rm -rf build
 mkdir build
 cd build
+# change or remove -DCMAKE_OSX_DEPLOYMENT_TARGET=<version> to match supported runtime targets
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="-DID_RETAIL" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-xcode-opengl-release.sh
+++ b/neo/cmake-xcode-opengl-release.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf xcode-opengl-release
 mkdir xcode-opengl-release
 cd xcode-opengl-release
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DSDL2=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-xcode-vulkan-release.sh
+++ b/neo/cmake-xcode-vulkan-release.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf xcode-vulkan-release
 mkdir xcode-vulkan-release
 cd xcode-vulkan-release
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/renderer/Vulkan/vma.h
+++ b/neo/renderer/Vulkan/vma.h
@@ -770,11 +770,9 @@ remove them if not needed.
 
 //SRS - Modified from vkQuake2, to compile with C++11 on OSX versions with no aligned_alloc
 #if defined(__APPLE__)
-#if !defined(MAC_OS_X_VERSION_10_16) && defined(__cplusplus) && __cplusplus < 201703L
-// For C++14, usr/include/malloc/_malloc.h declares aligned_alloc() only with
-// the MacOSX11.0 SDK in Xcode 12 (which is what adds MAC_OS_X_VERSION_10_16).
-// For C++17 aligned_alloc is available with the 10.15 SDK already.
-void* aligned_alloc( size_t alignment, size_t size )
+//SRS - aligned_alloc available on macOS starting with C++17 on 10.15 SDK, C++14 on 11.0 SDK
+//SRS - Instead, use custom _aligned_alloc for portability across macOS SDK and runtime versions
+void* _aligned_alloc( size_t alignment, size_t size )
 {
 	// alignment must be >= sizeof(void*)
 	if( alignment < sizeof( void* ) )
@@ -789,7 +787,6 @@ void* aligned_alloc( size_t alignment, size_t size )
 	}
 	return NULL;
 }
-#endif
 #elif !defined(_WIN32)
 #include <malloc.h> // for aligned_alloc()
 #endif
@@ -825,6 +822,8 @@ void* aligned_alloc( size_t alignment, size_t size )
 #ifndef VMA_SYSTEM_ALIGNED_MALLOC
 	#if defined(_WIN32)
 		#define VMA_SYSTEM_ALIGNED_MALLOC(size, alignment)   (_aligned_malloc((size), (alignment)))
+    #elif defined(__APPLE__)
+        #define VMA_SYSTEM_ALIGNED_MALLOC(size, alignment)   (_aligned_alloc((alignment), (size) ))
 	#else
 		#define VMA_SYSTEM_ALIGNED_MALLOC(size, alignment)   (aligned_alloc((alignment), (size) ))
 	#endif

--- a/neo/sound/snd_local.h
+++ b/neo/sound/snd_local.h
@@ -98,7 +98,8 @@ typedef enum
 
 //#define AL_ALEXT_PROTOTYPES
 
-#ifdef __APPLE__
+// SRS - Added check on OSX for OpenAL Soft headers vs macOS SDK headers
+#if defined(__APPLE__) && !defined(USE_OPENAL_SOFT_INCLUDES)
 	#include <OpenAL/al.h>
 	#include <OpenAL/alc.h>
 #else


### PR DESCRIPTION
Fixed issue where macOS builds were not picking up openal-soft include path, even if specified in build shell script.  Builds were using default OpenAL headers from macOS SDK, which lead to incorrect deprecation warnings even though the external openal-soft library was being linked.  Corrected to pick up correct openal-soft headers when specified.

Also fixed error in CMakeLists where the macOS sysroot string was empty for command line builds when a minimum macOS runtime version was not specified.  This lead to command line build errors with a blank sysroot.  Corrected error to properly support default sysroot on builds when minimum macOS runtime version is not specified.

Removed minimum macOS runtime version from Xcode and debug cmd line build scripts.  This makes the implementation more portable across macOS versions.  Left minimum macOS runtime version in release/retail cmd line build scripts but added comment to users to adjust macOS minimum version based on desired runtime needs.

Changed macOS Vulkan builds to always use custom _aligned_alloc() independent of macOS SDK and runtime version.  Was previously trying to be too smart with #ifdefs sensing macOS SDK version and C++ standards for native presence of aligned_alloc().  This would likely lead to brittle behaviour across future macOS SDKs targeting older runtimes with distracting build warnings (already an issue on Catalina builds when targeting earlier runtime versions).  Custom _aligned_alloc is simple posix code that should be portable across future SDKs and architectures.

All changes limited to macOS-specific code.  Tested on Mojave and Catalina.