### PR TITLE
Cinematic Video and Audio memory management fixes

### DIFF
--- a/neo/framework/Common.cpp
+++ b/neo/framework/Common.cpp
@@ -1571,10 +1571,6 @@ void idCommonLocal::Shutdown()
 	printf( "uiManager->Shutdown();\n" );
 	uiManager->Shutdown();
 
-	// shut down the sound system
-	printf( "soundSystem->Shutdown();\n" );
-	soundSystem->Shutdown();
-
 	// shut down the user command input code
 	printf( "usercmdGen->Shutdown();\n" );
 	usercmdGen->Shutdown();
@@ -1584,8 +1580,15 @@ void idCommonLocal::Shutdown()
 	eventLoop->Shutdown();
 
 	// shutdown the decl manager
+	// SRS - Note this also shuts down all cinematic resources, including cinematic audio voices
 	printf( "declManager->Shutdown();\n" );
 	declManager->Shutdown();
+
+	// shut down the sound system
+	// SRS - Shut down sound system after decl manager so cinematic audio voices are destroyed first
+	// Important for XAudio2 where the mastering voice cannot be destroyed if any other voices exist
+	printf( "soundSystem->Shutdown();\n" );
+	soundSystem->Shutdown();
 
 	// shut down the renderSystem
 	printf( "renderSystem->Shutdown();\n" );

--- a/neo/framework/common_frame.cpp
+++ b/neo/framework/common_frame.cpp
@@ -862,7 +862,7 @@ void idCommonLocal::Frame()
 		// RB begin
 #if defined(USE_DOOMCLASSIC)
 		// If we're in Doom or Doom 2, run tics and upload the new texture.
-		// SRS - Add check for com_pause cvar to make sure window is in focus - if not classic game should be paused (FIXME: but classic music still plays in background)
+		// SRS - Add check for com_pause cvar to make sure window is in focus - if not classic game should be paused
 		if( ( GetCurrentGame() == DOOM_CLASSIC || GetCurrentGame() == DOOM2_CLASSIC ) && !( Dialog().IsDialogPausing() || session->IsSystemUIShowing() || com_pause.GetInteger() ) )
 		{
 			RunDoomClassicFrame();
@@ -922,16 +922,18 @@ void idCommonLocal::Frame()
 		{
 			soundWorld->Pause();
 			soundSystem->SetPlayingSoundWorld( menuSoundWorld );
+			soundSystem->SetMute( false );
 		}
 		else
 		{
 			soundWorld->UnPause();
 			soundSystem->SetPlayingSoundWorld( soundWorld );
+			soundSystem->SetMute( false );
 		}
-		// SRS - Play silence when dialog waiting or window not in focus
+		// SRS - Mute all sound output when dialog waiting or window not in focus (mutes Doom3, Classic, Cinematic Audio)
 		if( Dialog().IsDialogPausing() || session->IsSystemUIShowing() || com_pause.GetInteger() )
 		{
-			soundSystem->SetPlayingSoundWorld( NULL );
+			soundSystem->SetMute( true );
 		}
 
 		soundSystem->Render();

--- a/neo/renderer/Cinematic.cpp
+++ b/neo/renderer/Cinematic.cpp
@@ -1017,6 +1017,7 @@ bool idCinematicLocal::InitFromFile( const char* qpath, bool amilooping )
 	}
 	// Carl: The rest of this function is for original Doom 3 RoQ files:
 	isRoQ = true;
+	fileName = temp;
 	ROQSize = iFile->Length();
 
 	looping = amilooping;
@@ -1042,7 +1043,7 @@ bool idCinematicLocal::InitFromFile( const char* qpath, bool amilooping )
 		RoQ_init();
 		status = FMV_PLAY;
 		ImageForTime( 0 );
-		common->Printf( "Loaded RoQ file: '%s', looping=%d, %dx%d, %3.2f FPS\n", qpath, looping, CIN_WIDTH, CIN_HEIGHT, frameRate );
+		common->Printf( "Loaded RoQ file: '%s', looping=%d, %dx%d, %3.2f FPS\n", fileName.c_str(), looping, CIN_WIDTH, CIN_HEIGHT, frameRate );
 		status = ( looping ) ? FMV_PLAY : FMV_IDLE;
 		return true;
 	}

