### PR TITLE
Fix timers for F12 screenshots and align SDL monitor refresh rates

### DIFF
--- a/neo/framework/Console.cpp
+++ b/neo/framework/Console.cpp
@@ -490,26 +490,12 @@ float idConsoleLocal::DrawFPS( float y )
 		ImGui::TextColored( gameThreadRenderTime > maxTime ? colorRed : colorWhite,			"RF:      %5llu us   SSR:          %5llu us", gameThreadRenderTime, rendererGPU_SSRTime );
 		ImGui::TextColored( rendererBackEndTime > maxTime ? colorRed : colorWhite,			"RB:      %5llu us   Ambient Pass: %5llu us", rendererBackEndTime, rendererGPUAmbientPassTime );
 		ImGui::TextColored( rendererGPUShadowAtlasTime > maxTime ? colorRed : colorWhite,	"Shadows: %5llu us   Shadow Atlas: %5llu us", rendererShadowsTime, rendererGPUShadowAtlasTime );
-		if( renderSystem->IsTakingScreenshot() )
-		{
-			ImGui::TextColored( rendererGPUInteractionsTime > maxTime ? colorRed : colorWhite,	"                    Interactions: %5llu us", rendererGPUInteractionsTime );
-		}
-		else
-		{
-			ImGui::TextColored( rendererGPUInteractionsTime > maxTime ? colorRed : colorWhite,	"Sync:    %5lld us   Interactions: %5llu us", frameSyncTime, rendererGPUInteractionsTime );
-		}
+		ImGui::TextColored( rendererGPUInteractionsTime > maxTime ? colorRed : colorWhite,	"Sync:    %5lld us   Interactions: %5llu us", frameSyncTime, rendererGPUInteractionsTime );
 		ImGui::TextColored( rendererGPUShaderPassesTime > maxTime ? colorRed : colorWhite,	"                    Shader Pass:  %5llu us", rendererGPUShaderPassesTime );
 		ImGui::TextColored( rendererGPU_TAATime > maxTime ? colorRed : colorWhite,			"                    TAA:          %5llu us", rendererGPU_TAATime );
 		ImGui::TextColored( rendererGPUPostProcessingTime > maxTime ? colorRed : colorWhite, "                    PostFX:       %5llu us", rendererGPUPostProcessingTime );
-		if( renderSystem->IsTakingScreenshot() )
-		{
-			ImGui::TextColored( rendererGPUTime > maxTime ? colorRed : colorWhite, "                    Total:        %5lld us", rendererGPUTime );
-		}
-		else
-		{
-			ImGui::TextColored( frameBusyTime > maxTime || rendererGPUTime > maxTime ? colorRed : colorWhite, "Total:   %5lld us   Total:        %5lld us", frameBusyTime, rendererGPUTime );
-			ImGui::TextColored( colorWhite,														"Idle:    %5lld us   Idle:         %5lld us", frameIdleTime, rendererGPUIdleTime );
-		}
+		ImGui::TextColored( frameBusyTime > maxTime || rendererGPUTime > maxTime ? colorRed : colorWhite, "Total:   %5lld us   Total:        %5lld us", frameBusyTime, rendererGPUTime );
+		ImGui::TextColored( colorWhite,														"Idle:    %5lld us   Idle:         %5lld us", frameIdleTime, rendererGPUIdleTime );
 
 		ImGui::End();
 	}

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -1076,6 +1076,10 @@ void idRenderSystemLocal::TakeScreenshot( int widthIgnored, int heightIgnored, c
 
 	// discard anything currently on the list
 	tr.SwapCommandBuffers( NULL, NULL, NULL, NULL, NULL, NULL );
+
+	// SRS - Update finishSyncTime so frame-over-frame timers display correctly for screenshots
+	commonLocal.frameTiming.finishSyncTime = Sys_Microseconds();
+
 	if( ref )
 	{
 		// ref is only used by envShot, Event_camShot, etc to grab screenshots of things in the world,

--- a/neo/sys/sdl/sdl_vkimp.cpp
+++ b/neo/sys/sdl/sdl_vkimp.cpp
@@ -750,7 +750,8 @@ bool R_GetModeListForDisplay( const int requestedDisplayNum, idList<vidMode_t>& 
 			{
 				continue;
 			}
-			if( ( m.refresh_rate != 60 ) && ( m.refresh_rate != 120 ) )
+			if( ( m.refresh_rate != 60 ) && ( m.refresh_rate != 120 ) &&
+			    ( m.refresh_rate != 144 ) && ( m.refresh_rate != 165 ) && ( m.refresh_rate != 240 ) )
 			{
 				continue;
 			}


### PR DESCRIPTION
This fixes the underlying issue with timers and F12 screenshots.  No need to hide certain timers on screenshot capture.
(Sorry I was unaware this was an issue or I would have looked at it sooner).

Also aligns SDL monitor refresh rates with Windows (i.e. adds 144, 165, and 240 Hz for SDL).