### PR TITLE
Allow packaged imgui to be used (and allow newer version of this library

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -69,6 +69,10 @@ option(USE_SYSTEM_LIBGLEW
 option(USE_SYSTEM_RAPIDJSON
                 "Use the system rapidjson instead of the bundled one" OFF)
 
+option(USE_SYSTEM_IMGUI
+                "Use the system imgui instead of the bundled one" OFF)
+
+
 set(CPU_TYPE "" CACHE STRING "When set, passes this string as CPU-ID which will be embedded into the binary.")
 
 # SRS - Turn on optimization when cross-compiling from Apple arm64 to x86_64
@@ -355,6 +359,18 @@ else (JPEG_FOUND)
 endif (JPEG_FOUND)
 
 
+if (USE_SYSTEM_IMGUI)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(IMGUI REQUIRED imgui)
+endif()
+
+if(IMGUI_FOUND)
+    include_directories(${IMGUI_INCLUDE_DIRS})
+else()
+    include_directories("libs/imgui/../")
+    set(IMGUI_LIBRARIES "")
+endif()
+
 macro(SET_OPTION option value)
   set(${option} ${value} CACHE "" INTERNAL FORCE)
 endmacro()
@@ -481,7 +497,6 @@ else (RAPIDJSON_FOUND)
 endif (RAPIDJSON_FOUND)
 
 
-	
 add_subdirectory(idlib)
 
 file(GLOB AAS_INCLUDES aas/*.h)
@@ -534,8 +549,13 @@ file(GLOB SHADERS_BUILTIN_VR ../base/renderprogs/builtin/VR/*.hlsl )
 file(GLOB IRRXML_INCLUDES libs/irrxml/src/*.h)
 file(GLOB IRRXML_SOURCES libs/irrxml/src/*.cpp)
 
-file(GLOB IMGUI_INCLUDES libs/imgui/*.h)
-file(GLOB IMGUI_SOURCES libs/imgui/*.cpp)
+if(NOT USE_SYSTEM_IMGUI)
+    file(GLOB IMGUI_INCLUDES libs/imgui/*.h)
+    file(GLOB IMGUI_SOURCES libs/imgui/*.cpp)
+else()
+    set(IMGUI_INCLUDES "")
+    set(IMGUI_SOURCES "")
+endif()
 
 file(GLOB STB_INCLUDES libs/stb/*.h)
 
@@ -1860,6 +1880,7 @@ else()
             ${PNG_LIBRARY}
             ${JPEG_LIBRARY}
             ${GLEW_LIBRARY}
+            ${IMGUI_LIBRARIES}
 	    	${CMAKE_DL_LIBS}
 			)
 	endif()

--- a/neo/imgui/BFGimgui.h
+++ b/neo/imgui/BFGimgui.h
@@ -2,7 +2,7 @@
 #ifndef NEO_IMGUI_BFGIMGUI_H_
 #define NEO_IMGUI_BFGIMGUI_H_
 
-#include "libs/imgui/imgui.h"
+#include "imgui/imgui.h"
 
 #include "../idlib/math/Vector.h"
 

--- a/neo/imgui/BFGimguiImpl.cpp
+++ b/neo/imgui/BFGimguiImpl.cpp
@@ -249,7 +249,9 @@ bool Init( int windowWidth, int windowHeight )
 	g_DisplaySize.y = windowHeight;
 	io.DisplaySize = g_DisplaySize;
 
+#if (IMGUI_VERSION_NUM <= 16000)
 	io.RenderDrawListsFn = idRenderBackend::ImGui_RenderDrawLists;
+#endif
 
 	// RB: FIXME double check
 	io.SetClipboardTextFn = SetClipboardText;
@@ -437,6 +439,10 @@ void Render()
 		//ImGui::End();
 
 		ImGui::Render();
+#if (IMGUI_VERSION_NUM > 16000)
+		idRenderBackend::ImGui_RenderDrawLists(ImGui::GetDrawData());
+#endif
+
 		g_haveNewFrame = false;
 	}
 }

--- a/neo/renderer/GuiModel.cpp
+++ b/neo/renderer/GuiModel.cpp
@@ -31,7 +31,7 @@ If you have questions concerning this license or the applicable additional terms
 #pragma hdrstop
 
 #include "RenderCommon.h"
-#include "libs/imgui/imgui.h"
+#include "imgui/imgui.h"
 
 const float idGuiModel::STEREO_DEPTH_NEAR = 0.0f;
 const float idGuiModel::STEREO_DEPTH_MID  = 0.5f;

--- a/neo/renderer/Image_intrinsic.cpp
+++ b/neo/renderer/Image_intrinsic.cpp
@@ -30,7 +30,7 @@ If you have questions concerning this license or the applicable additional terms
 #include "precompiled.h"
 #pragma hdrstop
 
-#include "libs/imgui/imgui.h"
+#include "imgui/imgui.h"
 
 #include "RenderCommon.h"
 #include "SMAA/AreaTex.h"

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -31,7 +31,7 @@ If you have questions concerning this license or the applicable additional terms
 #include "precompiled.h"
 #pragma hdrstop
 
-#include "libs/imgui/imgui.h"
+#include "imgui/imgui.h"
 
 #include "RenderCommon.h"
 

--- a/neo/ui/DeviceContext.cpp
+++ b/neo/ui/DeviceContext.cpp
@@ -31,7 +31,7 @@ If you have questions concerning this license or the applicable additional terms
 
 #include "DeviceContext.h"
 
-#include "libs/imgui/imgui.h"
+#include "imgui/imgui.h"
 #include "../renderer/GuiModel.h"
 
 extern idCVar in_useJoystick;


### PR DESCRIPTION
The changes in CMakeList.txt allows to avoid the bundled imgui, as for Debian
this is a policy*. This is via the USE_SYSTEM_IMGUI option, defaulting to OFF.

The only change I see to imgui.cpp is that there is an assertion commented out,
in ImGui::End() -- this triggers if there is a mismatched number of counts to
ImGui::Begin() and End(), howeever looking over the code, End() is only called
in one location (and another in the Editor) and it matches a Begin() call, so it
should not trigger. (Tested also with com_showFPS = 2)

The change requires some include directives changes from ''libs/imgui/imgui.h''
to ''imgui/imgui.h'', but this is ensured in CMakeList.txt that it will be
transparent whether its the system one or bundled one.

The change in BFGimguiImpl.cpp is recommended with any imgui > 1.60, required with > 1.80:
''io.RenderDrawListsFn'' has been deprecated in 1.60 and subsequently removed
in 1.80: Code should call their backend render function directly after ImGui::Render()
themselves.
Strictly, the version guard is not required, as the bundled version
is newer than 1.60; I've just added it for clarity; let me know if you prefer
me to remove the guard.  Upstream details on this topic:
https://github.com/ocornut/imgui/issues/1599 and the Changelog entry:
https://github.com/ocornut/imgui/blob/dfbe938e54858b8b443ca2981d037cc2f35cc931/docs/CHANGELOG.txt#L821

Cheers,
tobi