### PR TITLE
E2K: added use of Intel Intrinsics for MCST Elbrus 2000 architecture by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ I started this project in 2012 and focused on making this code being future proo
 * Sourcecode cleanup using the Artistic Style C++ beautifier to ensure the Git diffs and logs are clean
 * Fixed tons of warnings using the Clang compiler
 * Fast compile times using precompiled header support which allows to compile the entire engine and builtin tools in less than 30 seconds on a Ryzen 9
-* Although not really supported but runs on exotic hardware like MIPS64, PPC64 and ARM architectures
+* Although not really supported but runs on exotic hardware like MIPS64, PPC64, ARM64 and E2K architectures
 * Updated idRenderLog to support RenderDoc and Nvidia's Nsight and only issue OpenGL or Vulkan debug commands if the debug extensions are detected. Reference: https://devblogs.nvidia.com/best-practices-gpu-performance-events/
 
 ## Modding Support

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -341,11 +341,11 @@ Using the models argument will also export all needed models by entity declarati
 
 * Windows builds still require OpenGL 4.5 but they run in compatibility profile instead of core profile
 
-* Support for the MIPS64 architecture (thanks to Ramil Sattarov)
+* Initial support for the MIPS64 architecture (thanks to Ramil Sattarov)
 
 * Initial support for the PPC64 architecture (thanks to Trung Lê)
 
-* Initial support for the Rasperi PI4 (thanks to Alejandro Piñeiro)
+* Initial support for the Raspberry Pi 4 (thanks to Alejandro Piñeiro)
 
 * Updated Mac OS support (thanks to Steve Saunders)
 
@@ -404,6 +404,7 @@ This is a maintenance release without Vulkan support even though it contains a l
 * Many smaller compiler related fixes like VS 2017 and VS 2019 support.
   If it fails to compile with GCC then it should at least build with Clang on Linux
 
+* Initial support for the E2K (MCST Elbrus 2000) architecture (thanks to Ramil Sattarov)
 
 _______________________________________
 

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -72,7 +72,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
 	set(CPU_OPTIMIZATION "-mmmx -msse -msse2" CACHE STRING "Which CPU specific optimitations should be used beside the compiler's default?")
 endif()
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)|(e2k)|(E2K)")
 	option(USE_INTRINSICS_SSE "Compile using SSE intrinsics (e.g mmx, sse, msse2)" ON)
 else()
 	option(USE_INTRINSICS_SSE "Compile using SSE intrinsics (e.g mmx, sse, msse2)" OFF)

--- a/neo/cmake-linux-debug-nosimd.sh
+++ b/neo/cmake-linux-debug-nosimd.sh
@@ -1,5 +1,0 @@
-cd ..
-rm -rf build
-mkdir build
-cd build
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DSDL2=ON -DUSE_INTRINSICS=OFF ../neo

--- a/neo/cmake-linux-nvidia-jetson-vulkan-release.sh
+++ b/neo/cmake-linux-nvidia-jetson-vulkan-release.sh
@@ -1,5 +1,0 @@
-cd ..
-rm -rf build
-mkdir build
-cd build
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DSDL2=ON -DONATIVE=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF ../neo

--- a/neo/cmake-linux-release-nosimd.sh
+++ b/neo/cmake-linux-release-nosimd.sh
@@ -1,5 +1,0 @@
-cd ..
-rm -rf build
-mkdir build
-cd build
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DONATIVE=ON -DSDL2=ON -DUSE_INTRINSICS_SSE=OFF ../neo


### PR DESCRIPTION
- CMakeLists.txt: added use of Intel Intrinsics for e2k (MCST Elbrus 2000) by default
- Updated README.md and RELEASE-NOTES.md
- Removed cmake files with USE_INTRINSICS_SSE=OFF (they are no longer needed)