### PR TITLE
Remove #define JPEG_INTERNALS from Cinematic.cpp

### DIFF
--- a/neo/renderer/Cinematic.cpp
+++ b/neo/renderer/Cinematic.cpp
@@ -39,7 +39,6 @@ If you have questions concerning this license or the applicable additional terms
 
 extern idCVar s_noSound;
 
-#define JPEG_INTERNALS
 //extern "C" {
 #include <jpeglib.h>
 //}


### PR DESCRIPTION
Defining JPEG_INTERNALS should only be done by parts of libjpeg itself.
If defined it causes libjpeg-turbo to try to include jpegint.h which some Linux distros do not install as it is not part of it's public API.

Defining JPEG_INTERNALS is not required in Cinematic.cpp as far as I could find either.