### PR TITLE
[NVRHI] Build-time performance improvement for precompiled headers

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -1766,23 +1766,6 @@ else()
 				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 				COMMENT "Creating idlib/precompiled.h.gch for RBDoom3BFG"
 				)
-	endif()
-	
-	if(WIN32)
-		set(remove_command "del")
-	else()
-		set(remove_command "rm")
-	endif()
-	
-	if (USE_PRECOMPILED_HEADERS)
-		# it's ugly enough that the precompiled header binary needs to be in the 
-		# source directory (instead of the build directory), so let's at least
-		# delete it after build.
-		add_custom_target(rm_precomp_header ALL
-				COMMAND ${remove_command} "idlib/precompiled.h.gch"
-				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-				COMMENT "remove idlib/precompiled.h.gch"
-				)
 				
 		# make sure this is run after creating idlib
 		add_dependencies(precomp_header_rbdoom3bfg idlib)
@@ -1797,8 +1780,18 @@ else()
 		# make sure precompiled header is created before executable is compiled
 		add_dependencies(RBDoom3BFG precomp_header_rbdoom3bfg)
 		
+		if(WIN32)
+			set(remove_command "del")
+		else()
+			set(remove_command "rm")
+		endif()
+
 		# make sure precompiled header is deleted after executable is compiled
-		add_dependencies(rm_precomp_header RBDoom3BFG)
+		add_custom_command(TARGET RBDoom3BFG POST_BUILD
+				COMMAND ${remove_command} "idlib/precompiled.h.gch"
+				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+				COMMENT "remove idlib/precompiled.h.gch"
+		)
 	endif()	
 
 	if(NOT WIN32)

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -1131,7 +1131,7 @@ source_group("renderer\\jobs\\staticshadowvolume" FILES ${RENDERER_JOBS_STATICSH
 source_group("renderer\\OpenGL" FILES ${RENDERER_OPENGL_INCLUDES})
 source_group("renderer\\OpenGL" FILES ${RENDERER_OPENGL_SOURCES})
 
-source_group("renderer\\NVRHI" FILES ${RENDERER_NVRHI_INCLUES})
+source_group("renderer\\NVRHI" FILES ${RENDERER_NVRHI_INCLUDES})
 source_group("renderer\\NVRHI" FILES ${RENDERER_NVRHI_SOURCES})
 
 source_group("renderer\\Vulkan" FILES ${RENDERER_VULKAN_INCLUDES})
@@ -1583,10 +1583,6 @@ if(MSVC)
 		list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/renderer/jobs/prelightshadowvolume/PreLightShadowVolume.cpp)
 		list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/renderer/jobs/staticshadowvolume/StaticShadowVolume.cpp)
 		list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/renderer/jobs/ShadowShared.cpp)
-		list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/renderer/RenderLog.cpp)
-		list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/renderer/Vulkan/vma.cpp)
-		#list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES d3xp/gamesys/Class.cpp)
-		list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/framework/precompiled.cpp)
 	
 		#foreach( src_file ${RBDOOM3_PRECOMPILED_SOURCES} )
 		#	message(STATUS "-include precompiled.h for ${src_file}")
@@ -1738,7 +1734,6 @@ else()
 		list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/renderer/jobs/prelightshadowvolume/PreLightShadowVolume.cpp)
 		list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/renderer/jobs/staticshadowvolume/StaticShadowVolume.cpp)
 		list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/renderer/jobs/ShadowShared.cpp)
-		list(REMOVE_ITEM RBDOOM3_PRECOMPILED_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/renderer/RenderLog.cpp)
 
 		foreach( src_file ${RBDOOM3_PRECOMPILED_SOURCES} )
 			#message(STATUS "-include precompiled.h for ${src_file}")

