### PR TITLE
Enable VK_KHR_portability_enumeration for macOS on Vulkan SDK 1.3.211.0 or later

### DIFF
--- a/neo/renderer/Vulkan/RenderBackend_VK.cpp
+++ b/neo/renderer/Vulkan/RenderBackend_VK.cpp
@@ -309,8 +309,15 @@ static void CreateVulkanInstance()
 		{
 			vkcontext.instanceExtensions.AddUnique( VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME );
 			vkcontext.deviceProperties2Available = true;
-			break;
 		}
+#if defined(__APPLE__) && defined( VK_KHR_portability_enumeration )
+		// SRS - Enable physical device enumeration when using the Vulkan loader on macOS (MoltenVK portability driver)
+		if( idStr::Icmp( instanceExtensionProps[ i ].extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME ) == 0 )
+		{
+			vkcontext.instanceExtensions.AddUnique( VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME );
+			createInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+		}
+#endif
 	}
 
 	vkcontext.debugUtilsSupportAvailable = false;

--- a/neo/renderer/Vulkan/RenderBackend_VK.cpp
+++ b/neo/renderer/Vulkan/RenderBackend_VK.cpp
@@ -750,7 +750,12 @@ static void SelectPhysicalDevice()
 
 			static idStr version_string;
 			version_string.Clear();
+#if VK_HEADER_VERSION >= 176
 			version_string.Append( va( "Vulkan API %i.%i.%i", VK_API_VERSION_MAJOR( gpu.props.apiVersion ), VK_API_VERSION_MINOR( gpu.props.apiVersion ), VK_API_VERSION_PATCH( gpu.props.apiVersion ) ) );
+#else
+			// SRS - Allow deprecated version macros on older Vulkan SDKs < 1.2.176
+			version_string.Append( va( "Vulkan API %i.%i.%i", VK_VERSION_MAJOR( gpu.props.apiVersion ), VK_VERSION_MINOR( gpu.props.apiVersion ), VK_VERSION_PATCH( gpu.props.apiVersion ) ) );
+#endif
 
 			static idStr extensions_string;
 			extensions_string.Clear();
@@ -768,13 +773,13 @@ static void SelectPhysicalDevice()
 
 			if( vkcontext.deviceProperties2Available && driverPropertiesAvailable )
 			{
-				VkPhysicalDeviceProperties2 pProperties = {};
-				VkPhysicalDeviceDriverProperties pDriverProperties = {};
-				pProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-				pProperties.pNext = &pDriverProperties;
-				pDriverProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
-				vkGetPhysicalDeviceProperties2( vkcontext.physicalDevice, &pProperties );
-				version_string.Append( va( " (%s %s)", pDriverProperties.driverName, pDriverProperties.driverInfo ) );
+				VkPhysicalDeviceProperties2 deviceProperties = {};
+				VkPhysicalDeviceDriverProperties driverProperties = {};
+				deviceProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+				deviceProperties.pNext = &driverProperties;
+				driverProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
+				vkGetPhysicalDeviceProperties2( vkcontext.physicalDevice, &deviceProperties );
+				version_string.Append( va( " (%s %s)", driverProperties.driverName, driverProperties.driverInfo ) );
 			}
 			glConfig.version_string = version_string.c_str();
 


### PR DESCRIPTION
The Vulkan SDK 1.3.211.0 loader has implemented VK_KHR_portability_enumeration which requires the instance extension `VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME`, and the `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` flag bit to be set in `VkInstanceCreateInfo` when calling `vkCreateInstance()`.  Otherwise the MoltenVK portability driver may not be enumerated as an available Vulkan device.  This pull request enables the instance extension and flag when available in the Vulkan SDK for the macOS portability implementation.  A compiler directive guards this code to prevent build failures on earlier SDKs that did not define or require this extension.

Also moved the fix for issue #656 allowing deprecated Vulkan version macro compatibility for older Vulkan SDKs <  1.2.176 (i.e. `VK_VERSION_MAJOR` vs. `VK_API_VERSION_MAJOR`, etc) to this smaller Vulkan-specific pull request.

Note that as of Vulkan SDK 1.3.211.0 and MoltenVK 1.1.9, the `maxSamplerAllocationCount` limit has been lifted and the Vulkan loader should no longer report validation errors during game level loads when creating thousands of samplers on macOS MoltenVK.  This was previously an annoying issue, but thanks to @billhollings the issue is now solved.  See https://github.com/KhronosGroup/MoltenVK/issues/1512 for more details if interested.