### PR TITLE
sound/OpenAL/AL_CinematicAudio.cpp: Remove address check against array, zero out music buffer on shutdown

### DIFF
--- a/neo/sound/OpenAL/AL_CinematicAudio.cpp
+++ b/neo/sound/OpenAL/AL_CinematicAudio.cpp
@@ -243,7 +243,14 @@ void CinematicAudio_OpenAL::ShutdownAudio()
 		}
 	}
 
-	alDeleteBuffers( NUM_BUFFERS, alMusicBuffercin );
+	alDeleteBuffers( NUM_BUFFERS, &alMusicBuffercin[0] );
+	if( CheckALErrors() == AL_NO_ERROR )
+	{
+		for( int i = 0; i < NUM_BUFFERS; i++ )
+		{
+			alMusicBuffercin[ i ] = 0;
+		}
+	}
 
 	while( !tBuffer.empty() )
 	{

--- a/neo/sound/OpenAL/AL_CinematicAudio.cpp
+++ b/neo/sound/OpenAL/AL_CinematicAudio.cpp
@@ -243,10 +243,7 @@ void CinematicAudio_OpenAL::ShutdownAudio()
 		}
 	}
 
-	if( alMusicBuffercin )
-	{
-		alDeleteBuffers( NUM_BUFFERS, alMusicBuffercin );
-	}
+	alDeleteBuffers( NUM_BUFFERS, alMusicBuffercin );
 
 	while( !tBuffer.empty() )
 	{


### PR DESCRIPTION
```cpp
neo/sound/OpenAL/AL_CinematicAudio.cpp:246:6: warning: address of array 'this->alMusicBuffercin' will always evaluate to 'true' [-Wpointer-bool-conversion]
        if( alMusicBuffercin )
        ~~  ^~~~~~~~~~~~~~~~
```