### PR TITLE
fix: broken HU_Init due to uninitialized buffer

### DIFF
--- a/doomclassic/doom/f_finale.cpp
+++ b/doomclassic/doom/f_finale.cpp
@@ -725,7 +725,8 @@ void F_BunnyScroll (void)
     int		x;
     patch_t*	p1;
     patch_t*	p2;
-    char	name[10];
+    size_t	name_len = 10;
+    char	name[name_len];
     int		stage;
 		
     p1 = (patch_t*)W_CacheLumpName ("PFUB2", PU_LEVEL_SHARED);
@@ -765,8 +766,8 @@ void F_BunnyScroll (void)
 	S_StartSound (NULL, sfx_pistol);
 	::g->laststage = stage;
     }
-	
-    snprintf (name, strlen(name), "END%i",stage);
+
+	snprintf(name, name_len, "END%i", stage);
     V_DrawPatch ((ORIGINAL_WIDTH-13*8)/2, (ORIGINAL_HEIGHT-8*8)/2,0, (patch_t*)W_CacheLumpName (name,PU_CACHE_SHARED));
 }
 

--- a/doomclassic/doom/hu_stuff.cpp
+++ b/doomclassic/doom/hu_stuff.cpp
@@ -319,7 +319,8 @@ void HU_Init(void)
 
 	int		i;
 	int		j;
-	char	buffer[9];
+	size_t	buffer_len = 9;
+	char	buffer[buffer_len];
 
 	shiftxform = english_shiftxform;
 
@@ -327,7 +328,7 @@ void HU_Init(void)
 	j = HU_FONTSTART;
 	for (i=0;i<HU_FONTSIZE;i++)
 	{
-		snprintf(buffer, strlen(buffer), "STCFN%.3d", j++);
+		snprintf(buffer, buffer_len, "STCFN%03d", j++);
 		::g->hu_font[i] = (patch_t *) W_CacheLumpName(buffer, PU_STATIC_SHARED);
 	}
 


### PR DESCRIPTION
Fixes #692

This fixes a build fail I was running into on `master` in `doomclassic/` due to a `format-truncation` error. I found that the `HU_Init` seems to have been broken for a time due to the use of `strlen` on an uninitialized buffer, passing a max bytes of 0 to `snprintf`. This fixes the `snprintf` calls and consequently the build error. This also fixes a related problem nearby where `strlen` was used on an uninitialized buffer in a similar way.