### PR TITLE
Properly delete renderWorld, soundWorld, and menuSoundWorld on shutdown

### DIFF
--- a/neo/framework/Common.cpp
+++ b/neo/framework/Common.cpp
@@ -1540,15 +1540,18 @@ void idCommonLocal::Shutdown()
 	ImGuiHook::Destroy();
 
 	printf( "delete renderWorld;\n" );
-	delete renderWorld;
+    // SRS - Call FreeRenderWorld() vs. delete, otherwise worlds list not updated on shutdown
+    renderSystem->FreeRenderWorld( renderWorld );
 	renderWorld = NULL;
 
 	printf( "delete soundWorld;\n" );
-	delete soundWorld;
+    // SRS - Call FreeSoundWorld() vs. delete, otherwise soundWorlds list not updated and can segfault in soundSystem->Shutdown()
+    soundSystem->FreeSoundWorld( soundWorld );
 	soundWorld = NULL;
 
 	printf( "delete menuSoundWorld;\n" );
-	delete menuSoundWorld;
+    // SRS - Call FreeSoundWorld() vs. delete, otherwise soundWorlds list not updated and can segfault in soundSystem->Shutdown()
+    soundSystem->FreeSoundWorld( menuSoundWorld );
 	menuSoundWorld = NULL;
 
 	// shut down the session


### PR DESCRIPTION
This pull request solves a segfault in `soundSystem->Shutdown()` when exiting the game - see issue #603 

`soundWorld` and `menuSoundWorld` are now deleted properly using `soundSystem->FreeSoundWorld()` instead of direct deletion.  This change ensures the `soundWorlds` list is up to date and can be referenced in follow-on shutdown code.

When making this change, I noticed that `renderWorld` is also deleted incorrectly using `delete`.  It should be deleted using `renderSystem->FreeRenderWorld( renderWorld )` for the same reason as above, so the `worlds` list is up to date on shutdown.  Although I have not seen any segfaults or issues around this latter case, I decided to fix it properly as well.

Tested on Win10, linux (Manjaro + gcc 11.1), and macOS Mojave & Big Sur.