--- a/neo/renderer/Cinematic.cpp
+++ b/neo/renderer/Cinematic.cpp
@@ -655,8 +655,20 @@ bool idCinematicLocal::InitFromFFMPEGFile( const char* qpath, bool amilooping )
 
 	if( ( ret = avformat_open_input( &fmt_ctx, fullpath, NULL, NULL ) ) < 0 )
 	{
-		common->Warning( "idCinematic: Cannot open FFMPEG video file: '%s', %d\n", qpath, looping );
-		return false;
+		// SRS - another case sensitivity hack for Linux, this time for ffmpeg and RoQ files
+		idStr ext;
+		fullpath.ExtractFileExtension( ext );
+		if( idStr::Cmp( ext.c_str(), "roq" ) == 0 )
+		{
+			// SRS - If ffmpeg can't open .roq file, then try again with .RoQ extension instead
+			fullpath.Replace( ".roq", ".RoQ" );
+			ret = avformat_open_input( &fmt_ctx, fullpath, NULL, NULL );
+		}
+		if( ret < 0 )
+		{
+			common->Warning( "idCinematic: Cannot open FFMPEG video file: '%s', %d\n", qpath, looping );
+			return false;
+		}
 	}
 	if( ( ret = avformat_find_stream_info( fmt_ctx, NULL ) ) < 0 )
 	{

--- a/neo/renderer/Cinematic.cpp
+++ b/neo/renderer/Cinematic.cpp
@@ -910,7 +910,7 @@ bool idCinematicLocal::InitFromBinkDecFile( const char* qpath, bool amilooping )
 	{
 		trackIndex = 0;														// SRS - Use the first audio track - is this reasonable?
 		binkInfo = Bink_GetAudioTrackDetails( binkHandle, trackIndex );
-		common->Printf( "Cinematic audio stream found: Sample Rate=%d Hz, Channels=%d\n", binkInfo.sampleRate, binkInfo.nChannels );
+		common->Printf( "Cinematic audio stream found: Sample Rate=%d Hz, Channels=%d, Format=16-bit\n", binkInfo.sampleRate, binkInfo.nChannels );
 		cinematicAudio->InitAudio( &binkInfo );
 	}
 

--- a/neo/renderer/OpenGL/RenderDebug_GL.cpp
+++ b/neo/renderer/OpenGL/RenderDebug_GL.cpp
@@ -3263,6 +3263,11 @@ void idRenderBackend::DBG_TestImage()
 			imageCr = cin.imageCr;
 			imageCb = cin.imageCb;
 		}
