### PR TITLE
Frame sync changes for higher performance & fps

### DIFF
--- a/neo/cmake-xcode-debug.sh
+++ b/neo/cmake-xcode-debug.sh
@@ -5,6 +5,7 @@ cd xcode-debug
 # note 1: remove or set -DCMAKE_SUPPRESS_REGENERATION=OFF to reenable ZERO_CHECK target which checks for CMakeLists.txt changes and re-runs CMake before builds
 #         however, if ZERO_CHECK is reenabled **must** add VULKAN_SDK location to Xcode Custom Paths (under Prefs/Locations) otherwise build failures may occur
 # note 2: policy CMAKE_POLICY_DEFAULT_CMP0142=NEW suppresses non-existant per-config suffixes on Xcode library search paths, works for cmake version 3.25 and later
-#note 3: env variable MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1 enables MoltenVK's image view swizzle which may be required on older macOS versions or hardware (see vulkaninfo)
-# note 4: env variable MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=2 enables MoltenVK's use of Metal argument buffers only if VK_EXT_descriptor_indexing is enabled
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Debug -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_XCODE_SCHEME_ENVIRONMENT="MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1;MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=2" -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -DCMAKE_POLICY_DEFAULT_CMP0142=NEW -Wno-dev
+# note 3: env variable MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1 enables MoltenVK's image view swizzle which may be required on older macOS versions or hardware (see vulkaninfo)
+# note 4: env variable MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS=1 enforces synchronous queue submits which is required for the synchronization method used by the game
+# note 5: env variable MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=2 enables MoltenVK's use of Metal argument buffers only if VK_EXT_descriptor_indexing is enabled
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Debug -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_XCODE_SCHEME_ENVIRONMENT="MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1;MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS=1;MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=2" -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include ../neo -DCMAKE_POLICY_DEFAULT_CMP0142=NEW -Wno-dev

