### PR TITLE
Fix legacy SSAO for NVRHI Vulkan and implement new compute shader alternative

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -1817,13 +1817,24 @@ else()
 			set(remove_command "rm")
 		endif()
 
-		# make sure precompiled header is deleted after executable is compiled
-		add_custom_command(TARGET RBDoom3BFG POST_BUILD
-				COMMAND ${remove_command} "idlib/precompiled.h.gch"
-				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-				COMMENT "remove idlib/precompiled.h.gch"
-		)
-	endif()	
+		# delete precompiled header file after executable is compiled: command line build case
+		if(CMAKE_GENERATOR MATCHES "Makefiles" OR CMAKE_GENERATOR MATCHES "Ninja")
+			add_custom_target(rm_precomp_header ALL
+					COMMAND ${remove_command} "idlib/precompiled.h.gch"
+					WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+					COMMENT "remove idlib/precompiled.h.gch"
+					)
+			add_dependencies(rm_precomp_header RBDoom3BFG)
+
+		# delete precompiled header file after executable is compiled: IDE build case (e.g. Xcode)
+		else()
+			add_custom_command(TARGET RBDoom3BFG POST_BUILD
+					COMMAND ${remove_command} "idlib/precompiled.h.gch"
+					WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+					COMMENT "remove idlib/precompiled.h.gch"
+			)
+		endif()
+	endif()
 
 	if(NOT WIN32)
         if(NOT APPLE)

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -348,6 +348,7 @@ else (JPEG_FOUND)
     set(JPEG_LIBRARY "" )
 endif (JPEG_FOUND)
 
+include_directories("libs/imgui")
 
 macro(SET_OPTION option value)
   set(${option} ${value} CACHE "" INTERNAL FORCE)

--- a/neo/imgui/BFGimgui.h
+++ b/neo/imgui/BFGimgui.h
@@ -2,7 +2,7 @@
 #ifndef NEO_IMGUI_BFGIMGUI_H_
 #define NEO_IMGUI_BFGIMGUI_H_
 
-#include "libs/imgui/imgui.h"
+#include "imgui.h"
 
 #include "../idlib/math/Vector.h"
 

--- a/neo/renderer/GuiModel.cpp
+++ b/neo/renderer/GuiModel.cpp
@@ -32,7 +32,7 @@ If you have questions concerning this license or the applicable additional terms
 #pragma hdrstop
 
 #include "RenderCommon.h"
-#include "libs/imgui/imgui.h"
+#include "imgui.h"
 
 const float idGuiModel::STEREO_DEPTH_NEAR = 0.0f;
 const float idGuiModel::STEREO_DEPTH_MID  = 0.5f;

--- a/neo/renderer/Image_intrinsic.cpp
+++ b/neo/renderer/Image_intrinsic.cpp
@@ -1101,8 +1101,8 @@ void idImageManager::CreateIntrinsicImages()
 
 	gbufferNormalsRoughnessImage = ImageFromFunction( "_currentNormals", R_GeometryBufferImage_ResNative );
 
-	ambientOcclusionImage[0] = ImageFromFunction( "_ao0", R_SMAAImage_ResNative );
-	ambientOcclusionImage[1] = ImageFromFunction( "_ao1", R_SMAAImage_ResNative );
+	ambientOcclusionImage[0] = ImageFromFunction( "_ao0", R_AmbientOcclusionImage_ResNative );
+	ambientOcclusionImage[1] = ImageFromFunction( "_ao1", R_AmbientOcclusionImage_ResNative );
 
 	hierarchicalZbufferImage = ImageFromFunction( "_cszBuffer", R_HierarchicalZBufferImage_ResNative );
 

--- a/neo/renderer/Image_intrinsic.cpp
+++ b/neo/renderer/Image_intrinsic.cpp
@@ -31,7 +31,7 @@ If you have questions concerning this license or the applicable additional terms
 #include "precompiled.h"
 #pragma hdrstop
 
-#include "libs/imgui/imgui.h"
+#include "imgui.h"
 
 #include "RenderCommon.h"
 #include "SMAA/AreaTex.h"

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -249,12 +249,6 @@ void idRenderBackend::Init()
 	currentJointOffset = 0;
 	prevBindingLayoutType = -1;
 
-	// RB: FIXME but for now disable it to avoid validation errors
-	if( deviceManager->GetGraphicsAPI() == nvrhi::GraphicsAPI::VULKAN )
-	{
-		r_useSSAO.SetBool( false );
-	}
-
 	deviceManager->GetDevice()->waitForIdle();
 	deviceManager->GetDevice()->runGarbageCollection();
 }