+		// SRS - Also handle ffmpeg and original RoQ decoders for test videos (using cin.image)
+		else if( cin.image != NULL )
+		{
+			image = cin.image;
+		}
 		else
 		{
 			tr.testImage = NULL;
@@ -3302,9 +3307,9 @@ void idRenderBackend::DBG_TestImage()
 
 	float scale[16] = { 0 };
 	scale[0] = w; // scale
-	scale[5] = -h; // scale
+	scale[5] = h; // scale			(SRS - changed h from -ve to +ve so video plays right side up)
 	scale[12] = halfScreenWidth - ( halfScreenWidth * w ); // translate
-	scale[13] = halfScreenHeight - ( halfScreenHeight * h ); // translate
+	scale[13] = halfScreenHeight - ( halfScreenHeight * h ) - h; // translate (SRS - moved up by h)
 	scale[10] = 1.0f;
 	scale[15] = 1.0f;
 

--- a/neo/renderer/OpenGL/RenderDebug_GL.cpp
+++ b/neo/renderer/OpenGL/RenderDebug_GL.cpp
@@ -3256,7 +3256,9 @@ void idRenderBackend::DBG_TestImage()
 	{
 		cinData_t	cin;
 
-		cin = tr.testVideo->ImageForTime( viewDef->renderView.time[1] - tr.testVideoStartTime );
+		// SRS - Don't need calibrated time for testing cinematics, so just call ImageForTime( 0 ) for current system time
+		// This simplification allows cinematic test playback to work over both 2D and 3D background scenes
+		cin = tr.testVideo->ImageForTime( 0 /*viewDef->renderView.time[1] - tr.testVideoStartTime*/ );
 		if( cin.imageY != NULL )
 		{
 			image = cin.imageY;
@@ -3345,7 +3347,9 @@ void idRenderBackend::DBG_TestImage()
 		imageCr->Bind();
 		GL_SelectTexture( 2 );
 		imageCb->Bind();
-		renderProgManager.BindShader_Bink();
+		// SRS - Use Bink shader without sRGB to linear conversion, otherwise cinematic colours may be wrong
+		// BindShader_BinkGUI() does not seem to work here - perhaps due to vertex shader input dependencies?
+		renderProgManager.BindShader_Bink_sRGB();
 	}
 	else
 	{

--- a/neo/renderer/RenderBackend.cpp
+++ b/neo/renderer/RenderBackend.cpp
@@ -602,8 +602,8 @@ void idRenderBackend::BindVariableStageImage( const textureStage_t* texture, con
 			GL_SelectTexture( 0 );
 			cin.image->Bind();
 
-			/*
-			if( backEnd.viewDef->is2Dgui )
+			// SRS - Reenable shaders so ffmpeg and RoQ decoder cinematics are rendered with correct colour
+			if( viewDef->is2Dgui )
 			{
 				renderProgManager.BindShader_TextureVertexColor_sRGB();
 			}
@@ -611,7 +611,6 @@ void idRenderBackend::BindVariableStageImage( const textureStage_t* texture, con
 			{
 				renderProgManager.BindShader_TextureVertexColor();
 			}
-			*/
 		}
 		else
 		{

--- a/neo/renderer/RenderProgs.cpp
+++ b/neo/renderer/RenderProgs.cpp
@@ -213,6 +213,9 @@ void idRenderProgManager::Init()
 		{ BUILTIN_STEREO_DEGHOST, "builtin/VR/stereoDeGhost", "", 0, false, SHADER_STAGE_DEFAULT, LAYOUT_DRAW_VERT },
 		{ BUILTIN_STEREO_WARP, "builtin/VR/stereoWarp", "", 0, false, SHADER_STAGE_DEFAULT, LAYOUT_DRAW_VERT },
 		{ BUILTIN_BINK, "builtin/video/bink", "",  0, false, SHADER_STAGE_DEFAULT, LAYOUT_DRAW_VERT },
+		// SRS - Added Bink shader without sRGB to linear conversion for testVideo cmd
+		{ BUILTIN_BINK_SRGB, "builtin/video/bink", "_sRGB", BIT( USE_SRGB ), false, SHADER_STAGE_DEFAULT, LAYOUT_DRAW_VERT },
+		// SRS end
 		{ BUILTIN_BINK_GUI, "builtin/video/bink_gui", "", 0, false, SHADER_STAGE_DEFAULT, LAYOUT_DRAW_VERT },
 		{ BUILTIN_STEREO_INTERLACE, "builtin/VR/stereoInterlace", "", 0, false, SHADER_STAGE_DEFAULT, LAYOUT_DRAW_VERT },
 		{ BUILTIN_MOTION_BLUR, "builtin/post/motionBlur", "", 0, false, SHADER_STAGE_DEFAULT, LAYOUT_DRAW_VERT },

--- a/neo/renderer/RenderProgs.h
+++ b/neo/renderer/RenderProgs.h
@@ -693,6 +693,12 @@ public:
 		BindShader_Builtin( BUILTIN_BINK );
 	}
 
+	// SRS - Added Bink shader without sRGB to linear conversion for testVideo cmd
+	void	BindShader_Bink_sRGB()
+	{
+		BindShader_Builtin( BUILTIN_BINK_SRGB );
+	}
+
 	void	BindShader_BinkGUI()
 	{
 		BindShader_Builtin( BUILTIN_BINK_GUI );
@@ -854,6 +860,7 @@ private:
 		BUILTIN_STEREO_DEGHOST,
 		BUILTIN_STEREO_WARP,
 		BUILTIN_BINK,
+		BUILTIN_BINK_SRGB,	// SRS - Added Bink shader without sRGB to linear conversion for testVideo cmd
 		BUILTIN_BINK_GUI,
 		BUILTIN_STEREO_INTERLACE,
 		BUILTIN_MOTION_BLUR,

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -617,7 +617,8 @@ void R_TestVideo_f( const idCmdArgs& args )
 
 	cinData_t	cin;
 	cin = tr.testVideo->ImageForTime( 0 );
-	if( cin.imageY == NULL )
+	// SRS - Also handle ffmpeg and original RoQ decoders for test videos (using cin.image)
+	if( cin.imageY == NULL && cin.image == NULL )
 	{
 		delete tr.testVideo;
 		tr.testVideo = NULL;

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -631,7 +631,8 @@ void R_TestVideo_f( const idCmdArgs& args )
 	int	len = tr.testVideo->AnimationLength();
 	common->Printf( "%5.1f seconds of video\n", len * 0.001 );
 
-	tr.testVideoStartTime = tr.primaryRenderView.time[1];
+	// SRS - Not needed or used since InitFromFile() sets the correct start time automatically
+	//tr.testVideoStartTime = tr.primaryRenderView.time[1];
 
 	// try to play the matching wav file
 	idStr	wavString = args.Argv( ( args.Argc() == 2 ) ? 1 : 2 );

--- a/neo/renderer/Vulkan/RenderDebug_VK.cpp
+++ b/neo/renderer/Vulkan/RenderDebug_VK.cpp
@@ -570,6 +570,11 @@ void idRenderBackend::DBG_TestImage()
 			imageCr = cin.imageCr;
 			imageCb = cin.imageCb;
 		}
+		// SRS - Also handle ffmpeg and original RoQ decoders for test videos (using cin.image)
+		else if( cin.image != NULL )
+		{
+			image = cin.image;
+		}
 		else
 		{
 			tr.testImage = NULL;
@@ -610,7 +615,7 @@ void idRenderBackend::DBG_TestImage()
 	scale[0] = w; // scale
 	scale[5] = h; // scale
 	scale[12] = halfScreenWidth - ( halfScreenWidth * w ); // translate
-	scale[13] = halfScreenHeight - ( halfScreenHeight * h ); // translate
+	scale[13] = halfScreenHeight - ( halfScreenHeight * h ) - h; // translate (SRS - moved up by h)
 	scale[10] = 1.0f;
 	scale[15] = 1.0f;
 

--- a/neo/renderer/Vulkan/RenderDebug_VK.cpp
+++ b/neo/renderer/Vulkan/RenderDebug_VK.cpp
@@ -563,7 +563,9 @@ void idRenderBackend::DBG_TestImage()
 	{
 		cinData_t	cin;
 
-		cin = tr.testVideo->ImageForTime( viewDef->renderView.time[1] - tr.testVideoStartTime );
+		// SRS - Don't need calibrated time for testing cinematics, so just call ImageForTime( 0 ) for current system time
+		// This simplification allows cinematic test playback to work over both 2D and 3D background scenes
+		cin = tr.testVideo->ImageForTime( 0 /*viewDef->renderView.time[1] - tr.testVideoStartTime*/ );
 		if( cin.imageY != NULL )
 		{
 			image = cin.imageY;
@@ -651,7 +653,9 @@ void idRenderBackend::DBG_TestImage()
 		GL_SelectTexture( 2 );
 		imageCb->Bind();
 
-		renderProgManager.BindShader_Bink();
+		// SRS - Use Bink shader with no sRGB to linear conversion, otherwise cinematic colours may be wrong
+		// BindShader_BinkGUI() does not seem to work here - perhaps due to vertex shader input dependencies?
+		renderProgManager.BindShader_Bink_sRGB();
 	}
 	else
 	{

--- a/neo/sound/CinematicAudio.h
+++ b/neo/sound/CinematicAudio.h
@@ -30,6 +30,7 @@ class CinematicAudio
 public:
 	virtual void InitAudio( void* audioContext ) = 0;
 	virtual void PlayAudio( uint8_t* data, int size ) = 0;
+	virtual void ResetAudio() = 0;
 	virtual void ShutdownAudio() = 0;
 };
 

--- a/neo/sound/OpenAL/AL_CinematicAudio.cpp
+++ b/neo/sound/OpenAL/AL_CinematicAudio.cpp
@@ -108,22 +108,29 @@ void CinematicAudio_OpenAL::PlayAudio( uint8_t* data, int size )
 
 	if( trigger )
 	{
-		tBuffer->push( data );
-		sizes->push( size );
+		tBuffer.push( data );
+		sizes.push( size );
 		while( processed > 0 )
 		{
 			ALuint bufid;
 
-			alSourceUnqueueBuffers( alMusicSourceVoicecin, 1, &bufid );
-			processed--;
-			if( !tBuffer->empty() )
+			// SRS - Only unqueue an alBuffer if we don't already have a free bufid to use
+			if( bufids.size() == 0 )
 			{
-				int tempSize = sizes->front();
-				sizes->pop();
-				uint8_t* tempdata = tBuffer->front();
-				tBuffer->pop();
+				alSourceUnqueueBuffers( alMusicSourceVoicecin, 1, &bufid );
+				bufids.push( bufid );
+				processed--;
+			}
+			if( !tBuffer.empty() )
+			{
+				uint8_t* tempdata = tBuffer.front();
+				tBuffer.pop();
+				int tempSize = sizes.front();
+				sizes.pop();
 				if( tempSize > 0 )
 				{
+					bufid = bufids.front();
+					bufids.pop();
 					alBufferData( bufid, av_sample_cin, tempdata, tempSize, av_rate_cin );
 					// SRS - We must free the audio buffer once it has been copied into an alBuffer
 #if defined(USE_FFMPEG)
@@ -139,6 +146,10 @@ void CinematicAudio_OpenAL::PlayAudio( uint8_t* data, int size )
 						return;
 					}
 				}
+			}
+			else	// SRS - When no new audio frames left to queue, break and continue playing
+			{
+				break;
 			}
 		}
 	}
@@ -186,18 +197,49 @@ void CinematicAudio_OpenAL::PlayAudio( uint8_t* data, int size )
 	}
 }
 
+void CinematicAudio_OpenAL::ResetAudio()
+{
+	if( alIsSource( alMusicSourceVoicecin ) )
+	{
+		alSourceRewind( alMusicSourceVoicecin );
+		alSourcei( alMusicSourceVoicecin, AL_BUFFER, 0 );
+	}
+
+	if( !tBuffer.empty() )
+	{
+		int buffersize = tBuffer.size();
+		while( buffersize > 0 )
+		{
+			uint8_t* tempdata = tBuffer.front();
+			tBuffer.pop();
+			// SRS - We must free any audio buffers that have not been copied into an alBuffer
+#if defined(USE_FFMPEG)
+			av_freep( &tempdata );
+#elif defined(USE_BINKDEC)
+			Mem_Free( tempdata );
+#endif
+			buffersize--;
+		}
+	}
+	if( !sizes.empty() )
+	{
+		int buffersize = sizes.size();
+		while( buffersize > 0 )
+		{
+			sizes.pop();
+			buffersize--;
+		}
+	}
+
+	offset = 0;
+	trigger = false;
+}
+
 void CinematicAudio_OpenAL::ShutdownAudio()
 {
 	if( alIsSource( alMusicSourceVoicecin ) )
 	{
 		alSourceStop( alMusicSourceVoicecin );
-		// SRS - Make sure we don't try to unqueue buffers that were never processed
-		ALint processed;
-		alGetSourcei( alMusicSourceVoicecin, AL_BUFFERS_PROCESSED, &processed );
-		if( processed > 0 )
-		{
-			alSourceUnqueueBuffers( alMusicSourceVoicecin, processed, alMusicBuffercin );
-		}
 		alSourcei( alMusicSourceVoicecin, AL_BUFFER, 0 );
 		alDeleteSources( 1, &alMusicSourceVoicecin );
 		if( CheckALErrors() == AL_NO_ERROR )
@@ -210,13 +252,13 @@ void CinematicAudio_OpenAL::ShutdownAudio()
 	{
 		alDeleteBuffers( NUM_BUFFERS, alMusicBuffercin );
 	}
-	if( !tBuffer->empty() )
+	if( !tBuffer.empty() )
 	{
-		int buffersize = tBuffer->size();
+		int buffersize = tBuffer.size();
 		while( buffersize > 0 )
 		{
-			uint8_t* tempdata = tBuffer->front();
-			tBuffer->pop();
+			uint8_t* tempdata = tBuffer.front();
+			tBuffer.pop();
 			// SRS - We must free any audio buffers that have not been copied into an alBuffer
 #if defined(USE_FFMPEG)
 			av_freep( &tempdata );
@@ -226,12 +268,12 @@ void CinematicAudio_OpenAL::ShutdownAudio()
 			buffersize--;
 		}
 	}
-	if( !sizes->empty() )
+	if( !sizes.empty() )
 	{
-		int buffersize = sizes->size();
+		int buffersize = sizes.size();
 		while( buffersize > 0 )
 		{
-			sizes->pop();
+			sizes.pop();
 			buffersize--;
 		}
 	}

--- a/neo/sound/OpenAL/AL_CinematicAudio.cpp
+++ b/neo/sound/OpenAL/AL_CinematicAudio.cpp
@@ -129,7 +129,7 @@ void CinematicAudio_OpenAL::PlayAudio( uint8_t* data, int size )
 #if defined(USE_FFMPEG)
 					av_freep( &tempdata );
 #elif defined(USE_BINKDEC)
-					free( tempdata );
+					Mem_Free( tempdata );
 #endif
 					alSourceQueueBuffers( alMusicSourceVoicecin, 1, &bufid );
 					ALenum error = alGetError();
@@ -149,7 +149,7 @@ void CinematicAudio_OpenAL::PlayAudio( uint8_t* data, int size )
 #if defined(USE_FFMPEG)
 		av_freep( &data );
 #elif defined(USE_BINKDEC)
-		free( data );
+		Mem_Free( data );
 #endif
 		offset++;
 		if( offset == NUM_BUFFERS )
@@ -221,7 +221,7 @@ void CinematicAudio_OpenAL::ShutdownAudio()
 #if defined(USE_FFMPEG)
 			av_freep( &tempdata );
 #elif defined(USE_BINKDEC)
-			free( tempdata );
+			Mem_Free( tempdata );
 #endif
 			buffersize--;
 		}

--- a/neo/sound/OpenAL/AL_CinematicAudio.cpp
+++ b/neo/sound/OpenAL/AL_CinematicAudio.cpp
@@ -205,30 +205,25 @@ void CinematicAudio_OpenAL::ResetAudio()
 		alSourcei( alMusicSourceVoicecin, AL_BUFFER, 0 );
 	}
 
-	if( !tBuffer.empty() )
+	while( !tBuffer.empty() )
 	{
-		int buffersize = tBuffer.size();
-		while( buffersize > 0 )
+		uint8_t* tempdata = tBuffer.front();
+		tBuffer.pop();
+		sizes.pop();
+		if( tempdata )
 		{
-			uint8_t* tempdata = tBuffer.front();
-			tBuffer.pop();
 			// SRS - We must free any audio buffers that have not been copied into an alBuffer
 #if defined(USE_FFMPEG)
 			av_freep( &tempdata );
 #elif defined(USE_BINKDEC)
 			Mem_Free( tempdata );
 #endif
-			buffersize--;
 		}
 	}
-	if( !sizes.empty() )
+
+	while( !bufids.empty() )
 	{
-		int buffersize = sizes.size();
-		while( buffersize > 0 )
-		{
-			sizes.pop();
-			buffersize--;
-		}
+		bufids.pop();
 	}
 
 	offset = 0;
@@ -252,29 +247,25 @@ void CinematicAudio_OpenAL::ShutdownAudio()
 	{
 		alDeleteBuffers( NUM_BUFFERS, alMusicBuffercin );
 	}
-	if( !tBuffer.empty() )
+	
+	while( !tBuffer.empty() )
 	{
-		int buffersize = tBuffer.size();
-		while( buffersize > 0 )
+		uint8_t* tempdata = tBuffer.front();
+		tBuffer.pop();
+		sizes.pop();
+		if( tempdata )
 		{
-			uint8_t* tempdata = tBuffer.front();
-			tBuffer.pop();
 			// SRS - We must free any audio buffers that have not been copied into an alBuffer
 #if defined(USE_FFMPEG)
 			av_freep( &tempdata );
 #elif defined(USE_BINKDEC)
 			Mem_Free( tempdata );
 #endif
-			buffersize--;
 		}
 	}
-	if( !sizes.empty() )
+
+	while( !bufids.empty() )
 	{
-		int buffersize = sizes.size();
-		while( buffersize > 0 )
-		{
-			sizes.pop();
-			buffersize--;
-		}
+		bufids.pop();
 	}
 }

--- a/neo/sound/OpenAL/AL_CinematicAudio.h
+++ b/neo/sound/OpenAL/AL_CinematicAudio.h
@@ -41,6 +41,7 @@ public:
 	CinematicAudio_OpenAL();
 	void InitAudio( void* audioContext );
 	void PlayAudio( uint8_t* data, int size );
+	void ResetAudio();
 	void ShutdownAudio();
 private:
 	ALuint		alMusicSourceVoicecin;
@@ -55,8 +56,9 @@ private:
 	//	  So, what happens if there are no freely available buffers but we still geting audio frames ? Loss of data.
 	//	  That why now I am using two queues in order to store the frames (and their sizes) and when we have available buffers,
 	//	  then start popping those frames instead of the current, so we don't lose any audio frames and the sound doesn't crack anymore.
-	std::queue<uint8_t*>	tBuffer[NUM_BUFFERS];
-	std::queue<int>			sizes[NUM_BUFFERS];
+	std::queue<uint8_t*>	tBuffer;
+	std::queue<int>			sizes;
+	std::queue<ALuint>		bufids;		// SRS - Added queue of free alBuffer ids to handle audio frame underflow (starvation) case
 };
 
 #endif

--- a/neo/sound/OpenAL/AL_SoundVoice.cpp
+++ b/neo/sound/OpenAL/AL_SoundVoice.cpp
@@ -206,10 +206,13 @@ void idSoundVoice_OpenAL::DestroyInternal()
 			idLib::Printf( "%dms: %i destroyed\n", Sys_Milliseconds(), openalSource );
 		}
 
