### PR TITLE
Support for macOS Universal Binary builds and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,27 +619,24 @@ Anyway:
 	/your/path/to/Steam/steamapps/common/DOOM 3 BFG Edition/base/
 	or, if you used SteamCMD or GOG installer with Wine, in the path you used above.
 
-4. Copy your RBDoom3BFG executable and the FFmpeg DLLs (Windows only) to your own 
+4. Copy your RBDoom3BFG executable and the optional FFmpeg DLLs (if Windows FFmpeg enabled) to your own 
    Doom 3 BFG directory (/path/to/Doom3BFG). Your Doom 3 BFG directory now should look like:  
    
 	/path/to/Doom3BFG/
 	* RBDoom3BFG (or RBDoom3BFG.exe on Windows)
-	* avcodec-58.dll (Windows only)
-	* avdevice-58.dll (Windows only)
-	* avfilter-7.dll (Windows only)
-	* avformat-58.dll (Windows only)
-	* avutil-56.dll (Windows only)
-	* postproc-55.dll (Windows only)
-	* swresample-3.dll (Windows only)
-	* swscale-5.dll (Windows only)
+	* avcodec-58.dll (Windows FFmpeg only)
+	* avformat-58.dll (Windows FFmpeg only)
+	* avutil-56.dll (Windows FFmpeg only)
+	* swresample-3.dll (Windows FFmpeg only)
+	* swscale-5.dll (Windows FFmpeg only)
 	* base/
 		* classicmusic/
 		* _common.crc
 		* (etc)
 		 
