### PR TITLE
Build fixes

### DIFF
--- a/neo/renderer/BinaryImage.h
+++ b/neo/renderer/BinaryImage.h
@@ -104,6 +104,17 @@ private:
 			memcpy( data, other.data, other.dataSize );
 			return *this;
 		}
+		idBinaryImageData& operator=( idBinaryImageData&& other )
+		{
+			if( this == &other )
+			{
+				return *this;
+			}
+			dataSize = other.dataSize;
+			data = other.data;
+			other.data = NULL;
+			return *this;
+		}
 		void Free()
 		{
 			if( data != NULL )

--- a/neo/renderer/Cinematic.cpp
+++ b/neo/renderer/Cinematic.cpp
@@ -2808,7 +2808,7 @@ fill_input_buffer( j_decompress_ptr cinfo )
  */
 
 #ifdef USE_NEWER_JPEG
-	METHODDEF()
+	METHODDEF(void)
 #else
 	METHODDEF void
 #endif
@@ -2836,7 +2836,7 @@ init_source( j_decompress_ptr cinfo )
  */
 
 #ifdef USE_NEWER_JPEG
-	METHODDEF()
+	METHODDEF(void)
 #else
 	METHODDEF void
 #endif
@@ -2876,7 +2876,7 @@ skip_input_data( j_decompress_ptr cinfo, long num_bytes )
  */
 
 #ifdef USE_NEWER_JPEG
-	METHODDEF()
+	METHODDEF(void)
 #else
 	METHODDEF void
 #endif
@@ -2887,7 +2887,7 @@ term_source( j_decompress_ptr cinfo )
 }
 
 #ifdef USE_NEWER_JPEG
-	GLOBAL()
+	GLOBAL(void)
 #else
 	GLOBAL void
 #endif

--- a/neo/swf/SWF.h
+++ b/neo/swf/SWF.h
@@ -50,6 +50,7 @@ public:
 	idSWFDictionaryEntry();
 	~idSWFDictionaryEntry();
 	idSWFDictionaryEntry& operator=( idSWFDictionaryEntry& other );
+	idSWFDictionaryEntry& operator=( idSWFDictionaryEntry&& other );
 
 	swfDictType_t		type;
 	const idMaterial* 	material;

--- a/neo/swf/SWF_Bitstream.cpp
+++ b/neo/swf/SWF_Bitstream.cpp
@@ -86,6 +86,33 @@ idSWFBitStream& idSWFBitStream::operator=( idSWFBitStream& other )
 
 /*
 ========================
+idSWFBitStream::operator=
+========================
+*/
+idSWFBitStream& idSWFBitStream::operator=( idSWFBitStream&& other )
+{
+	Free();
+	free = other.free;
+	startp = other.startp;
+	readp = other.readp;
+	endp = other.endp;
+	currentBit = other.currentBit;
+	currentByte = other.currentByte;
+	if( other.free )
+	{
+		// this is actually quite dangerous, but we need to do this
+		// because these things are copied around inside idList
+		other.free = false;
+	}
+	other.readp = NULL;
+	other.endp = NULL;
+	other.currentBit = 0;
+	other.currentByte = 0;
+	return *this;
+}
+
+/*
+========================
 idSWFBitStream::Free
 ========================
 */

--- a/neo/swf/SWF_Bitstream.h
+++ b/neo/swf/SWF_Bitstream.h
@@ -43,6 +43,7 @@ public:
 	}
 
 	idSWFBitStream& operator=( idSWFBitStream& other );
+	idSWFBitStream& operator=( idSWFBitStream&& other );
 
 	void			Load( const byte* data, uint32 len, bool copy );
 	void			Free();

--- a/neo/swf/SWF_Dictionary.cpp
+++ b/neo/swf/SWF_Dictionary.cpp
@@ -90,6 +90,32 @@ idSWFDictionaryEntry& idSWFDictionaryEntry::operator=( idSWFDictionaryEntry& oth
 
 /*
 ========================
+idSWF::idSWFDictionaryEntry::operator= (move)
+========================
+*/
+idSWFDictionaryEntry& idSWFDictionaryEntry::operator=( idSWFDictionaryEntry&& other )
+{
+	type = other.type;
+	material = other.material;
+	shape = other.shape;
+	sprite = other.sprite;
+	font = other.font;
+	text = other.text;
+	edittext = other.edittext;
+	imageSize = other.imageSize;
+	imageAtlasOffset = other.imageAtlasOffset;
+	other.type = SWF_DICT_NULL;
+	other.material = NULL;
+	other.shape = NULL;
+	other.sprite = NULL;
+	other.font = NULL;
+	other.text = NULL;
+	other.edittext = NULL;
+	return *this;
+}
+
+/*
+========================
 idSWF::AddDictionaryEntry
 ========================
 */


### PR DESCRIPTION
I ran into #708 when trying to build on Arch Linux, and eyeballed a fix. `idSWFDictionaryEntry` might be replaceable with a default move constructor; I didn't think too hard about it.

I also ran into a build issue that fell out of fd6c589 that only appears when the vendoring is not used, which is presently the case for the current AUR package; I eyeballed a fix for that too.

Smoke-testing by running on my Steam Deck for a bit.