### PR TITLE
List.h fix and Doom Classic snprintf() fixes for modern clang and gcc compilers

### DIFF
--- a/doomclassic/doom/f_finale.cpp
+++ b/doomclassic/doom/f_finale.cpp
@@ -830,7 +830,7 @@ void F_BunnyScroll( void )
 	int		x;
 	patch_t*	p1;
 	patch_t*	p2;
-	const size_t name_len = 10;
+	const size_t name_len = 14;
 	char	name[name_len];
 	int		stage;
 

--- a/doomclassic/doom/hu_stuff.cpp
+++ b/doomclassic/doom/hu_stuff.cpp
@@ -319,7 +319,7 @@ void HU_Init( void )
 
 	int		i;
 	int		j;
-	const size_t buffer_len = 9;
+	const size_t buffer_len = 17;
 	char	buffer[buffer_len];
 
 	shiftxform = english_shiftxform;

--- a/neo/idlib/containers/List.h
+++ b/neo/idlib/containers/List.h
@@ -32,6 +32,7 @@ If you have questions concerning this license or the applicable additional terms
 
 #include <new>
 #include <initializer_list>
+#include <algorithm>	// SRS - Needed for clang 14 so std::copy() is defined
 
 /*
 ===============================================================================


### PR DESCRIPTION
Fixes the following:

1. Missing def for `std::copy()` with clang 14+ (macOS Monterey). Include STL `<algorithm>` to resolve issue.
2. `snprintf()` buffer length compile errors with gcc 12.2 (linux Manjaro).  Increased buffer lengths to resolve issue.
     (e.g. _error: 'snprintf' output may be truncated before the last format character [-Werror=format-truncation=], note: 'snprintf' output between 5 and 14 bytes into a destination of size 10_)


Tested the above for compatibility on Windows, linux Manjaro, and macOS Monterey (Intel and Apple Silicon).