+		// SRS - Make sure the source is stopped before detaching buffers
+		alSourceStop( openalSource );
+		alSourcei( openalSource, AL_BUFFER, 0 );
+
+		// SRS - Delete source only after detaching buffers above
 		alDeleteSources( 1, &openalSource );
 		openalSource = 0;
-
-		alSourcei( openalSource, AL_BUFFER, 0 );
 
 		if( openalStreamingBuffer[0] && openalStreamingBuffer[1] && openalStreamingBuffer[2] )
 		{

--- a/neo/sound/XAudio2/XA2_CinematicAudio.cpp
+++ b/neo/sound/XAudio2/XA2_CinematicAudio.cpp
@@ -179,6 +179,15 @@ void CinematicAudio_XAudio2::PlayAudio( uint8_t* data, int size )
 	}
 }
 
+void CinematicAudio_XAudio2::ResetAudio()
+{
+	if( pMusicSourceVoice1 )
+	{
+		pMusicSourceVoice1->Stop();
+		pMusicSourceVoice1->FlushSourceBuffers();
+	}
+}
+
 void CinematicAudio_XAudio2::ShutdownAudio()
 {
 	if( pMusicSourceVoice1 )

--- a/neo/sound/XAudio2/XA2_CinematicAudio.cpp
+++ b/neo/sound/XAudio2/XA2_CinematicAudio.cpp
@@ -52,7 +52,7 @@ public:
 #if defined(USE_FFMPEG)
 		av_freep( &data );
 #elif defined(USE_BINKDEC)
-		free( data );
+		Mem_Free( data );
 #endif
 	}
 	//Unused methods are stubs