@@ -1858,12 +1852,6 @@ void idRenderBackend::CheckCVars()
 		r_antiAliasing.ClearModified();
 	}
 #endif
-
-	// RB: FIXME but for now disable it to avoid validation errors
-	if( deviceManager->GetGraphicsAPI() == nvrhi::GraphicsAPI::VULKAN )
-	{
-		r_useSSAO.SetBool( false );
-	}
 }
 
 /*

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -35,7 +35,7 @@ If you have questions concerning this license or the applicable additional terms
 #include "../RenderCommon.h"
 #include "../RenderBackend.h"
 #include "../../framework/Common_local.h"
-#include "../../imgui/imgui.h"
+#include "imgui.h"
 #include "../ImmediateMode.h"
 
 #include "nvrhi/utils.h"

--- a/neo/renderer/Passes/SsaoPass.cpp
+++ b/neo/renderer/Passes/SsaoPass.cpp
@@ -34,8 +34,13 @@ If you have questions concerning this license or the applicable additional terms
 
 struct SsaoConstants
 {
-	idVec2i		viewportOrigin;
-	idVec2i		viewportSize;
+	idVec2		viewportOrigin;
+	idVec2		viewportSize;
+
+	idVec4		modelMatrixX;
+	idVec4		modelMatrixY;
+	idVec4		modelMatrixZ;
+	idVec4 		modelMatrixW;
 
 	idVec2      clipToView;
 	idVec2      invQuantizedGbufferSize;
@@ -244,8 +249,9 @@ void SsaoPass::Render(
 	quarterResExtent.maxY = ( quarterResExtent.maxY + 3 ) / 4;
 
 	SsaoConstants ssaoConstants = {};
-	ssaoConstants.viewportOrigin = idVec2i( viewDef->viewport.x1, viewDef->viewport.y1 );
-	ssaoConstants.viewportSize = idVec2i( viewDef->viewport.GetWidth(), viewDef->viewport.GetHeight() );
+	ssaoConstants.viewportOrigin = idVec2( viewDef->viewport.x1, viewDef->viewport.y1 );
+	ssaoConstants.viewportSize = idVec2( viewDef->viewport.GetWidth(), viewDef->viewport.GetHeight() );
+	idRenderMatrix::CopyMatrix( *( idRenderMatrix* )viewDef->worldSpace.modelMatrix, ssaoConstants.modelMatrixX, ssaoConstants.modelMatrixY, ssaoConstants.modelMatrixZ, ssaoConstants.modelMatrixW );
 	ssaoConstants.clipToView = idVec2(
 								   viewDef->projectionMatrix[2 * 4 + 3] / viewDef->projectionMatrix[0 * 4 + 0],
 								   viewDef->projectionMatrix[2 * 4 + 3] / viewDef->projectionMatrix[1 * 4 + 1] );

--- a/neo/renderer/Passes/SsaoPass.cpp
+++ b/neo/renderer/Passes/SsaoPass.cpp
@@ -36,11 +36,10 @@ struct SsaoConstants
 {
 	idVec2		viewportOrigin;
 	idVec2		viewportSize;
-
-	idVec4		modelMatrixX;
-	idVec4		modelMatrixY;
-	idVec4		modelMatrixZ;
-	idVec4 		modelMatrixW;
+	
+	idRenderMatrix matClipToView;
+	idRenderMatrix matWorldToView;
+	idRenderMatrix matViewToWorld;
 
 	idVec2      clipToView;
 	idVec2      invQuantizedGbufferSize;
@@ -251,7 +250,13 @@ void SsaoPass::Render(
 	SsaoConstants ssaoConstants = {};
 	ssaoConstants.viewportOrigin = idVec2( viewDef->viewport.x1, viewDef->viewport.y1 );
 	ssaoConstants.viewportSize = idVec2( viewDef->viewport.GetWidth(), viewDef->viewport.GetHeight() );
-	idRenderMatrix::CopyMatrix( *( idRenderMatrix* )viewDef->worldSpace.modelMatrix, ssaoConstants.modelMatrixX, ssaoConstants.modelMatrixY, ssaoConstants.modelMatrixZ, ssaoConstants.modelMatrixW );
+
+	// SRS - FIXME: These transformations need to be verified
+	ssaoConstants.matClipToView = viewDef->unprojectionToCameraRenderMatrix;
+	ssaoConstants.matViewToWorld = viewDef->unprojectionToWorldRenderMatrix;
+	idRenderMatrix::Inverse( ssaoConstants.matViewToWorld, ssaoConstants.matWorldToView );
+	// SRS end
+
 	ssaoConstants.clipToView = idVec2(
 								   viewDef->projectionMatrix[2 * 4 + 3] / viewDef->projectionMatrix[0 * 4 + 0],
 								   viewDef->projectionMatrix[2 * 4 + 3] / viewDef->projectionMatrix[1 * 4 + 1] );

--- a/neo/renderer/Passes/SsaoPass.h
+++ b/neo/renderer/Passes/SsaoPass.h
@@ -93,7 +93,7 @@ public:
 	void Render(
 		nvrhi::ICommandList* commandList,
 		const SsaoParameters& params,
-		viewDef_t* viewDef,
+		const viewDef_t* viewDef,
 		int bindingSetIndex = 0 );
 };
 

--- a/neo/renderer/RenderBackend.cpp
+++ b/neo/renderer/RenderBackend.cpp
@@ -6241,7 +6241,8 @@ void idRenderBackend::DrawScreenSpaceAmbientOcclusion2( const viewDef_t* _viewDe
 	if( !_viewDef->viewEntitys || _viewDef->is2Dgui )
 	{
 		// 3D views only
-		return;
+		// FIXME: Disable for now until flickering problem is solved
+		//return;
 	}
 
 	if( !r_useSSAO.GetBool() )

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -32,7 +32,7 @@ If you have questions concerning this license or the applicable additional terms
 #include "precompiled.h"
 #pragma hdrstop
 
-#include "libs/imgui/imgui.h"
+#include "imgui.h"
 
 #include "RenderCommon.h"
 

--- a/neo/shaders/builtin/SSAO/AmbientOcclusion_AO.ps.hlsl
+++ b/neo/shaders/builtin/SSAO/AmbientOcclusion_AO.ps.hlsl
@@ -93,11 +93,11 @@ static const float projScale = 500.0;
 
 #define VALUE_TYPE float
 
-Texture2D				t_NormalRoughness	: register( t0 VK_DESCRIPTOR_SET( 1 ) );
-Texture2D<VALUE_TYPE>	t_ViewDepth			: register( t1 VK_DESCRIPTOR_SET( 1 ) );
-Texture2D				t_BlueNoise			: register( t2 VK_DESCRIPTOR_SET( 1 ) );
+Texture2D				t_NormalRoughness	: register( t0 VK_DESCRIPTOR_SET( 0 ) );
+Texture2D<VALUE_TYPE>	t_ViewDepth			: register( t1 VK_DESCRIPTOR_SET( 0 ) );
+Texture2D				t_BlueNoise			: register( t2 VK_DESCRIPTOR_SET( 0 ) );
 
-SamplerState	blueNoiseSampler	: register( s0 VK_DESCRIPTOR_SET( 2 ) );
+SamplerState	blueNoiseSampler	: register( s0 VK_DESCRIPTOR_SET( 1 ) );
 
 #define CS_Z_buffer		t_ViewDepth
 

--- a/neo/shaders/builtin/SSAO/AmbientOcclusion_blur.ps.hlsl
+++ b/neo/shaders/builtin/SSAO/AmbientOcclusion_blur.ps.hlsl
@@ -22,9 +22,9 @@
 // *INDENT-OFF*
 #define VALUE_TYPE float
 
-Texture2D				t_NormalRoughness	: register( t0 VK_DESCRIPTOR_SET( 1 ) );
-Texture2D<VALUE_TYPE>	t_ViewDepth			: register( t1 VK_DESCRIPTOR_SET( 1 ) );
-Texture2D				t_Ao				: register( t2 VK_DESCRIPTOR_SET( 1 ) );
+Texture2D				t_NormalRoughness	: register( t0 VK_DESCRIPTOR_SET( 0 ) );
+Texture2D<VALUE_TYPE>	t_ViewDepth			: register( t1 VK_DESCRIPTOR_SET( 0 ) );
+Texture2D				t_Ao				: register( t2 VK_DESCRIPTOR_SET( 0 ) );
 
 #define normal_buffer	t_NormalRoughness
 #define cszBuffer		t_ViewDepth
@@ -103,7 +103,7 @@ float3 sampleNormal( Texture2D normalBuffer, int2 ssC, int mipLevel )
 
 /** Used for preventing AO computation on the sky (at infinite depth) and defining the CS Z to bilateral depth key scaling.
     This need not match the real far plane but should not be much more than it.*/
