### PR TITLE
Sync points revisited

### DIFF
--- a/neo/idlib/precompiled.h
+++ b/neo/idlib/precompiled.h
@@ -91,7 +91,7 @@ const int MAX_EXPRESSION_REGISTERS = 4096;
 // to be double buffered to allow it to run in
 // parallel on a dual cpu machine
 // SRS - use triple buffering for NVRHI with command queue event query sync method
-const uint32 NUM_FRAME_DATA	= 3;
+constexpr uint32 NUM_FRAME_DATA	= 3;
 
 #include "nvrhi/nvrhi.h"
 

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -1552,8 +1552,6 @@ void idRenderBackend::GL_StartFrame()
 	// fetch GPU timer queries of last frame
 	renderLog.FetchGPUTimers( pc );
 
-	deviceManager->BeginFrame();
-
 #if defined( USE_AMD_ALLOCATOR )
 	idImage::EmptyGarbage();
 #endif
@@ -1588,7 +1586,7 @@ void idRenderBackend::GL_EndFrame()
 	deviceManager->GetDevice()->executeCommandList( commandList );
 
 	// required for Vulkan: transition our swap image to present
-	deviceManager->EndFrame();
+	//deviceManager->EndFrame();
 
 	// update jitter for perspective matrix
 	taaPass->AdvanceFrame();

--- a/neo/sys/DeviceManager.h
+++ b/neo/sys/DeviceManager.h
@@ -53,10 +53,11 @@ struct DeviceCreationParameters
 	uint32_t backBufferHeight = 720;
 	uint32_t backBufferSampleCount = 1;  // optional HDR Framebuffer MSAA
 	uint32_t refreshRate = 0;
-	uint32_t swapChainBufferCount = 3;
+	uint32_t swapChainBufferCount = NUM_FRAME_DATA;
 	nvrhi::Format swapChainFormat = nvrhi::Format::RGBA8_UNORM; // RB: don't do the sRGB gamma ramp with the swapchain
 	uint32_t swapChainSampleCount = 1;
 	uint32_t swapChainSampleQuality = 0;
+	uint32_t maxFramesInFlight = 2;
 	bool enableDebugRuntime = false;
 	bool enableNvrhiValidationLayer = false;
 	bool vsyncEnabled = false;

--- a/neo/sys/DeviceManager_DX12.cpp
+++ b/neo/sys/DeviceManager_DX12.cpp
@@ -64,7 +64,7 @@ class DeviceManager_DX12 : public DeviceManager
 	std::vector<nvrhi::TextureHandle>           m_RhiSwapChainBuffers;
 	RefCountPtr<ID3D12Fence>                    m_FrameFence;
 	std::vector<HANDLE>                         m_FrameFenceEvents;
-	
+
 	UINT64                                      m_FrameCount = 1;
 
 	nvrhi::DeviceHandle                         m_NvrhiDevice;

--- a/neo/sys/DeviceManager_VK.cpp
+++ b/neo/sys/DeviceManager_VK.cpp
@@ -1273,11 +1273,11 @@ void DeviceManager_VK::Present()
 	BeginFrame();
 
 	vk::PresentInfoKHR info = vk::PresentInfoKHR()
-		.setWaitSemaphoreCount( 1 )
-		.setPWaitSemaphores( &m_PresentSemaphore )
-		.setSwapchainCount( 1 )
-		.setPSwapchains( &m_SwapChain )
-		.setPImageIndices( &m_SwapChainIndex );
+							  .setWaitSemaphoreCount( 1 )
+							  .setPWaitSemaphores( &m_PresentSemaphore )
+							  .setSwapchainCount( 1 )
+							  .setPSwapchains( &m_SwapChain )
+							  .setPImageIndices( &m_SwapChainIndex );
 
 	const vk::Result res = m_PresentQueue.presentKHR( &info );
 	assert( res == vk::Result::eSuccess || res == vk::Result::eErrorOutOfDateKHR || res == vk::Result::eSuboptimalKHR );
@@ -1299,7 +1299,7 @@ void DeviceManager_VK::Present()
 
 			m_QueryPool.push_back( query );
 		}
-		
+
 		nvrhi::EventQueryHandle query;
 		if( !m_QueryPool.empty() )
 		{


### PR DESCRIPTION
I didn't want to have to increase my frame data by 50%, so I added an option to use 2 buffers of frame data without gpu artifacts happening.

This doesn't quite work well with vulkan yet. I need help with that one. I don't see a reason to need that 3rd frame buffer data in order to prevent those gpu artifacts, it should be viable to use however many frames you want.