--- a/neo/d3xp/Camera.cpp
+++ b/neo/d3xp/Camera.cpp
@@ -771,7 +771,7 @@ void idCameraAnim::gltfLoadAnim( idStr gltfFileName, idStr animName )
 
 		if( anim == nullptr )
 		{
-			gameLocal.Error( "Missing 'anim.%s' on '%s'", animName, gltfFileName.c_str() );
+			gameLocal.Error( "Missing 'anim.%s' on '%s'", animName.c_str(), gltfFileName.c_str() );
 		}
 
 		cameraCuts.Clear();

--- a/neo/idlib/precompiled.h
+++ b/neo/idlib/precompiled.h
@@ -99,7 +99,7 @@ const int MAX_EXPRESSION_REGISTERS = 4096;
 
 #if defined( USE_NVRHI )
 	#include "nvrhi/nvrhi.h"
-#elif defined(USE_VULKAN)
+#elif defined( USE_VULKAN )
 	#include "../renderer/Vulkan/qvk.h"
 #else
 	#include <GL/glew.h>
@@ -114,6 +114,7 @@ const int MAX_EXPRESSION_REGISTERS = 4096;
 #include "../renderer/RenderSystem.h"
 #include "../renderer/RenderWorld.h"
 #include "../renderer/BindingCache.h"
+#include "../renderer/RenderCommon.h"
 
 // sound engine
 #include "../sound/sound.h"

--- a/neo/renderer/GuiModel.h
+++ b/neo/renderer/GuiModel.h
@@ -43,10 +43,11 @@ struct guiModelSurface_t
 class idRenderMatrix;
 class Framebuffer;
 
-namespace ImGui
-{
-struct ImDrawData;
-}
+// SRS - not needed, causes mismatched types when calling ImGui_RenderDrawLists( ImDrawData* )
+//namespace ImGui
+//{
+//struct ImDrawData;
+//}
 
 struct ImDrawData;
 

--- a/neo/renderer/RenderBackend.h
+++ b/neo/renderer/RenderBackend.h
@@ -127,7 +127,7 @@ void RB_SetVertexColorParms( stageVertexColor_t svc );
 #if defined( USE_VULKAN )
 
 // SRS - Generalized Vulkan SDL platform
-#if defined(VULKAN_USE_PLATFORM_SDL)
+#if defined( VULKAN_USE_PLATFORM_SDL )
 	#include <SDL.h>
 	#include <SDL_vulkan.h>
 #endif
@@ -148,7 +148,7 @@ struct vulkanContext_t
 {
 	// Eric: If on linux, use this to pass SDL_Window pointer to the SDL_Vulkan_* methods not in sdl_vkimp.cpp file.
 // SRS - Generalized Vulkan SDL platform
-#if defined(VULKAN_USE_PLATFORM_SDL)
+#if defined( VULKAN_USE_PLATFORM_SDL )
 	SDL_Window*						sdlWindow = nullptr;
 #endif
 	uint64							frameCounter;

--- a/neo/renderer/RenderCommon.h
+++ b/neo/renderer/RenderCommon.h
@@ -40,27 +40,6 @@ If you have questions concerning this license or the applicable additional terms
 #include "Font.h"
 #include "Framebuffer.h"
 
-#if defined( USE_NVRHI )
-
-	#if USE_DX11 || USE_DX12
-		#include <DXGI.h>
-	#endif
-
-	#if USE_DX11
-		#include <d3d11.h>
-	#endif
-
-	#if USE_DX12
-		#include <d3d12.h>
-	#endif
-
-	#if USE_VK
-		#include <nvrhi/vulkan.h>
-	#endif
-
-	#include <nvrhi/nvrhi.h>
-#endif
-
 // maximum texture units
 const int MAX_PROG_TEXTURE_PARMS	= 16;
 
@@ -1415,15 +1394,14 @@ struct glimpParms_t
 
 // Eric: If on Linux using Vulkan use the sdl_vkimp.cpp methods
 // SRS - Generalized Vulkan SDL platform
-#if defined(VULKAN_USE_PLATFORM_SDL)
+#if defined( VULKAN_USE_PLATFORM_SDL )
 #include <vector>
 
 #define CLAMP(x, lo, hi)    ((x) < (lo) ? (lo) : (x) > (hi) ? (hi) : (x))
-// Helper functions for using SDL2 and Vulkan on Linux.
+// Helper function for using SDL2 and Vulkan on Linux.
 std::vector<const char*> get_required_extensions();
-#if defined( USE_NVRHI )
-	vk::Result CreateSDLWindowSurface( vk::Instance instance, vk::SurfaceKHR* surface );
-#else
+
+#if !defined( USE_NVRHI )
 	extern vulkanContext_t vkcontext;
 #endif
 

--- a/neo/renderer/RenderLog.cpp
+++ b/neo/renderer/RenderLog.cpp
@@ -26,7 +26,7 @@ If you have questions concerning this license or the applicable additional terms
 
 ===========================================================================
 */
-#include "RenderCommon.h"
+#include "precompiled.h"
 #pragma hdrstop
 
 #if defined( USE_NVRHI )

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -1516,7 +1516,7 @@ void R_SetColorMappings()
 		tr.gammaTable[i] = idMath::ClampInt( 0, 0xFFFF, inf );
 	}
 // SRS - Generalized Vulkan SDL platform