-5. On macOS the RBDoom3BFG executable will also search for game data within the Contents/Resources/base directory as part of a macOS app bundle.  In addition, if you want the game to be standalone without dependencies on pre-installed dynamic libs, you can use macdylibbundler to bundle all external lib dependencies into the app bundle (see https://github.com/auriamg/macdylibbundler or simply install via "brew install dylibbundler").  For example, the following command will copy all external dynamic lib dependencies to the Contents/libs directory of the app bundle and adjust the rpaths within the RBDoom3BFG executable and copied libs.
+5. On macOS the RBDoom3BFG executable will also search for game data within an app bundle's relative path ../Resources/base and, as a last resort, within the absolute path /Applications/RBDoom-3-BFG.app/Contents/Resources/base.  In addition, if you want the game to be standalone without dependencies on pre-installed dynamic libs, you can use macdylibbundler to bundle all external dylib dependencies into the app bundle (see https://github.com/auriamg/macdylibbundler or simply install via "brew install dylibbundler").  For example, the following command will copy all external dynamic lib dependencies to the Contents/libs directory of the game's app bundle and adjust the rpaths within the RBDoom3BFG executable and copied dylibs.
 
-		> dylibbundler -od -b -x ./Doom3BFG.app/Contents/MacOS/RBDoom3BFG -d ./Doom3BFG.app/Contents/libs/
+		> dylibbundler -od -b -x ./RBDoom-3-BFG.app/Contents/MacOS/RBDoom3BFG -d ./RBDoom-3-BFG.app/Contents/libs/
 
 6. Run the game by executing the RBDoom3BFG executable.
 

--- a/README.md
+++ b/README.md
@@ -517,13 +517,15 @@ Recommended in this case is `cmake-vs2017-64bit-windows10.bat`
 ---
 # Compiling on macOS <a name="compile_macos"></a>
 
-1.	Download and install Homebrew (https://brew.sh)
+1.	Download and install Homebrew (https://brew.sh) for single architecture builds or MacPorts (https://www.macports.org/install.php) for universal architecture builds on macOS Big Sur or later.
 
 2.	You need the following dependencies in order to compile RBDoom3BFG with all features:
 
-		> brew install cmake sdl2 openal-soft ffmpeg
+		> brew install cmake sdl2 openal-soft ffmpeg (for single arch libraries only)
+		or
+		> sudo port install cmake libsdl2 +universal openal-soft +universal (for universal arch libraries)
 		
-	You don't need FFmpeg to be installed. You can turn it off by adding -DFFMPEG=OFF and -DBINKDEC=ON to the CMake options. For debug builds FFmpeg is enabled by default because the bundled libbinkdec is slow during development if compiled for Debug mode.  For release and retail builds FFmpeg is disabled and libbinkdec is enabled by default.
+	You don't need FFmpeg to be installed. You can turn it off by adding -DFFMPEG=OFF and -DBINKDEC=ON to the CMake options. For debug builds FFmpeg is enabled by default because the bundled libbinkdec is slow during development if compiled for Debug mode.  For release, retail and universal builds FFmpeg is disabled and libbinkdec is enabled by default.
 
 3. Generate the Makefiles using CMake:
 
@@ -536,6 +538,10 @@ Recommended in this case is `cmake-vs2017-64bit-windows10.bat`
 	
 		> cd neo/
 		> ./cmake-xcode-opengl-release.sh	
+		or
+		> ./cmake-xcode-opengl-universal.sh (universal build on macOS Big Sur / Xcode 12.2 or later)
+	
+	Depending on which package manager you install (Homebrew or MacPorts) you may need to change the openal-soft library and include paths specified in the cmake shell scripts.  For single architecture builds (debug, release, retail) the default openal-soft paths are set for Homebrew on x86, while for universal builds the default paths are set for MacPorts on x86 or Apple Silicon.  If you want to build using the single architecture shell scripts (debug, release, retail) on Apple Silicon, you will need to change the openal-soft paths from `/usr/local/...` to either `/opt/homebrew/...` (Homebrew) or `/opt/local/...` (MacPorts).
 	
 4. Compile RBDOOM-3-BFG targets:
 
@@ -544,7 +550,7 @@ Recommended in this case is `cmake-vs2017-64bit-windows10.bat`
 		> cd ../build
 		> make
 	
-	For Xcode builds double click on RBDOOM-3-BFG/xcode-opengl-release/RBDoom3BFG.xcodeproj and start the build. The generated Xcode project file is pre-configured with the correct targets and build settings.
+	For Xcode builds double click on RBDOOM-3-BFG/xcode-opengl-\<buildtype\>/RBDoom3BFG.xcodeproj and start the build. The generated Xcode project file is pre-configured with the correct targets and build settings.
 
 ---
 # Installation, Getting the Game Data, Running the Game <a name="installation"></a>
@@ -634,9 +640,15 @@ Anyway:
 		* _common.crc
 		* (etc)
 		 
-5. On macOS the RBDoom3BFG executable will also search for game data within an app bundle's relative path ../Resources/base and, as a last resort, within the absolute path /Applications/RBDoom-3-BFG.app/Contents/Resources/base.  In addition, if you want the game to be standalone without dependencies on pre-installed dynamic libs, you can use macdylibbundler to bundle all external dylib dependencies into the app bundle (see https://github.com/auriamg/macdylibbundler or simply install via "brew install dylibbundler").  For example, the following command will copy all external dynamic lib dependencies to the Contents/libs directory of the game's app bundle and adjust the rpaths within the RBDoom3BFG executable and copied dylibs.
+5. On macOS the RBDoom3BFG executable will also search for game data within an app bundle's relative path ../Resources/base and, as a last resort, within the absolute path /Applications/RBDoom-3-BFG.app/Contents/Resources/base.  In addition, if you want the game to be standalone without dependencies on pre-installed dynamic libs, you can use macdylibbundler to bundle all external dylib dependencies into the app bundle (see https://github.com/auriamg/macdylibbundler or simply install via "brew install dylibbundler" or "sudo port install dylibbundler").  For example, the following command will copy all external dynamic library dependencies to the Contents/libs directory of the game's app bundle and adjust the rpaths within the RBDoom3BFG executable and copied dylibs.
 
-		> dylibbundler -od -b -x ./RBDoom-3-BFG.app/Contents/MacOS/RBDoom3BFG -d ./RBDoom-3-BFG.app/Contents/libs/
+		> dylibbundler -od -b -x RBDoom-3-BFG.app/Contents/MacOS/RBDoom3BFG -d RBDoom-3-BFG.app/Contents/libs/
+
+	After running dylibbundler you must re-sign the modified executable and dylibs if planning to run on **Apple Silicon** machines.  The output of dylibbundler will indicate which dylibs (if any) require re-signing.  This code signing step is not needed for x86-based Macs.
+
+		> codesign -s - --force RBDoom-3-BFG.app/Contents/libs/lib<modified-by-dylibbundler>.dylib
+		...
+		> codesign -s - --force RBDoom-3-BFG.app/Contents/MacOS/RBDoom3BFG
 
 6. Run the game by executing the RBDoom3BFG executable.
 

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -68,11 +68,13 @@ option(USE_SYSTEM_RAPIDJSON
 
 set(CPU_TYPE "" CACHE STRING "When set, passes this string as CPU-ID which will be embedded into the binary.")
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+# SRS - Turn on optimization when cross-compiling from Apple arm64 to x86_64
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)" OR CMAKE_OSX_ARCHITECTURES MATCHES "x86_64")
 	set(CPU_OPTIMIZATION "-mmmx -msse -msse2" CACHE STRING "Which CPU specific optimitations should be used beside the compiler's default?")
 endif()
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)|(e2k)|(E2K)")
+# SRS - Turn off MMX/SSE intrinsics when cross-compiling from Apple x86_64 to arm64
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)|(e2k)|(E2K)" AND NOT CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
 	option(USE_INTRINSICS_SSE "Compile using SSE intrinsics (e.g mmx, sse, msse2)" ON)
 else()
 	option(USE_INTRINSICS_SSE "Compile using SSE intrinsics (e.g mmx, sse, msse2)" OFF)
@@ -85,6 +87,12 @@ endif()
 if(UNIX)
 	set(OPENAL ON)
 	
+    # SRS - Disable precompiled headers when cross-compiling on OSX, e.g. when creating universal binaries
+    if((CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64" AND CMAKE_OSX_ARCHITECTURES MATCHES "arm64" ) OR
+       (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64"  AND CMAKE_OSX_ARCHITECTURES MATCHES "x86_64"))
+        set(USE_PRECOMPILED_HEADERS OFF)
+    endif()
+
 	if(USE_VULKAN)
 		SET(SDL2 ON)
 		
@@ -182,8 +190,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 
 	# SRS - Make sure OSX can find system headers and add support for minimum OSX runtime version
 	if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-		# SRS - Also add -fasm-blocks otherwise Xcode complains
-		add_definitions(-fasm-blocks)
+		# SRS - Also add -fasm-blocks otherwise Xcode complains and -Qunused-arguments to silence MMX/SSE unused arg warnings when compiling for Apple arm64
+		add_definitions(-fasm-blocks -Qunused-arguments)
         if(CMAKE_OSX_SYSROOT)
             add_definitions(-isysroot "${CMAKE_OSX_SYSROOT}")
             message(STATUS "Using macOS sysroot: " ${CMAKE_OSX_SYSROOT})
@@ -1706,7 +1714,7 @@ else()
 			add_definitions(-DUSE_OPENAL)
    
             # SRS - Added support for OpenAL Soft headers on OSX (vs default macOS SDK headers)
-            if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND OPENAL_INCLUDE_DIR MATCHES "openal-soft")
+            if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT OPENAL_INCLUDE_DIR MATCHES "SDKs/MacOSX.*\.sdk")
                 include_directories(${OPENAL_INCLUDE_DIR})
                 add_definitions(-DUSE_OPENAL_SOFT_INCLUDES)
             endif()

--- a/neo/cmake-xcode-opengl-universal.sh
+++ b/neo/cmake-xcode-opengl-universal.sh
@@ -1,0 +1,6 @@
+cd ..
+rm -rf xcode-opengl-universal
+mkdir xcode-opengl-universal
+cd xcode-opengl-universal
+# note: universal openal-soft library and include paths assume MacPorts install locations
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DSDL2=ON -DFFMPEG=OFF -DBINKDEC=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DOPENAL_LIBRARY=/opt/local/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/opt/local/include ../neo -Wno-dev

--- a/neo/cmake-xcode-vulkan-universal.sh
+++ b/neo/cmake-xcode-vulkan-universal.sh
@@ -1,0 +1,8 @@
+cd ..
+rm -rf xcode-vulkan-universal
+mkdir xcode-vulkan-universal
+cd xcode-vulkan-universal
+# remove or set -DCMAKE_SUPPRESS_REGENERATION=OFF to reenable ZERO_CHECK target which checks for CMakeLists.txt changes and re-runs CMake before builds
+# however, if ZERO_CHECK is reenabled **must** add VULKAN_SDK location to Xcode Custom Paths (under Prefs/Locations) otherwise build failures may occur
+# note: universal openal-soft library and include paths assume MacPorts install locations
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DSDL2=ON -DFFMPEG=OFF -DBINKDEC=ON -DUSE_VULKAN=ON -DSPIRV_SHADERC=OFF -DUSE_MoltenVK=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=/opt/local/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/opt/local/include ../neo -Wno-dev


### PR DESCRIPTION
Updated README:

1. Be more clear about Windows FFmpeg DLL optionality in the README's detailed installation section.  Also pruned FFmpeg DLL list to minimum required set.
2. Better describe macOS app bundle relative and absolute search paths for game data.  Also aligned dylibbundler example with default app name within the `DEFAULT_BASEPATH` for macOS.
3. Provided instructions on universal binary libraries (MacPorts) and building an RBDoom3BFG macOS universal binary.
4. Provided instructions on how to code sign a self-contained RBDoom3BFG app bundle for execution on Apple Silicon.

Updated CMakeLists:

1. Disabled SSE intrinsics when cross-compiling on x86_64 for Apple arm64
2. Disabled pre-compiled headers when cross-compiling and building a macOS universal binary
3. Suppressed warnings from unused MMX/SSE optimization args when compiling for Apple arm64
4. Fixed test for openal-soft headers vs. Mac SDK openal headers so it also works with MacPorts (not just Homebrew)

Added two additional cmake shell scripts: cmake-xcode-opengl-universal.sh & cmake-xcode-vulkan-universal.sh

Tested on macOS Mojave, Big Sur (x86 and Apple Silicon machines), Windows 10, Linux Manjaro.