--- a/neo/sound/XAudio2/XA2_CinematicAudio.h
+++ b/neo/sound/XAudio2/XA2_CinematicAudio.h
@@ -33,6 +33,7 @@ public:
 	CinematicAudio_XAudio2();
 	void InitAudio( void* audioContext );
 	void PlayAudio( uint8_t* data, int size );
+	void ResetAudio();
 	void ShutdownAudio();
 private:
 	WAVEFORMATEX			voiceFormatcine = { 0 };

--- a/neo/sound/snd_system.cpp
+++ b/neo/sound/snd_system.cpp
@@ -532,6 +532,7 @@ cinData_t idSoundSystemLocal::ImageForTime( const int milliseconds, const bool w
 	cd.imageY = NULL;
 	cd.imageCr = NULL;
 	cd.imageCb = NULL;
+	cd.image = NULL;
 	cd.imageWidth = 0;
 	cd.imageHeight = 0;
 	cd.status = FMV_IDLE;


### PR DESCRIPTION
A modest set of cinematics, audio and memory management fixes:

Cinematics:
1. Calculate and use correct number of bytes for ffmpeg cinematic video image buffer allocation
2. Use Mem_Alloc() and Mem_Free() (vs malloc and free) for Bink cinematic audio buffer allocation and release
3. Properly release ffmpeg video and audio codec contexts and ffmpeg audio lag buffers (for sync) when required
4. Support cinematic audio looping if called for, and clean up redundant cinematic variable initialization
5. Handle cinematic audio buffer underflow condition, and change queues to scalars vs arrays of queues
6. Properly close all ffmpeg contexts using correct procedures (e.g. `avcodec_free_context`, `swr_free`)
7. Remove cinematic audio packet queue - not needed and dangerous if packet on queue is freed before use
8. **NEW FEATURE**: Support ffmpeg decoding of RoQ files for better video quality plus audio support
9. Enabled ffmpeg and RoQ decoder playback in testVideo console command (previously was Bink decoder only)
10. Added estimate of RoQ video duration when using the ffmpeg decoder (not applicable to original RoQ decoder)
11. Aligned frame logic for all Cinematic decoders (ffmpeg, Bink, RoQ) - eliminates differences and edge case bugs
12. Use correct sRGB shaders for ffmpeg cinematics (for load video and in-game 2D) & bink cinematics (testVideo cmd)
13. Fixed bugs in RoQ cinematic looping and in the testVideo console command (works in all cases now with audio)

Game Audio:
1. Implement audio muting when game paused or in background (applies to Doom3, Classic, and in-game Cinematics, does not apply to initial load video which is outside the normal rendering loop)
2. Properly release OpenAL buffers and delete audio sources in correct order on game shutdown (was in wrong order)
3. **IMPORTANT FIX**: On exit, shutdown sound system **after** decl manager to prevent XAudio2 exception on Windows caused by trying to delete the mastering voice if cinematic audio voices are still allocated.  The decl manager manages all cinematic resources and cleans up cinematic audio before sound system shutdown.

That's all I plan to contribute for now.  It was a lot more involved than I imagined when I first dug into it.  I thought the ffmpeg5 work would be a fun small project, but it grew into a larger effort.  The combinatorics of testing and bug fixing was the main issue: 2 file formats (.bik, .roq) x 3 decoders (ffmpeg, bink, RoQ) x 2 audio systems (XAudio2, OpenAL) x 2 renderers (OpenGL, Vulkan) x 3 platforms (Windows, Linux, macOS).  In any case, I think it's pretty clean now and hopefully it will help modders out there with new custom A/V cinematics and/or legacy files.