### PR TITLE
Release mouse when console opened in-game: revert previous change

### DIFF
--- a/neo/framework/common_frame.cpp
+++ b/neo/framework/common_frame.cpp
@@ -564,8 +564,8 @@ void idCommonLocal::Frame()
 			// RB end, DG end
 		{
 			// RB: don't release the mouse when opening a PDA or menu
-			// SRS - don't release when console open in a game (otherwise may be out of frame on return) but always release at main menu
-			if( ( console->Active() && !game ) || !mapSpawned || ImGuiTools::ReleaseMouseForTools() )
+			// SRS - but always release at main menu after exiting game or demo
+			if( console->Active() || !mapSpawned || ImGuiTools::ReleaseMouseForTools() )
 			{
 				Sys_GrabMouseCursor( false );
 			}


### PR DESCRIPTION
Response to issue #584 raised by BielBdeLuna, to better support map development workflows.

Previous change stopped the mouse from being released in-game when console opened.  This was to prevent possible out-of-frame issues with mouse after console was closed on macOS.  This problem may not exist on linux or windows.  Further research needed on this issue for macOS.

This commit reverts the previous change and releases the mouse in-game when console is opened.