### PR TITLE
Move semantics for idList and idStr

### DIFF
--- a/neo/framework/Common.h
+++ b/neo/framework/Common.h
@@ -167,6 +167,7 @@ struct MemInfo_t
 
 struct mpMap_t
 {
+	mpMap_t& operator=( mpMap_t&& src ) = default;
 
 	void operator=( const mpMap_t& src )
 	{

--- a/neo/idlib/Str.h
+++ b/neo/idlib/Str.h
@@ -130,6 +130,7 @@ class idStr
 
 public:
 	idStr();
+	idStr( idStr&& text ) noexcept; // Admer: added move constructor
 	idStr( const idStr& text );
 	idStr( const idStr& text, int start, int end );
 	idStr( const char* text );
@@ -149,6 +150,7 @@ public:
 	char				operator[]( int index ) const;
 	char& 				operator[]( int index );
 
+	void				operator=( idStr&& text ) noexcept; // Admer: added move operator
 	void				operator=( const idStr& text );
 	void				operator=( const char* text );
 
@@ -477,6 +479,12 @@ ID_INLINE idStr::idStr()
 	Construct();
 }
 
+ID_INLINE idStr::idStr( idStr&& text ) noexcept
+{
+	Construct();
+	*this = std::move( text );
+}
+
 ID_INLINE idStr::idStr( const idStr& text )
 {
 	Construct();
@@ -675,6 +683,28 @@ ID_INLINE char& idStr::operator[]( int index )
 {
 	assert( ( index >= 0 ) && ( index <= len ) );
 	return data[ index ];
+}
+
+ID_INLINE void idStr::operator=( idStr&& text ) noexcept
+{
+	Clear();
+
+	len = text.len;
+	allocedAndFlag = text.allocedAndFlag;
+	memcpy( baseBuffer, text.baseBuffer, sizeof( baseBuffer ) );
+	
+	if ( text.data == text.baseBuffer )
+	{
+		data = baseBuffer;
+	}
+	else
+	{
+		data = text.data;
+	}
+
+	text.len = 0;
+	text.allocedAndFlag = 0;
+	text.data = nullptr;
 }
 
 ID_INLINE void idStr::operator=( const idStr& text )

--- a/neo/idlib/containers/List.h
+++ b/neo/idlib/containers/List.h
@@ -98,7 +98,8 @@ ID_INLINE void* idListArrayResize( void* voldptr, int oldNum, int newNum, bool z
 		int overlap = Min( oldNum, newNum );
 		for( int i = 0; i < overlap; i++ )
 		{
-			newptr[i] = oldptr[i];
+			//newptr[i] = oldptr[i];
+			newptr[i] = std::move( oldptr[i] );
 		}
 	}
 	idListArrayDelete<_type_>( voldptr, oldNum );
@@ -125,6 +126,7 @@ public:
 	typedef _type_	new_t();
 
 	idList( int newgranularity = 16 );
+	idList( idList&& other );
 	idList( const idList& other );
 	idList( std::initializer_list<_type_> initializerList );
 	~idList();
@@ -139,6 +141,7 @@ public:
 	size_t			Size() const;										// returns total size of allocated memory including size of list _type_
 	size_t			MemoryUsed() const;									// returns size of the used elements in the list
 
+	idList<_type_, _tag_>& 		operator=( idList<_type_, _tag_>&& other );
 	idList<_type_, _tag_>& 		operator=( const idList<_type_, _tag_>& other );
 	const _type_& 	operator[]( int index ) const;
 	_type_& 		operator[]( int index );
@@ -301,6 +304,18 @@ ID_INLINE idList<_type_, _tag_>::idList( int newgranularity )
 	granularity	= newgranularity;
 	memTag		= _tag_;
 	Clear();
+}
+
+/*
+================
+idList<_type_,_tag_>::idList( idList< _type_, _tag_ >&& other )
+================
+*/
+template< typename _type_, memTag_t _tag_ >
+ID_INLINE idList<_type_, _tag_>::idList( idList&& other )
+{
+	list = NULL;
+	*this = std::move( other );
 }
 
 /*
@@ -694,6 +709,30 @@ ID_INLINE void idList<_type_, _tag_>::AssureSizeAlloc( int newSize, new_t* alloc
 	}
 
 	num = newNum;
+}
+
+/*
+================
+idList<_type_,_tag_>::operator=
+
+Moves the contents and size attributes of another list, effectively emptying the other list.
+================
+*/
+template< typename _type_, memTag_t _tag_ >
+ID_INLINE idList<_type_, _tag_>& idList<_type_, _tag_>::operator=( idList<_type_, _tag_>&& other )
+{
+	Clear();
+
+	num			= other.num;
+	size		= other.size;
+	granularity = other.granularity;
+	memTag		= other.memTag;
+	list		= other.list;
+
+	other.list = nullptr;
+	other.Clear();
+
+	return *this;
 }
 
 /*


### PR DESCRIPTION
This PR introduces a performance boost to `idStrList` by adding move semantics to `idList` and `idStr`.

With the following test code:
```cpp
static const char SomeStringStuff[] = "fa73ifta2bicfta09qweroitzoripmyxnv,mn1icraetifadigtfejkagfmadhg45fgadkgfadhfvaezkvf68";

CONSOLE_COMMAND( test_idlist, "tests the stuff", nullptr )
{
	// Generating the idList and populating it with elements
	const uint64 startAllocUs = Sys_Microseconds();
	idStrList list;
	for ( int i = 0; i < 100'000; i++ )
	{
		list.Append( SomeStringStuff + (i & 0b111111) );
	}

	// Resizing the idList
	const uint64 startResizeUs = Sys_Microseconds();
	list.Resize( 50'000 );

	// Moving the contents of an idList to another
	const uint64 startMoveUs = Sys_Microseconds();
	idStrList list2 = std::move( list );
	
	const uint64 endUs = Sys_Microseconds();

	const uint64 allocTime = startResizeUs - startAllocUs;
	const uint64 resizeTime = startMoveUs - startResizeUs;
	const uint64 moveTime = endUs - startMoveUs;

	common->Printf( "Test results:\n" );
	common->Printf( "  * Alloc time:  %6.2f ms\n", (allocTime * 0.001f) );
	common->Printf( "  * Resize time: %6.2f ms\n", (resizeTime * 0.001f) );
	common->Printf( "  * Move time:   %6.2f ms\n", (moveTime * 0.001f) );
}
```
I was able to get these results:
```
========================
Without move
========================
#1:
- Alloc time: 	40900 milliseconds
- Resize time:	8.95 milliseconds
- Move time:  	4.38 milliseconds
#2:
- Alloc time: 	40675 milliseconds
- Resize time:	9.00 milliseconds
- Move time:  	4.50 milliseconds
#3:
- Alloc time: 	40021 milliseconds
- Resize time:	8.93 milliseconds
- Move time:  	4.51 milliseconds

========================
With move
========================
#1:
- Alloc time: 	7681 milliseconds
- Resize time:	3.59 milliseconds
- Move time:  	0.00 milliseconds
#2:
- Alloc time: 	7720 milliseconds
- Resize time:	3.64 milliseconds
- Move time:  	0.00 milliseconds
#3:
- Alloc time: 	7749 milliseconds
- Resize time:	3.59 milliseconds
- Move time:  	0.00 milliseconds
```
We see a massive speedup in the resizing of `idList`, in particular when it stores `idStr` elements. Previously the code would just copy strings between the old and resized buffer, but now they're moved. Understandably this wasn't doable back in 2004 because C++11 and move semantics weren't a thing yet.

For something like level load times, improvements are small but kind of significant.
Loading Mars City 1 is about 300 ms faster, when it normally loads in 6 seconds (5% improvement) on my i5 8400, 16 GB of DDR4 RAM and RTX 3060. Here's more detailed info:
```
========================
Without move
========================
mars_city1
10069 milliseconds,¸
5540 milliseconds,
5568 milliseconds,
restart game,
5766 milliseconds,
6253 milliseconds
Average: 6639 milliseconds (5781 without the 1st timing)

mars_city1, attempt 2
5773 milliseconds,¸
6200 milliseconds,
6119 milliseconds,
6133 milliseconds,
6226 milliseconds,
6165 milliseconds
Average: 6102 milliseconds

========================
With move
========================
mars_city1
5875 milliseconds,
restart game on accident,
5629 milliseconds,
5331 milliseconds,
5476 milliseconds,
5349 milliseconds
Average: 5532 milliseconds (1107 milliseconds faster, 249 without the 1st timing)

mars_city1, attempt 2
5643 milliseconds,
5373 milliseconds,
5334 milliseconds,
6107 milliseconds,
6106 milliseconds,
6129 milliseconds
Average: 5782 milliseconds (320 milliseconds faster)
```
There might be more opportunity to optimise this stuff, looking at `std::vector` and EASTL as a reference, but I haven't taken a look at either yet.