--- a/neo/framework/File_SaveGame.cpp
+++ b/neo/framework/File_SaveGame.cpp
@@ -71,7 +71,9 @@ class idSGFcompressThread : public idSysThread
 public:
 	virtual int			Run()
 	{
+#if USE_OPTICK
 		OPTICK_THREAD( "idSGFcompressThread" );
+#endif
 
 		sgf->CompressBlock();
 		return 0;
@@ -83,7 +85,9 @@ class idSGFdecompressThread : public idSysThread
 public:
 	virtual int			Run()
 	{
+#if USE_OPTICK
 		OPTICK_THREAD( "idSGFdecompressThread" );
+#endif
 
 		sgf->DecompressBlock();
 		return 0;
@@ -95,7 +99,9 @@ class idSGFwriteThread : public idSysThread
 public:
 	virtual int			Run()
 	{
+#if USE_OPTICK
 		OPTICK_THREAD( "idSGFwriteThread" );
+#endif
 
 		sgf->WriteBlock();
 		return 0;
@@ -107,7 +113,9 @@ class idSGFreadThread : public idSysThread
 public:
 	virtual int			Run()
 	{
+#if USE_OPTICK
 		OPTICK_THREAD( "idSGFreadThread" );
+#endif
 
 		sgf->ReadBlock();
 		return 0;

--- a/neo/framework/common_frame.cpp
+++ b/neo/framework/common_frame.cpp
@@ -90,7 +90,9 @@ be called directly in the foreground thread for comparison.
 */
 int idGameThread::Run()
 {
+#if USE_OPTICK
 	OPTICK_THREAD( "idGameThread" );
+#endif
 
 	commonLocal.frameTiming.startGameTime = Sys_Microseconds();
 

--- a/neo/idlib/ParallelJobList.cpp
+++ b/neo/idlib/ParallelJobList.cpp
@@ -1145,7 +1145,9 @@ idJobThread::Run
 */
 int idJobThread::Run()
 {
+#if USE_OPTICK
 	OPTICK_THREAD( GetName() );
+#endif
 
 	threadJobListState_t threadJobListState[MAX_JOBLISTS];
 	int numJobLists = 0;

--- a/neo/idlib/precompiled.h
+++ b/neo/idlib/precompiled.h
@@ -107,7 +107,7 @@ const int MAX_EXPRESSION_REGISTERS = 4096;
 #endif
 
 // RB: make Optick profiling available everywhere
-#if defined( USE_OPTICK )
+#if USE_OPTICK
 	#include "../libs/optick/optick.h"
 #endif
 

--- a/neo/idlib/precompiled.h
+++ b/neo/idlib/precompiled.h
@@ -90,8 +90,9 @@ const int MAX_EXPRESSION_REGISTERS = 4096;
 // everything that is needed by the backend needs
 // to be double buffered to allow it to run in
 // parallel on a dual cpu machine
-#if defined(__APPLE__) && ( defined( USE_VULKAN ) || defined( USE_NVRHI ) )
+#if ( defined(__APPLE__) && defined( USE_VULKAN ) ) || defined( USE_NVRHI )
 	// SRS - macOS MoltenVK/Metal needs triple buffering for full screen to work properly
+	// SRS - use triple buffering for NVRHI with command queue event query sync method
 	const uint32 NUM_FRAME_DATA	= 3;
 #else
 	const uint32 NUM_FRAME_DATA = 2;

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -1597,13 +1597,15 @@ We want to exit this with the GPU idle, right at vsync
 void idRenderBackend::GL_BlockingSwapBuffers()
 {
 	// Make sure that all frames have finished rendering
-	deviceManager->GetDevice()->waitForIdle();
-
-	// Release all in-flight references to the render targets
-	deviceManager->GetDevice()->runGarbageCollection();
+	// SRS - device-level sync kills perf by serializing command queue processing (CPU) and rendering (GPU) 
+	//	   - instead, use alternative sync method (based on command queue event queries) inside Present()
+	//deviceManager->GetDevice()->waitForIdle();
 
 	// Present to the swap chain.
 	deviceManager->Present();
+
+	// Release all in-flight references to the render targets
+	deviceManager->GetDevice()->runGarbageCollection();
 
 	renderLog.EndFrame();
 

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -890,7 +890,8 @@ bool R_ReadPixelsRGB8( nvrhi::IDevice* device, CommonRenderPasses* pPasses, nvrh
 		data[ i * 4 + 3 ] = 0xff;
 	}
 
-	R_WritePNG( fullname, static_cast<byte*>( pData ), 4, desc.width, desc.height, true, "fs_basepath" );
+	// SRS - Save screen shots to fs_savepath, not fs_basepath
+	R_WritePNG( fullname, static_cast<byte*>( pData ), 4, desc.width, desc.height, true, "fs_savepath" );
 
 	if( newData )
 	{

--- a/neo/sys/DeviceManager.h
+++ b/neo/sys/DeviceManager.h
@@ -61,7 +61,6 @@ struct DeviceCreationParameters
 	nvrhi::Format swapChainFormat = nvrhi::Format::RGBA8_UNORM; // RB: don't do the sRGB gamma ramp with the swapchain
 	uint32_t swapChainSampleCount = 1;
 	uint32_t swapChainSampleQuality = 0;
-	uint32_t maxFramesInFlight = 2;
 	bool enableDebugRuntime = false;
 	bool enableNvrhiValidationLayer = false;
 	bool vsyncEnabled = false;

--- a/neo/sys/DeviceManager_DX12.cpp
+++ b/neo/sys/DeviceManager_DX12.cpp
@@ -636,6 +636,11 @@ void DeviceManager_DX12::EndFrame()
 
 void DeviceManager_DX12::Present()
 {
+	// SRS - Sync on previous frame's command queue completion vs. waitForIdle() on whole device
+	nvrhiDevice->waitEventQuery( m_FrameWaitQuery );
+	nvrhiDevice->resetEventQuery( m_FrameWaitQuery );
+	nvrhiDevice->setEventQuery( m_FrameWaitQuery, nvrhi::CommandQueue::Graphics );
+
 	if( !windowVisible )
 	{
 		return;
@@ -653,11 +658,6 @@ void DeviceManager_DX12::Present()
 
 	// SRS - Don't change deviceParms.vsyncEnabled here, simply test for vsync mode 2 to set DXGI SyncInterval
 	m_SwapChain->Present( deviceParms.vsyncEnabled && r_swapInterval.GetInteger() == 2 ? 1 : 0, presentFlags );
-
-	// SRS - Sync on previous frame's command queue completion vs. waitForIdle() on whole device
-	nvrhiDevice->waitEventQuery( m_FrameWaitQuery );
-	nvrhiDevice->resetEventQuery( m_FrameWaitQuery );
-	nvrhiDevice->setEventQuery( m_FrameWaitQuery, nvrhi::CommandQueue::Graphics );
 
 	m_FrameFence->SetEventOnCompletion( m_FrameCount, m_FrameFenceEvents[bufferIndex] );
 	m_GraphicsQueue->Signal( m_FrameFence, m_FrameCount );

--- a/neo/sys/DeviceManager_VK.cpp
+++ b/neo/sys/DeviceManager_VK.cpp
@@ -272,8 +272,7 @@ private:
 	nvrhi::CommandListHandle m_BarrierCommandList;
 	vk::Semaphore m_PresentSemaphore;
 
-	std::queue<nvrhi::EventQueryHandle> m_FramesInFlight;
-	std::vector<nvrhi::EventQueryHandle> m_QueryPool;
+	nvrhi::EventQueryHandle m_FrameWaitQuery;
 
 	// SRS - flag indicating support for eFifoRelaxed surface presentation (r_swapInterval = 1) mode
 	bool enablePModeFifoRelaxed = false;
@@ -1124,6 +1123,10 @@ bool DeviceManager_VK::CreateDeviceAndSwapChain()
 
 	vkGetMoltenVKConfigurationMVK( m_VulkanInstance, &pConfig, &pConfigSize );
 
+	// SRS - Enforce synchronous queue submission for vkQueueSubmit() & vkQueuePresentKHR()
+	pConfig.synchronousQueueSubmits = VK_TRUE;
+	vkSetMoltenVKConfigurationMVK( m_VulkanInstance, &pConfig, &pConfigSize );
+
 	// SRS - If we don't have native image view swizzle, enable MoltenVK's image view swizzle feature
 	if( portabilityFeatures.imageViewFormatSwizzle == VK_FALSE )
 	{
@@ -1182,6 +1185,9 @@ bool DeviceManager_VK::CreateDeviceAndSwapChain()
 
 	m_PresentSemaphore = m_VulkanDevice.createSemaphore( vk::SemaphoreCreateInfo() );
 
+	m_FrameWaitQuery = m_NvrhiDevice->createEventQuery();
+	m_NvrhiDevice->setEventQuery( m_FrameWaitQuery, nvrhi::CommandQueue::Graphics );
+
 #undef CHECK
 
 	return true;
@@ -1191,24 +1197,12 @@ void DeviceManager_VK::DestroyDeviceAndSwapChain()
 {
 	destroySwapChain();
 
+	m_FrameWaitQuery = nullptr;
+
 	m_VulkanDevice.destroySemaphore( m_PresentSemaphore );
 	m_PresentSemaphore = vk::Semaphore();
 
 	m_BarrierCommandList = nullptr;
-
-	while( m_FramesInFlight.size() > 0 )
-	{
-		auto query = m_FramesInFlight.front();
-		m_FramesInFlight.pop();
-		query = nullptr;
-	}
-
-	if( !m_QueryPool.empty() )
-	{
-		auto query = m_QueryPool.back();
-		m_QueryPool.pop_back();
-		query = nullptr;
-	}
 
 	m_NvrhiDevice = nullptr;
 	m_ValidationLayer = nullptr;
@@ -1294,37 +1288,17 @@ void DeviceManager_VK::Present()
 	}
 	else
 	{
-#ifndef _WIN32
 		if( deviceParms.vsyncEnabled )
 		{
 			m_PresentQueue.waitIdle();
 		}
-#endif
-
-		while( m_FramesInFlight.size() > deviceParms.maxFramesInFlight )
-		{
-			auto query = m_FramesInFlight.front();
-			m_FramesInFlight.pop();
-
-			m_NvrhiDevice->waitEventQuery( query );
-
-			m_QueryPool.push_back( query );
-		}
-
-		nvrhi::EventQueryHandle query;
-		if( !m_QueryPool.empty() )
-		{
-			query = m_QueryPool.back();
-			m_QueryPool.pop_back();
-		}
+		// SRS - Sync on previous frame's command queue completion vs. waitForIdle() on whole device
 		else
 		{
-			query = m_NvrhiDevice->createEventQuery();
+			m_NvrhiDevice->waitEventQuery( m_FrameWaitQuery );
+			m_NvrhiDevice->resetEventQuery( m_FrameWaitQuery );
+			m_NvrhiDevice->setEventQuery( m_FrameWaitQuery, nvrhi::CommandQueue::Graphics );
 		}
-
-		m_NvrhiDevice->resetEventQuery( query );
-		m_NvrhiDevice->setEventQuery( query, nvrhi::CommandQueue::Graphics );
-		m_FramesInFlight.push( query );
 	}
 }
 

--- a/neo/sys/common/savegame.cpp
+++ b/neo/sys/common/savegame.cpp
@@ -746,7 +746,9 @@ idSaveGameThread::Run
 */
 int idSaveGameThread::Run()
 {
+#if USE_OPTICK
 	OPTICK_THREAD( "idSaveGameThread" );
+#endif
 
 	int ret = ERROR_SUCCESS;
 

--- a/neo/sys/sdl/sdl_vkimp.cpp
+++ b/neo/sys/sdl/sdl_vkimp.cpp
@@ -470,15 +470,24 @@ static bool SetScreenParmsFullscreen( glimpParms_t parms )
 
 	// change settings in that display mode according to parms
 	// FIXME: check if refreshrate, width and height are supported?
-	m.refresh_rate = parms.displayHz;
-	m.w = parms.width;
-	m.h = parms.height;
-
-	// set that displaymode
-	if( SDL_SetWindowDisplayMode( window, &m ) < 0 )
+	if( m.w != parms.width || m.h != parms.height || m.refresh_rate != parms.displayHz )
 	{
-		common->Warning( "Couldn't set window mode for fullscreen, reason: %s", SDL_GetError() );
-		return false;
+		m.w = parms.width;
+		m.h = parms.height;
+		m.refresh_rate = parms.displayHz;
+
+		// if we're already in fullscreen mode, disable it first so resizing works properly
+		if( glConfig.isFullscreen )
+		{
+			SDL_SetWindowFullscreen( window, SDL_FALSE );
+		}
+
+		// set the new displaymode
+		if( SDL_SetWindowDisplayMode( window, &m ) < 0 )
+		{
+			common->Warning( "Couldn't set window mode for fullscreen, reason: %s", SDL_GetError() );
+			return false;
+		}
 	}
 
 	// if we're currently not in fullscreen mode, we need to switch to fullscreen

--- a/neo/sys/win32/win_main.cpp
+++ b/neo/sys/win32/win_main.cpp
@@ -1949,6 +1949,7 @@ int WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	Sys_SetDPIAwareness();
 
 	// Setting memory allocators
+#if USE_OPTICK
 	OPTICK_SET_MEMORY_ALLOCATOR(
 		[]( size_t size ) -> void* { return operator new( size ); },
 		[]( void* p )
@@ -1960,6 +1961,7 @@ int WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 		/* Do some TLS initialization here if needed */
 	}
 	);
+#endif
 
 #if 0
 	DWORD handler = ( DWORD )_except_handler;
@@ -2034,7 +2036,9 @@ int WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	// main game loop
 	while( 1 )
 	{
+#if USE_OPTICK
 		OPTICK_FRAME( "MainThread" );
+#endif
 
 		Win_Frame();
 
@@ -2049,7 +2053,9 @@ int WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 		common->Frame();
 	}
 
+#if USE_OPTICK
 	OPTICK_SHUTDOWN();
+#endif
 
 	// never gets here
 	return 0;


### PR DESCRIPTION
Over the past few weeks I have been doing some profiling using Xcode Instruments to see if I could improve macOS performance / fps.  This process allowed me to observe that RBDoom3BFG is largely serializing CPU-side command queue processing and GPU processing.  This is especially bad on macOS given that Vulkan commands have to be translated via MoltenVK to Metal commands on the fly, and this overhead makes things worse compared to Windows and Linux where Vulkan is native.  The main reason for the serialization is due to the device-level `waitForIdle()` call inside `GL_BlockingSwapBuffers()`, where the CPU waits for GPU operations to complete before getting started on the next frame's game thread and command queue processing.  This limits the parallel overlap between the CPU and GPU and really slows things down.  For vanilla versions of Doom3 this may not be so bad since rendering was fairly simple.  However, with RBDoom3BFG rendering is becoming more complex and time consuming, and parallelism is needed.

I noticed that NVRHI offers other modes of sync, most notably command queue event queries.  This pull request experiments with two things: a) using triple frame buffering vs. double buffering for NVRHI (DX12 & Vulkan), and b) replacing the device `waitForIdle()` device sync with a command queue sync operation based on completion of the previous frame's graphics command queue.  The results with my AMD 6600XT card are fairly significant as seen below:

Win32 DX12: before: 50 fps (as of Feb 28, before additional commits), after: 136 fps
Win32 Vulkan: before: 74 fps (as of today using up-to-date master), after: 133 fps
Linux Vulkan: before: 27 fps (as of Feb 28, before additional commits), after: 122 fps
macOS Vulkan: before: 38 fps (as of today using up-to-date master), after: 58 fps

This work has been tested using my AMD 6600XT card on all OSs, as well as an internal Intel UHD 630 graphics processor (on my Intel 8700K) to test these sync changes on a slow GPU.  So far so good.  However, I would like to see how these operate on a faster GPU (i.e. a more powerful Nvidia or AMD chip).

In addition this pull request also includes:

1) Save screenshots to **fs_savepath** (as per original Doom3 default) vs. **fs_basepath**
2) Fix SDL display mode size/refresh rate changes when already in fullscreen mode
3) Fix compilation errors when Optick profiling is OFF.  (note that setting OPTICK=ON for macOS/linux exposes some issues with including optick.h in precompiled.h, but this may not be the main use case so I did not attempt to fix.  On macOS the default profiler is Instruments' Game Performance tool)

Win32 DX12 before and after screenshots:

![win32-dx12-before-pic1](https://user-images.githubusercontent.com/82544213/222941824-b607031e-0317-4331-9670-9aefbb3e2775.png)
![win32-dx12-after](https://user-images.githubusercontent.com/82544213/222941841-f2ddd4d4-e6bc-4d7c-8579-6e9d23a83ee6.png)

Win32 Vulkan before and after screenshots:

![win32-vulkan-before](https://user-images.githubusercontent.com/82544213/222941858-ad5c4995-f316-449d-9e57-84bc2453980a.png)
![win32-vulkan-after](https://user-images.githubusercontent.com/82544213/222941865-8741c742-8c16-4c84-9265-5b6dd6cfd5f6.png)
