### PR TITLE
Add Dockerfile to build Ubuntu builds in containers.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:focal AS build
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ADD . /workspace
+RUN apt-get update \
+    && apt-get install -y \
+        build-essential git cmake \
+        libsdl2-dev libopenal-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
+
+WORKDIR /workspace
+RUN cd neo && ./cmake-eclipse-linux-profile.sh
+RUN cd build && make
+
+FROM scratch AS export
+COPY --from=build /workspace/build/RBDoom3BFG /workspace/base/maps/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,34 @@
-FROM ubuntu:focal AS build
+FROM ubuntu:focal AS rbdoom3bfg-buildenv
+ENV DEBIAN_FRONTEND=noninteractive
 
-ENV DEBIAN_FRONTEND noninteractive
+# Add the Vulkan SDK repository
+RUN apt-get update \
+    && apt-get install -y curl gpg\
+    && curl -Lso /tmp/lunarg-signing-key-pub.asc \
+        http://packages.lunarg.com/lunarg-signing-key-pub.asc \
+    && apt-key add /tmp/lunarg-signing-key-pub.asc \
+    && curl -Lso /etc/apt/sources.list.d/lunarg-vulkan-focal.list \
+        http://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
 
-ADD . /workspace
+# Install the general RBDoom3BFG dependencies
 RUN apt-get update \
     && apt-get install -y \
         build-essential git cmake \
-        libsdl2-dev libopenal-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
+        libsdl2-dev libopenal-dev vulkan-sdk \
+        libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
 
+# From the previous build environment stage, actually run the build
+FROM rbdoom3bfg-buildenv AS build
+
+ARG CONFIGSCRIPT=cmake-eclipse-linux-profile.sh
+ENV CONFIGSCRIPT=${CONFIGSCRIPT}
+
+ADD . /workspace
 WORKDIR /workspace
-RUN cd neo && ./cmake-eclipse-linux-profile.sh
+RUN cd neo && ./${CONFIGSCRIPT}
 RUN cd build && make
 
+# Copy only the finished RBDoom3BFG executable to an empty image
+# for use with docker build --output
 FROM scratch AS export
 COPY --from=build /workspace/build/RBDoom3BFG /workspace/base/maps/ /

--- a/README.md
+++ b/README.md
@@ -465,7 +465,10 @@ If your system has Docker installed, you can create RBDOOM3BFG builds without ha
 	
 	> docker build . --output type=local,dest=./build
 
-This will run a build and save the resulting executables to `./build` on your host machine.
+This will run a build and save the resulting executables to `./build` on your host machine. By default, this will create a build using the `eclipse-linux-profile` configuration; to customize this you can also pass in the `CONFIGSCRIPT` build argument. For example, to create a build using the Vulkan release configuration:
+
+	> docker build . --output type=local,dest=./build --build-arg CONFIGSCRIPT=cmake-linux-vulkan-release.sh
+
 
 ## Local build
 	

--- a/README.md
+++ b/README.md
@@ -459,6 +459,16 @@ Recommended in this case is `cmake-vs2017-64bit-windows10.bat`
 ---
 # Compiling on Linux <a name="compile_linux"></a>
 
+## Containerised build
+	
+If your system has Docker installed, you can create RBDOOM3BFG builds without having to install any of the dependencies on your host system. There is a `Dockerfile` in this repository that will set up the environment inside an `ubuntu` container and run the build for you. To run a build inside a Docker container, simply run the following command in the root path of this repository:
+	
+	> docker build . --output type=local,dest=./build
+
+This will run a build and save the resulting executables to `./build` on your host machine.
+
+## Local build
+	
 1. You need the following dependencies in order to compile RBDoom3BFG with all features:
 
 	On Debian or Ubuntu:


### PR DESCRIPTION
I set this up so I could build RBDOOM3BFG for myself without having to install a pile of dev libraries and dependencies to my daily use system and figured I'll contribute that back.

As it stands, on Linux systems with Docker installed this greatly simplifies the process of creating a build:

`docker build . --output type=local,dest=./build`

Additionally with `docker buildx` this will make it possible to create builds for other architectures - say, `arm64`.

Further plans:

* Make base image a parameter so builds can be easily compiled on multiple Ubuntu/Debian versions
* Investigate using Microsoft's Windows Docker images to simplify creating Windows builds too
* Add GitHub workflows to run CI builds on pull requests and build and store binary builds whenever a release is published - thus basically having "official" builds. These could then also be further used to provide e.g. Flatpak builds which will work independent of the end user's distribution.