-const float FAR_PLANE_Z = -16000.0;
+static const float FAR_PLANE_Z = -16000.0;
 
 float CSZToKey( float z )
 {

--- a/neo/shaders/builtin/SSAO/ssao_blur.cs.hlsl
+++ b/neo/shaders/builtin/SSAO/ssao_blur.cs.hlsl
@@ -26,6 +26,9 @@
 
 struct SsaoConstants
 {
+	int2		viewportOrigin;
+	int2		viewportSize;
+
 	float2      clipToView;
 	float2      invQuantizedGbufferSize;
 
@@ -168,10 +171,9 @@ void main( uint2 groupId : SV_GroupID, uint2 threadId : SV_GroupThreadID, uint2 
 #endif
 
 	int2 storePos = int2( globalId.xy ) + g_Ssao.quantizedViewportOrigin;
-	float2 storePosF = float2( storePos );
 
-	//if (all(storePosF >= g_Ssao.view.viewportOrigin.xy) && all(storePosF < g_Ssao.view.viewportOrigin.xy + g_Ssao.view.viewportSize.xy))
-	//{
-	//    u_RenderTarget[storePos] = totalOcclusion;
-	//}
+	if (all(storePos >= g_Ssao.viewportOrigin.xy) && all(storePos < g_Ssao.viewportOrigin.xy + g_Ssao.viewportSize.xy))
+	{
+		u_RenderTarget[storePos] = totalOcclusion;
+	}
 }

--- a/neo/shaders/builtin/SSAO/ssao_blur.cs.hlsl
+++ b/neo/shaders/builtin/SSAO/ssao_blur.cs.hlsl
@@ -26,8 +26,13 @@
 
 struct SsaoConstants
 {
-	int2		viewportOrigin;
-	int2		viewportSize;
+	float2		viewportOrigin;
+	float2		viewportSize;
+
+	float4		modelMatrixX;
+	float4		modelMatrixY;
+	float4		modelMatrixZ;
+	float4 		modelMatrixW;
 
 	float2      clipToView;
 	float2      invQuantizedGbufferSize;
@@ -171,8 +176,9 @@ void main( uint2 groupId : SV_GroupID, uint2 threadId : SV_GroupThreadID, uint2 
 #endif
 
 	int2 storePos = int2( globalId.xy ) + g_Ssao.quantizedViewportOrigin;
+	float2 storePosF = float2( storePos );
 
-	if (all(storePos >= g_Ssao.viewportOrigin.xy) && all(storePos < g_Ssao.viewportOrigin.xy + g_Ssao.viewportSize.xy))
+	if (all(storePosF >= g_Ssao.viewportOrigin.xy) && all(storePosF < g_Ssao.viewportOrigin.xy + g_Ssao.viewportSize.xy))
 	{
 		u_RenderTarget[storePos] = totalOcclusion;
 	}

--- a/neo/shaders/builtin/SSAO/ssao_blur.cs.hlsl
+++ b/neo/shaders/builtin/SSAO/ssao_blur.cs.hlsl
@@ -29,10 +29,9 @@ struct SsaoConstants
 	float2		viewportOrigin;
 	float2		viewportSize;
 
-	float4		modelMatrixX;
-	float4		modelMatrixY;
-	float4		modelMatrixZ;
-	float4 		modelMatrixW;
+	float4x4	matClipToView;
+	float4x4	matWorldToView;
+	float4x4	matViewToWorld;
 
 	float2      clipToView;
 	float2      invQuantizedGbufferSize;

--- a/neo/shaders/builtin/SSAO/ssao_compute.cs.hlsl
+++ b/neo/shaders/builtin/SSAO/ssao_compute.cs.hlsl
@@ -26,8 +26,13 @@
 
 struct SsaoConstants
 {
-	int2		viewportOrigin;
-	int2		viewportSize;
+	float2		viewportOrigin;
+	float2		viewportSize;
+
+	float4		modelMatrixX;
+	float4		modelMatrixY;
+	float4		modelMatrixZ;
+	float4 		modelMatrixW;
 
 	float2      clipToView;
 	float2      invQuantizedGbufferSize;
@@ -172,8 +177,8 @@ float ComputeAO( float3 V, float3 N, float InvR2 )
 
 float2 WindowToClip( float2 windowPos )
 {
-	float2 clipToWindowScale = float2( 0.5f * rpWindowCoord.z, -0.5f * rpWindowCoord.w );
-	float2 clipToWindowBias = rpViewOrigin.xy + rpWindowCoord.zw * 0.5f;
+	float2 clipToWindowScale = float2( 0.5f * g_Ssao.viewportSize.x, -0.5f * g_Ssao.viewportSize.y );
+	float2 clipToWindowBias = g_Ssao.viewportOrigin.xy + g_Ssao.viewportSize.xy * 0.5f;
 
 	float2 windowToClipScale = 1.f / clipToWindowScale;
 	float2 windowToClipBias = -clipToWindowBias * windowToClipScale;
@@ -204,9 +209,9 @@ void main( uint3 globalId : SV_DispatchThreadID )
 
 	// View to clip space.
 	float3 pN;
-	pN.x = dot4( float4( pixelNormal, 0 ), rpModelMatrixX );
-	pN.y = dot4( float4( pixelNormal, 0 ), rpModelMatrixY );
-	pN.z = dot4( float4( pixelNormal, 0 ), rpModelMatrixZ );
+	pN.x = dot4( float4( pixelNormal, 0 ), g_Ssao.modelMatrixX );
+	pN.y = dot4( float4( pixelNormal, 0 ), g_Ssao.modelMatrixY );
+	pN.z = dot4( float4( pixelNormal, 0 ), g_Ssao.modelMatrixZ );
 
 	pixelNormal = normalize( pN );
 
@@ -272,9 +277,9 @@ void main( uint3 globalId : SV_DispatchThreadID )
 	if( directionalLength > 0 )
 	{
 		float3 worldSpaceResult;
-		worldSpaceResult.x = dot4( float4( normalize( result.xyz ), 0 ), rpModelMatrixX );
-		worldSpaceResult.y = dot4( float4( normalize( result.xyz ), 0 ), rpModelMatrixY );
-		worldSpaceResult.z = dot4( float4( normalize( result.xyz ), 0 ), rpModelMatrixZ );
+		worldSpaceResult.x = dot4( float4( normalize( result.xyz ), 0 ), g_Ssao.modelMatrixX );
+		worldSpaceResult.y = dot4( float4( normalize( result.xyz ), 0 ), g_Ssao.modelMatrixY );
+		worldSpaceResult.z = dot4( float4( normalize( result.xyz ), 0 ), g_Ssao.modelMatrixZ );
 
 		result.xyz = worldSpaceResult.xyz * directionalLength;
 	}

--- a/neo/shaders/builtin/SSAO/ssao_compute.cs.hlsl
+++ b/neo/shaders/builtin/SSAO/ssao_compute.cs.hlsl
@@ -26,6 +26,9 @@
 
 struct SsaoConstants
 {
+	int2		viewportOrigin;
+	int2		viewportSize;
+
 	float2      clipToView;
 	float2      invQuantizedGbufferSize;
 

--- a/neo/shaders/builtin/SSAO/ssao_deinterleave.cs.hlsl
+++ b/neo/shaders/builtin/SSAO/ssao_deinterleave.cs.hlsl
@@ -26,8 +26,13 @@
 
 struct SsaoConstants
 {
-	int2		viewportOrigin;
-	int2		viewportSize;
+	float2		viewportOrigin;
+	float2		viewportSize;
+
+	float4		modelMatrixX;
+	float4		modelMatrixY;
+	float4		modelMatrixZ;
+	float4 		modelMatrixW;
 
 	float2      clipToView;
 	float2      invQuantizedGbufferSize;
@@ -72,10 +77,10 @@ void main( uint3 globalId : SV_DispatchThreadID )
 #else
 			float4 clipPos = float4( 0, 0, depth, 1 );
 			float4 viewPos;
-			viewPos.x = dot4( clipPos, rpModelMatrixX );
-			viewPos.y = dot4( clipPos, rpModelMatrixY );
-			viewPos.z = dot4( clipPos, rpModelMatrixZ );
-			viewPos.w = dot4( clipPos, rpModelMatrixW );
+			viewPos.x = dot4( clipPos, g_Ssao.modelMatrixX );
+			viewPos.y = dot4( clipPos, g_Ssao.modelMatrixY );
+			viewPos.z = dot4( clipPos, g_Ssao.modelMatrixZ );
+			viewPos.w = dot4( clipPos, g_Ssao.modelMatrixW );
 
 			float linearDepth = viewPos.z / viewPos.w;
 #endif

--- a/neo/shaders/builtin/SSAO/ssao_deinterleave.cs.hlsl
+++ b/neo/shaders/builtin/SSAO/ssao_deinterleave.cs.hlsl
@@ -29,10 +29,9 @@ struct SsaoConstants
 	float2		viewportOrigin;
 	float2		viewportSize;
 
-	float4		modelMatrixX;
-	float4		modelMatrixY;
-	float4		modelMatrixZ;
-	float4 		modelMatrixW;
+	float4x4	matClipToView;
+	float4x4	matWorldToView;
+	float4x4	matViewToWorld;
 
 	float2      clipToView;
 	float2      invQuantizedGbufferSize;
@@ -76,12 +75,7 @@ void main( uint3 globalId : SV_DispatchThreadID )
 			float linearDepth = depth;
 #else
 			float4 clipPos = float4( 0, 0, depth, 1 );
-			float4 viewPos;
-			viewPos.x = dot4( clipPos, g_Ssao.modelMatrixX );
-			viewPos.y = dot4( clipPos, g_Ssao.modelMatrixY );
-			viewPos.z = dot4( clipPos, g_Ssao.modelMatrixZ );
-			viewPos.w = dot4( clipPos, g_Ssao.modelMatrixW );
-
+			float4 viewPos = mul(clipPos, g_Ssao.matClipToView);
 			float linearDepth = viewPos.z / viewPos.w;
 #endif
 

--- a/neo/shaders/builtin/SSAO/ssao_deinterleave.cs.hlsl
+++ b/neo/shaders/builtin/SSAO/ssao_deinterleave.cs.hlsl
@@ -26,6 +26,9 @@
 
 struct SsaoConstants
 {
+	int2		viewportOrigin;
+	int2		viewportSize;
+
 	float2      clipToView;
 	float2      invQuantizedGbufferSize;
 

--- a/neo/shaders/builtin/mipmapgen.cs.hlsl
+++ b/neo/shaders/builtin/mipmapgen.cs.hlsl
@@ -83,7 +83,7 @@ cbuffer c_MipMapgen : register( b0 )
 	MipmmapGenConstants g_MipMapGen;
 };
 
-RWTexture2D<VALUE_TYPE> u_output[NUM_LODS] : register( u0 );
+RWTexture2D<VALUE_TYPE> u_output[] : register( u0 );
 Texture2D<VALUE_TYPE> t_input : register( t0 );
 // *INDENT-ON*
 

--- a/neo/shaders/builtin/mipmapgen.cs.hlsl
+++ b/neo/shaders/builtin/mipmapgen.cs.hlsl
@@ -83,7 +83,11 @@ cbuffer c_MipMapgen : register( b0 )
 	MipmmapGenConstants g_MipMapGen;
 };
 
+#ifdef __spirv__	// use unbounded array size for proper SPIR-V descriptor binding
 RWTexture2D<VALUE_TYPE> u_output[] : register( u0 );
+#else				// use bounded array for DXIL -flegacy-resource-reservation flag
+RWTexture2D<VALUE_TYPE> u_output[NUM_LODS] : register( u0 );
+#endif
 Texture2D<VALUE_TYPE> t_input : register( t0 );
 // *INDENT-ON*
 

--- a/neo/tools/imgui/util/Imgui_IdWidgets.cpp
+++ b/neo/tools/imgui/util/Imgui_IdWidgets.cpp
@@ -30,7 +30,7 @@ If you have questions concerning this license or the applicable additional terms
 #include "precompiled.h"
 #pragma hdrstop
 
-#include "../imgui/imgui.h"
+#include "imgui.h"
 
 #include "Imgui_IdWidgets.h"
 

--- a/neo/ui/DeviceContext.cpp
+++ b/neo/ui/DeviceContext.cpp
@@ -31,7 +31,7 @@ If you have questions concerning this license or the applicable additional terms
 
 #include "DeviceContext.h"
 
-#include "libs/imgui/imgui.h"
+#include "imgui.h"
 #include "../renderer/RenderCommon.h"
 
 extern idCVar in_useJoystick;


### PR DESCRIPTION
See discussion at #710 

Default is currently set to use legacy SSAO shaders for DX12 and Vulkan.  Set `r_useNewSsaoPass 1` to run with new ssao compute shader.

Also fixes #733, and restores **rm_precomp_header** custom target for makefile/ninja command line builds while retaining custom POST_BUILD remove command for IDEs like Xcode.