### PR TITLE
Support FFmpeg / BinkDec optionality for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,8 +502,7 @@ Recommended in this case is `cmake-vs2017-64bit-windows10.bat`
 	
 		> sudo zypper install cmake libSDL2-devel openal-soft-devel
 
-	You don't need FFmpeg to be installed. You can turn it off by adding -DFFMPEG=OFF to the CMake options.
-	It is enabled by default because the bundled libbinkdec is slow during development if compiled for Debug mode.
+	You don't need FFmpeg to be installed. You can turn it off by adding -DFFMPEG=OFF and -DBINKDEC=ON to the CMake options. It is enabled by default because the bundled libbinkdec is slow during development if compiled for Debug mode.
 
 2. Generate the Makefiles using CMake:
 
@@ -523,6 +522,8 @@ Recommended in this case is `cmake-vs2017-64bit-windows10.bat`
 2.	You need the following dependencies in order to compile RBDoom3BFG with all features:
 
 		> brew install cmake sdl2 openal-soft ffmpeg
+		
+	You don't need FFmpeg to be installed. You can turn it off by adding -DFFMPEG=OFF and -DBINKDEC=ON to the CMake options. It is enabled by default because the bundled libbinkdec is slow during development if compiled for Debug mode.
 
 3. Generate the Makefiles using CMake:
 

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ Recommended in this case is `cmake-vs2017-64bit-windows10.bat`
 
 		> brew install cmake sdl2 openal-soft ffmpeg
 		
-	You don't need FFmpeg to be installed. You can turn it off by adding -DFFMPEG=OFF and -DBINKDEC=ON to the CMake options. It is enabled by default because the bundled libbinkdec is slow during development if compiled for Debug mode.
+	You don't need FFmpeg to be installed. You can turn it off by adding -DFFMPEG=OFF and -DBINKDEC=ON to the CMake options. For debug builds FFmpeg is enabled by default because the bundled libbinkdec is slow during development if compiled for Debug mode.  For release and retail builds FFmpeg is disabled and libbinkdec is enabled by default.
 
 3. Generate the Makefiles using CMake:
 

--- a/neo/cmake-macos-opengl-release.sh
+++ b/neo/cmake-macos-opengl-release.sh
@@ -3,4 +3,4 @@ rm -rf build
 mkdir build
 cd build
 # change or remove -DCMAKE_OSX_DEPLOYMENT_TARGET=<version> to match supported runtime targets
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DFFMPEG=OFF -DBINKDEC=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-macos-opengl-retail.sh
+++ b/neo/cmake-macos-opengl-retail.sh
@@ -3,4 +3,4 @@ rm -rf build
 mkdir build
 cd build
 # change or remove -DCMAKE_OSX_DEPLOYMENT_TARGET=<version> to match supported runtime targets
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="-DID_RETAIL" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="-DID_RETAIL" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DFFMPEG=OFF -DBINKDEC=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-macos-vulkan-release.sh
+++ b/neo/cmake-macos-vulkan-release.sh
@@ -1,6 +1,6 @@
 cd ..
-rm -rf build
-mkdir build
-cd build
+rm -rf build-vulkan
+mkdir build-vulkan
+cd build-vulkan
 # change or remove -DCMAKE_OSX_DEPLOYMENT_TARGET=<version> to match supported runtime targets
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DFFMPEG=OFF -DBINKDEC=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-macos-vulkan-retail.sh
+++ b/neo/cmake-macos-vulkan-retail.sh
@@ -1,6 +1,6 @@
 cd ..
-rm -rf build
-mkdir build
-cd build
+rm -rf build-vulkan
+mkdir build-vulkan
+cd build-vulkan
 # change or remove -DCMAKE_OSX_DEPLOYMENT_TARGET=<version> to match supported runtime targets
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="-DID_RETAIL" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="-DID_RETAIL" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DSDL2=ON -DFFMPEG=OFF -DBINKDEC=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-xcode-opengl-release.sh
+++ b/neo/cmake-xcode-opengl-release.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf xcode-opengl-release
 mkdir xcode-opengl-release
 cd xcode-opengl-release
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DSDL2=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DSDL2=ON -DFFMPEG=OFF -DBINKDEC=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/cmake-xcode-vulkan-release.sh
+++ b/neo/cmake-xcode-vulkan-release.sh
@@ -4,4 +4,4 @@ mkdir xcode-vulkan-release
 cd xcode-vulkan-release
 # remove or set -DCMAKE_SUPPRESS_REGENERATION=OFF to reenable ZERO_CHECK target which checks for CMakeLists.txt changes and re-runs CMake before builds
 # however, if ZERO_CHECK is reenabled **must** add VULKAN_SDK location to Xcode Custom Paths (under Prefs/Locations) otherwise build failures may occur
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DSDL2=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DSDL2=ON -DFFMPEG=OFF -DBINKDEC=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -Wno-dev

--- a/neo/libs/libbinkdec/include/FFmpeg_includes.h
+++ b/neo/libs/libbinkdec/include/FFmpeg_includes.h
@@ -56,8 +56,13 @@
 #else // DG: add alternative that should work with at least GCC and clang
 #define DECLARE_ALIGNED(n,t,v)      t __attribute__ ((aligned (n))) v
 #endif
+// SRS - Add guards to prevent override of standard math defines
+#ifndef M_PI
 #define M_PI           3.14159265358979323846  /* pi */
+#endif
+#ifndef M_SQRT1_2
 #define M_SQRT1_2      0.70710678118654752440  /* 1/sqrt(2) */
+#endif
 
 #define HAVE_MMX 0
 #define ARCH_ARM 0

--- a/neo/libs/libbinkdec/src/BinkVideo.cpp
+++ b/neo/libs/libbinkdec/src/BinkVideo.cpp
@@ -452,7 +452,7 @@ int BinkDecoder::ReadDCs(BinkCommon::BitReader &bits, Bundle *b, int start_bits,
                 v += v2;
                 *dst++ = v;
                 if (v < -32768 || v > 32767) {
-					BinkCommon::LogError("DC value went out of bounds" + v);
+					BinkCommon::LogError("DC value went out of bounds: " + std::to_string(v));
                     return -1;
                 }
             }

--- a/neo/sys/posix/platform_osx.cpp
+++ b/neo/sys/posix/platform_osx.cpp
@@ -26,7 +26,7 @@ If you have questions concerning this license or the applicable additional terms
 
 ===========================================================================
 */
-//#include "../../idlib/precompiled.h"
+#include "../../idlib/precompiled.h"
 #include "../posix/posix_public.h"
 //#include "../sys_local.h"
 

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -50,7 +50,7 @@ If you have questions concerning this license or the applicable additional terms
 #endif
 
 #if defined(__APPLE__)
-	#include <SDL2/SDL.h>
+	#include <SDL.h>
 #endif
 
 #include <sys/statvfs.h>


### PR DESCRIPTION
Added support for disabling FFmpeg and enabling libbinkdec on macOS.  Fixed a few errors and warnings, as well as added information to the README.

Also fixed ability to turn off PCH on macOS builds (not really required, but there for flexibility - solves issue #597).

Disabled FFmpeg and enabled libbinkdec in release and retail build shell scripts for macOS (cmd line and Xcode).