### PR TITLE
cm/CollisionModel: Initialize "material" and "id" fields in "contactInfo_t"

### DIFF
--- a/neo/cm/CollisionModel_contents.cpp
+++ b/neo/cm/CollisionModel_contents.cpp
@@ -567,6 +567,8 @@ int idCollisionModelManagerLocal::ContentsTrm( trace_t* results, const idVec3& s
 	tw.trace.fraction = 1.0f;
 	tw.trace.c.contents = 0;
 	tw.trace.c.type = CONTACT_NONE;
+	tw.trace.c.material = NULL;
+	tw.trace.c.id = 0;
 	tw.contents = contentMask;
 	tw.isConvex = true;
 	tw.rotation = false;

--- a/neo/cm/CollisionModel_translate.cpp
+++ b/neo/cm/CollisionModel_translate.cpp
@@ -872,6 +872,8 @@ void idCollisionModelManagerLocal::Translation( trace_t* results, const idVec3& 
 	tw.trace.fraction = 1.0f;
 	tw.trace.c.contents = 0;
 	tw.trace.c.type = CONTACT_NONE;
+	tw.trace.c.material = NULL;
+	tw.trace.c.id = 0;
 	tw.contents = contentMask;
 	tw.isConvex = true;
 	tw.rotation = false;


### PR DESCRIPTION
The Dark Mod only does it in `idCollisionModelManagerLocal::ContentsTrm()`.

Prey only initializes `id`, in `idCollisionModelManagerLocal::Translation()`.