-#if defined(VULKAN_USE_PLATFORM_SDL)
+#if defined( VULKAN_USE_PLATFORM_SDL )
 	VKimp_SetGamma( tr.gammaTable, tr.gammaTable, tr.gammaTable );
 #else
 	GLimp_SetGamma( tr.gammaTable, tr.gammaTable, tr.gammaTable );

--- a/neo/sys/DeviceManager.h
+++ b/neo/sys/DeviceManager.h
@@ -132,7 +132,7 @@ class DeviceManager
 public:
 	static DeviceManager* Create( nvrhi::GraphicsAPI api );
 
-#if defined( USE_VK ) && defined( VULKAN_USE_PLATFORM_SDL )
+#if USE_VK && defined( VULKAN_USE_PLATFORM_SDL )
 	// SRS - Helper method for creating SDL Vulkan surface within DeviceManager_VK()
     vk::Result CreateSDLWindowSurface( vk::Instance instance, vk::SurfaceKHR* surface );
 #endif

--- a/neo/sys/DeviceManager.h
+++ b/neo/sys/DeviceManager.h
@@ -30,7 +30,21 @@ If you have questions concerning this license or the applicable additional terms
 #ifndef SYS_DEVICE_MANAGER_H_
 #define SYS_DEVICE_MANAGER_H_
 
-#include "renderer/RenderCommon.h"
+#if USE_DX11 || USE_DX12
+	#include <DXGI.h>
+#endif
+
+#if USE_DX11
+	#include <d3d11.h>
+#endif
+
+#if USE_DX12
+	#include <d3d12.h>
+#endif
+
+#if USE_VK
+	#include <nvrhi/vulkan.h>
+#endif
 
 struct DeviceCreationParameters
 {
@@ -117,6 +131,11 @@ class DeviceManager
 {
 public:
 	static DeviceManager* Create( nvrhi::GraphicsAPI api );
+
+#if defined( USE_VK ) && defined( VULKAN_USE_PLATFORM_SDL )
+	// SRS - Helper method for creating SDL Vulkan surface within DeviceManager_VK()
+    vk::Result CreateSDLWindowSurface( vk::Instance instance, vk::SurfaceKHR* surface );
+#endif
 
 	bool CreateWindowDeviceAndSwapChain( const glimpParms_t& params, const char* windowTitle );
 

--- a/neo/sys/DeviceManager_VK.cpp
+++ b/neo/sys/DeviceManager_VK.cpp
@@ -27,6 +27,7 @@
 #include <queue>
 #include <unordered_set>
 
+#include "renderer/RenderCommon.h"
 #include <sys/DeviceManager.h>
 
 #include <nvrhi/vulkan.h>

--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -853,7 +853,7 @@ void Sys_GrabMouseCursor( bool grabIt )
 		flags = GRAB_SETSTATE;
 	}
 // SRS - Generalized Vulkan SDL platform
-#if defined(VULKAN_USE_PLATFORM_SDL)
+#if defined( VULKAN_USE_PLATFORM_SDL )
 	VKimp_GrabInput( flags );
 #else
 	GLimp_GrabInput( flags );

--- a/neo/sys/sdl/sdl_local.h
+++ b/neo/sys/sdl/sdl_local.h
@@ -36,7 +36,7 @@ const int GRAB_HIDECURSOR	= ( 1 << 2 );
 const int GRAB_SETSTATE		= ( 1 << 3 );
 
 // SRS - Generalized Vulkan SDL platform
-#if defined(VULKAN_USE_PLATFORM_SDL)
+#if defined( VULKAN_USE_PLATFORM_SDL )
 	void VKimp_GrabInput( int flags );
 #else
 	void GLimp_GrabInput( int flags );

--- a/neo/sys/sdl/sdl_vkimp.cpp
+++ b/neo/sys/sdl/sdl_vkimp.cpp
@@ -89,8 +89,8 @@ std::vector<const char*> get_required_extensions()
 }
 
 #if defined( USE_NVRHI )
