### PR TITLE
Revert commit using getters for gameThread times - wrong type size

### DIFF
--- a/neo/framework/Console.cpp
+++ b/neo/framework/Console.cpp
@@ -270,13 +270,14 @@ float idConsoleLocal::DrawFPS( float y )
 	}
 	// DG end
 
-	const uint64 gameThreadTotalTime = commonLocal.GetGameThreadTotalTime();
-	const uint64 gameThreadGameTime = commonLocal.GetGameThreadGameTime();
-	const uint64 gameThreadRenderTime = commonLocal.GetGameThreadRenderTime();
+	// SRS - Shouldn't use these getters since they access and return int-sized variables measured in milliseconds
+    //const uint64 gameThreadTotalTime = commonLocal.GetGameThreadTotalTime();
+	//const uint64 gameThreadGameTime = commonLocal.GetGameThreadGameTime();
+	//const uint64 gameThreadRenderTime = commonLocal.GetGameThreadRenderTime();
 
-	//const uint64 gameThreadTotalTime	= commonLocal.mainFrameTiming.finishDrawTime - commonLocal.mainFrameTiming.startGameTime;
-	//const uint64 gameThreadGameTime		= commonLocal.mainFrameTiming.finishGameTime - commonLocal.mainFrameTiming.startGameTime;
-	//const uint64 gameThreadRenderTime	= commonLocal.mainFrameTiming.finishDrawTime - commonLocal.mainFrameTiming.finishGameTime;
+	const uint64 gameThreadTotalTime	= commonLocal.mainFrameTiming.finishDrawTime - commonLocal.mainFrameTiming.startGameTime;
+	const uint64 gameThreadGameTime		= commonLocal.mainFrameTiming.finishGameTime - commonLocal.mainFrameTiming.startGameTime;
+	const uint64 gameThreadRenderTime	= commonLocal.mainFrameTiming.finishDrawTime - commonLocal.mainFrameTiming.finishGameTime;
 
 	const uint64 rendererBackEndTime = commonLocal.GetRendererBackEndMicroseconds();
 	const uint64 rendererShadowsTime = commonLocal.GetRendererShadowsMicroseconds();

--- a/neo/framework/common_frame.cpp
+++ b/neo/framework/common_frame.cpp
@@ -155,7 +155,7 @@ int idGameThread::Run()
 
 	commonLocal.frameTiming.finishGameTime = Sys_Microseconds();
 
-	SetThreadGameTime( commonLocal.frameTiming.finishGameTime - commonLocal.frameTiming.startGameTime );
+	SetThreadGameTime( ( commonLocal.frameTiming.finishGameTime - commonLocal.frameTiming.startGameTime ) / 1000 );
 
 	// build render commands and geometry
 	{
@@ -165,9 +165,9 @@ int idGameThread::Run()
 
 	commonLocal.frameTiming.finishDrawTime = Sys_Microseconds();
 
-	SetThreadRenderTime( commonLocal.frameTiming.finishDrawTime - commonLocal.frameTiming.finishGameTime );
+	SetThreadRenderTime( ( commonLocal.frameTiming.finishDrawTime - commonLocal.frameTiming.finishGameTime ) / 1000 );
 
-	SetThreadTotalTime( commonLocal.frameTiming.finishDrawTime - commonLocal.frameTiming.startGameTime );
+	SetThreadTotalTime( ( commonLocal.frameTiming.finishDrawTime - commonLocal.frameTiming.startGameTime ) / 1000 );
 
 	return 0;
 }


### PR DESCRIPTION
commonLocal.GetGameThread<...>Time() getters access and return int-sized variables designed for millisecond timing measurements vs. uint64 variables that are used for microsecond timing measurements.  Revert previous change and restore direct calculation of gameThreadTotalTime, gameThreadGameTime, and gameThreadRenderTime using uint64 variables.

The perf counter information and display should be identical, just with safer types.