### PR TITLE
Clean up NVRHI shutdown to eliminate errors on exit, fix SDL device shutdown

### DIFF
--- a/neo/renderer/ImageManager.cpp
+++ b/neo/renderer/ImageManager.cpp
@@ -785,7 +785,7 @@ void idImageManager::Shutdown()
 	deferredImages.DeleteContents( true );
 	deferredImageHash.Clear();
 #if defined( USE_NVRHI )
-	commandList = nullptr;
+	commandList.Reset();
 #endif
 }
 

--- a/neo/renderer/ImageManager.cpp
+++ b/neo/renderer/ImageManager.cpp
@@ -784,6 +784,9 @@ void idImageManager::Shutdown()
 	imageHash.Clear();
 	deferredImages.DeleteContents( true );
 	deferredImageHash.Clear();
+#if defined( USE_NVRHI )
+	commandList = nullptr;
+#endif
 }
 
 /*

--- a/neo/renderer/ImmediateMode.cpp
+++ b/neo/renderer/ImmediateMode.cpp
@@ -67,6 +67,12 @@ void fhImmediateMode::Init( nvrhi::ICommandList* commandList )
 	InitBuffers( commandList );
 }
 
+void fhImmediateMode::Shutdown()
+{
+	vertexBuffer.FreeBufferObject();
+	indexBuffer.FreeBufferObject();
+}
+
 void fhImmediateMode::ResetStats()
 {
 	drawCallCount = 0;

--- a/neo/renderer/ImmediateMode.h
+++ b/neo/renderer/ImmediateMode.h
@@ -73,6 +73,7 @@ public:
 	static void AddTrianglesFromPolygon( fhImmediateMode& im, const idVec3* xyz, int num );
 
 	static void Init( nvrhi::ICommandList* commandList );
+	static void Shutdown();
 	static void ResetStats();
 	static int DrawCallCount();
 	static int DrawCallVertexSize();

--- a/neo/renderer/ModelManager.cpp
+++ b/neo/renderer/ModelManager.cpp
@@ -286,6 +286,9 @@ void idRenderModelManagerLocal::Shutdown()
 {
 	models.DeleteContents( true );
 	hash.Free();
+#if defined( USE_NVRHI )
+	commandList.Reset();
+#endif
 }
 
 /*

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -199,8 +199,32 @@ void idRenderBackend::Init()
 
 void idRenderBackend::Shutdown()
 {
-	delete ssaoPass;
+	// SRS - Clean up NVRHI resources before Sys_Quit(), otherwise non-zero exit code (destructors too late)
+	
+	// Clear all cached pipeline data
+	tr.backend.ClearCaches();
+	
+	// Delete all renderpass resources
+	commonPasses.Shutdown();
+	
+	// Delete current binding sets
+	for( int i = 0; i < currentBindingSets.Num(); i++ )
+	{
+		currentBindingSets[i].Reset();
+	}
 
+	// Unload shaders, delete binding layouts, and unmap memory
+	renderProgManager.Shutdown();
+
+	// Delete renderlog command buffer and timer query resources
+	renderLog.Shutdown();
+	
+	// Delete command list
+	commandList.Reset();
+	
+	// Delete immediate mode buffer objects
+	fhImmediateMode::Shutdown();
+	
 #if defined( VULKAN_USE_PLATFORM_SDL )
 	VKimp_Shutdown();
 #else

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -203,6 +203,7 @@ void idRenderBackend::Shutdown()
 	
 	// Clear all cached pipeline data
 	tr.backend.ClearCaches();
+	pipelineCache.Shutdown();
 	
 	// Delete all renderpass resources
 	commonPasses.Shutdown();

--- a/neo/renderer/Passes/CommonPasses.cpp
+++ b/neo/renderer/Passes/CommonPasses.cpp
@@ -209,6 +209,9 @@ void CommonRenderPasses::Shutdown()
 	m_AnisotropicClampEdgeSampler = nullptr;
 
 	m_BlitBindingLayout = nullptr;
+	
+	// SRS - Remove reference to nvrhi::IDevice, otherwise won't clean up properly on shutdown
+	m_Device = nullptr;
 }
 
 void CommonRenderPasses::BlitTexture( nvrhi::ICommandList* commandList, const BlitParameters& params, BindingCache* bindingCache )

--- a/neo/renderer/Passes/CommonPasses.cpp
+++ b/neo/renderer/Passes/CommonPasses.cpp
@@ -177,6 +177,40 @@ void CommonRenderPasses::Init( nvrhi::IDevice* device )
 	}
 }
 
+void CommonRenderPasses::Shutdown()
+{
+	// SRS - Delete the pipelines referenced by the blit cache
+	for( auto& [key, pipeline] : m_BlitPsoCache )
+	{
+		   pipeline.Reset();
+	}
+
+	// SRS - These assets have automatic resource management with overloaded = operator
+	m_RectVS = nullptr;
+	m_BlitPS = nullptr;
+	m_BlitArrayPS = nullptr;
+	m_SharpenPS = nullptr;
+	m_SharpenArrayPS = nullptr;
+
+	m_BlackTexture = nullptr;
+	m_GrayTexture = nullptr;
+	m_WhiteTexture = nullptr;
+	m_BlackTexture2DArray = nullptr;
+	m_WhiteTexture2DArray = nullptr;
+	m_BlackCubeMapArray = nullptr;
+
+	m_PointClampSampler = nullptr;
+	m_PointWrapSampler = nullptr;
+	m_LinearClampSampler = nullptr;
+	m_LinearBorderSampler = nullptr;
+	m_LinearClampCompareSampler = nullptr;
+	m_LinearWrapSampler = nullptr;
+	m_AnisotropicWrapSampler = nullptr;
+	m_AnisotropicClampEdgeSampler = nullptr;
+
+	m_BlitBindingLayout = nullptr;
+}
+
 void CommonRenderPasses::BlitTexture( nvrhi::ICommandList* commandList, const BlitParameters& params, BindingCache* bindingCache )
 {
 	assert( commandList );

--- a/neo/renderer/Passes/CommonPasses.h
+++ b/neo/renderer/Passes/CommonPasses.h
@@ -134,6 +134,7 @@ public:
 	CommonRenderPasses();
 
 	void	Init( nvrhi::IDevice* device );
+	void	Shutdown();
 
 	void	BlitTexture( nvrhi::ICommandList* commandList, const BlitParameters& params, BindingCache* bindingCache = nullptr );
 

--- a/neo/renderer/PipelineCache.cpp
+++ b/neo/renderer/PipelineCache.cpp
@@ -43,6 +43,12 @@ void PipelineCache::Init( nvrhi::DeviceHandle deviceHandle )
 	device = deviceHandle;
 }
 
+void PipelineCache::Shutdown()
+{
+	// SRS - Remove reference to nvrhi::IDevice, otherwise won't clean up properly on shutdown
+	device = nullptr;
+}
+
 void PipelineCache::Clear()
 {
 	pipelines.Clear();

--- a/neo/renderer/PipelineCache.h
+++ b/neo/renderer/PipelineCache.h
@@ -69,6 +69,7 @@ public:
 	PipelineCache();
 
 	void Init( nvrhi::DeviceHandle deviceHandle );
+	void Shutdown();
 
 	void Clear();
 

--- a/neo/renderer/RenderLog.cpp
+++ b/neo/renderer/RenderLog.cpp
@@ -332,6 +332,21 @@ void idRenderLog::Init()
 #endif
 }
 
+void idRenderLog::Shutdown()
+{
+#if defined( USE_NVRHI )
+	if( commandList )
+	{
+		commandList.Reset();
+	}
+
+	for( int i = 0; i < MRB_TOTAL_QUERIES; i++ )
+	{
+		timerQueries[i].Reset();
+	}
+#endif
+}
+
 void idRenderLog::StartFrame( nvrhi::ICommandList* _commandList )
 {
 #if defined( USE_NVRHI )

--- a/neo/renderer/RenderLog.h
+++ b/neo/renderer/RenderLog.h
@@ -90,6 +90,7 @@ public:
 	idRenderLog();
 
 	void		Init();
+	void		Shutdown();
 
 	void		StartFrame( nvrhi::ICommandList* _commandList );
 	void		EndFrame();

--- a/neo/renderer/RenderProgs.cpp
+++ b/neo/renderer/RenderProgs.cpp
@@ -769,6 +769,29 @@ idRenderProgManager::Shutdown()
 void idRenderProgManager::Shutdown()
 {
 	KillAllShaders();
+	
+#if defined( USE_NVRHI )
+	// SRS - Delete renderprogs builtin binding layouts
+	for( int i = 0; i < renderProgs.Num(); i++ )
+	{
+		for( int j = 0; j < renderProgs[i].bindingLayouts.Num(); j++ )
+		{
+			renderProgs[i].bindingLayouts[j].Reset();
+		}
+	}
+	
+	// SRS - Delete binding layouts
+	for( int i = 0; i < bindingLayouts.Num(); i++ )
+	{
+		for( int j = 0; j < bindingLayouts[i].Num(); j++ )
+		{
+			bindingLayouts[i][j].Reset();
+		}
+	}
+	
+	// SRS - Unmap buffer memory using overloaded = operator
+	constantBuffer = nullptr;
+#endif
 }
 
 /*

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -2284,6 +2284,10 @@ void idRenderSystemLocal::Shutdown()
 
 	Clear();
 
+#if defined( USE_NVRHI )
+	commandList.Reset();
+#endif
+
 	ShutdownOpenGL();
 
 	bInitialized = false;

--- a/neo/sys/sdl/DeviceManager_VK.cpp
+++ b/neo/sys/sdl/DeviceManager_VK.cpp
@@ -1083,6 +1083,20 @@ void DeviceManager_VK::DestroyDeviceAndSwapChain()
 
 	m_BarrierCommandList = nullptr;
 
+	while( m_FramesInFlight.size() > 0 )
+	{
+		auto query = m_FramesInFlight.front();
+		m_FramesInFlight.pop();
+		query = nullptr;
+	}
+
+	if( !m_QueryPool.empty() )
+	{
+		auto query = m_QueryPool.back();
+		m_QueryPool.pop_back();
+		query = nullptr;
+	}
+
 	m_NvrhiDevice = nullptr;
 	m_ValidationLayer = nullptr;
 	m_RendererString.clear();

--- a/neo/sys/sdl/sdl_vkimp.cpp
+++ b/neo/sys/sdl/sdl_vkimp.cpp
@@ -534,12 +534,6 @@ bool VKimp_SetScreenParms( glimpParms_t parms )
 void DeviceManager::Shutdown()
 {
 	DestroyDeviceAndSwapChain();
-
-	// destroy window
-	VKimp_Shutdown();
-
-	// restore gamma
-	//VKimp_RestoreGamma();
 }
 #endif
 
@@ -552,6 +546,13 @@ void VKimp_Shutdown()
 {
 	common->Printf( "Shutting down Vulkan subsystem\n" );
 
+#if defined( USE_NVRHI )
+	if( deviceManager )
+	{
+		deviceManager->Shutdown();
+	}
+#endif
+	
 	if( window )
 	{
 		SDL_DestroyWindow( window );


### PR DESCRIPTION
**UPDATE**: was able to test on linux by setting com_showFPS to 0 or 1 (not 2), updated comments in bold below:

Vulkan backend throws validation errors on exit with **linux**, macOS and Windows. **On linux, quitting the game terminates abnormally with a segfault and core dump**.  On macOS, quitting the game terminates abnormally with non-zero exit code and NVRHI destructors still in flight while executing `Sys_Quit()`. ~~Can't observe on linux yet since game dies after splash screen and can't test.~~ Problem is magnified when r_useValidationLayers = 2.

Issues are caused by:

1. Dangling and/or duplicate resource refs in the code as refcounted by NVRHI, especially to `nvrhi::IDevice`
2. Logic error in `VKimp_Shutdown()` preventing proper execution of `deviceManager->Shutdown()` with SDL backend

This pull request deletes resources on shutdown so NVRHI public asset reference counts are zero before calling `m_NvrhiDevice = nullptr`, then `m_VulkanDevice.destroy()` and finally `Sys_Quit()`. Logic error in SDL backend shutdown code also fixed.

Fixes issue #717.  Tested on Windows 10, **Manjaro linux**, and macOS Monterey.

Positive outcome is that linux and macOS are effectively at the same point now.  Both can run up to initial game selection screen (Doom3 vs. Classic) and can exit normally from there.  Proceeding to a game selection results in a fault due to drawing outside of a renderpass.  This is the next thing I will work on for linux and macOS.