-// SRS - Helper function for creating SDL Vulkan surface within DeviceManager_VK() when NVRHI enabled
-vk::Result CreateSDLWindowSurface( vk::Instance instance, vk::SurfaceKHR* surface )
+// SRS - Helper method for creating SDL Vulkan surface within DeviceManager_VK() when NVRHI enabled
+vk::Result DeviceManager::CreateSDLWindowSurface( vk::Instance instance, vk::SurfaceKHR* surface )
 {
 	if( !SDL_Vulkan_CreateSurface( window, ( VkInstance )instance, ( VkSurfaceKHR* )surface ) )
 	{

--- a/neo/ui/DeviceContext.cpp
+++ b/neo/ui/DeviceContext.cpp
@@ -32,7 +32,7 @@ If you have questions concerning this license or the applicable additional terms
 #include "DeviceContext.h"
 
 #include "libs/imgui/imgui.h"
-#include "../renderer/GuiModel.h"
+#include "../renderer/RenderCommon.h"
 
 extern idCVar in_useJoystick;
 


### PR DESCRIPTION
**UPDATE: retargeted to master now that 635-nvrhi5 has been merged, results should be similar**

Here is a small present for the season:

I noticed that PCH build performance was limited in the NVRHI stream. Having a deeper look showed that `precompiled.h` could be improved by adding `RenderCommon.h`, however some restructuring of renderer-specific library includes (e.g. `d3d12.h`, `nvrhi/vulkan.h`, etc) would be needed. A positive side-effect is that it cleans up and restricts the location of the **USE_DX12**, **USE_VK**, etc. defines and related includes to `DeviceManager.h` and `DeviceManager_<renderer>.cpp`.

Here is the result of that work and the results are significant. The data below are fresh builds including shader compile time:

Windows 10 build using VS2019:
Before: 97 seconds
After: **52 seconds**

Linux (Manjaro) build using Code:Blocks/clang**:
Before: 113 seconds
After: **74 seconds**

macOS Monterey build using Xcode 13/clang:
Before: 120 seconds
After: **63 seconds**

** Note: Linux timings were measured when booting off a USB stick, so absolute results may be better on a real SSD

Overall the results look good, with an almost 2x improvement in build time for Windows and macOS. Linux data is TBD pending verification on a machine with an SSD build drive.

Also fixes a minor `c_str()` issue inside `idCameraAnim::gltfLoadAnim()`, otherwise clang complains.

Merry Christmas to all!

**UPDATE**: Simplify **precompiled.h.gch** cleanup using cmake custom command vs. a custom target.  This makes the code simpler and works more reliably cross platform for linux/macOS.