### PR TITLE
Fix broken glslang include path in CMakeLists.txt

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -392,7 +392,7 @@ if(USE_VULKAN)
 		set(GLSLANG_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/glslang)
 		add_subdirectory(${GLSLANG_DIR})
 	
-		include_directories(${GLSLANG_DIR}/glslang)
+		include_directories(${GLSLANG_DIR})
 		
 		#link_directories($ENV{VULKAN_SDK}/Lib)
 	endif()


### PR DESCRIPTION
The glslang include path was broken in CMakeLists.txt.  This caused glslang to pick up headers from the VULKAN_SDK versus its own install tree at neo/extern/glslang/...  Depending on the platform and version of VULKAN_SDK installed, this could lead to version mismatches and other issues.

It was also the root cause of glslang build problems on macOS (see issue #590).  This issue is now fixed and the default glslang version referenced by the RBDOOM-3-BFG project works as it should on macOS.

Tested on macOS Big Sur, Linux (Manjaro), and Windows 10.