### PR TITLE
Update gameReturn_t() to explicitly initialize sessionCommand

### DIFF
--- a/neo/d3xp/Game.h
+++ b/neo/d3xp/Game.h
@@ -48,6 +48,7 @@ struct gameReturn_t
 {
 
 	gameReturn_t() :
+        sessionCommand( "" ),       // SRS - Explicitly init sessionCommand otherwise can be optimized out and skipped with gcc or Apple clang
 		syncNextGameFrame( false ),
 		vibrationLow( 0 ),
 		vibrationHigh( 0 )


### PR DESCRIPTION
This one-line pull request solves issue #605 by clearing out stale gameReturn data (i.e. `sessionCommand == "died"`) when idling at the session menu screen after player death.

By explicitly initializing the `sessionCommand` member within the `gameReturn_t()` struct initializer function, we avoid compiler-specific and optimization-specific behaviour (e.g. differences between gcc and Apple Clang vs. MSVC).

The following code snippet within `idGameThread::Run()` then works as intended, clearing all `ret` struct members including the `sessionCommand` member:

```
	if( numGameFrames == 0 )
	{
		// Ensure there's no stale gameReturn data from a paused game
		ret = gameReturn_t();
	}
```
Tested on linux (Manjaro + gcc 11.1), macOS Big Sur, and Windows 10.