### PR TITLE
Borderless Fullscreen mode for Win32 and SDL linux/macOS

### DIFF
--- a/neo/d3xp/menus/MenuScreen.h
+++ b/neo/d3xp/menus/MenuScreen.h
@@ -626,7 +626,7 @@ private:
 		}
 		bool operator==( const optionData_t& other ) const
 		{
-			return ( fullscreen == other.fullscreen ) && ( ( vidmode == other.vidmode ) || ( fullscreen == 0 ) );
+			return ( fullscreen == other.fullscreen ) && ( ( vidmode == other.vidmode ) || ( fullscreen <= 0 ) );
 		}
 		int fullscreen;
 		int vidmode;

--- a/neo/d3xp/menus/MenuScreen_Shell_Resolution.cpp
+++ b/neo/d3xp/menus/MenuScreen_Shell_Resolution.cpp
@@ -163,6 +163,16 @@ void idMenuScreen_Shell_Resolution::ShowScreen( const mainMenuTransition_t trans
 	optionData.Append( optionData_t( 0, 0 ) );
 
 	int viewIndex = 0;
+	// SRS - Added support for selecting borderless fullscreen window mode
+	idStr bw_str;
+	bw_str.Append( va( "%s", "Borderless Fullscreen" ) );
+	menuOptions.Alloc().Alloc() = bw_str;
+	optionData.Append( optionData_t( -2, 0 ) );
+	if( originalOption.fullscreen == -2 )
+	{
+		viewIndex = menuOptions.Num() - 1;
+	}
+	// SRS end
 	idList< idList<vidMode_t> > displays;
 	for( int displayNum = 0 ; ; displayNum++ )
 	{
@@ -280,10 +290,11 @@ bool idMenuScreen_Shell_Resolution::HandleAction( idWidgetAction& action, const 
 					// No change
 					menuData->SetNextScreen( SHELL_AREA_SYSTEM_OPTIONS, MENU_TRANSITION_SIMPLE );
 				}
-				else if( currentOption.fullscreen == 0 )
+				// SRS - Added support for selecting borderless fullscreen window mode
+				else if( currentOption.fullscreen == 0 || currentOption.fullscreen == -2 )
 				{
-					// Changing to windowed mode
-					r_fullscreen.SetInteger( 0 );
+					// Changing to windowed or borderless fullscreen mode
+					r_fullscreen.SetInteger( currentOption.fullscreen );
 					cmdSystem->BufferCommandText( CMD_EXEC_APPEND, "vid_restart\n" );
 					menuData->SetNextScreen( SHELL_AREA_SYSTEM_OPTIONS, MENU_TRANSITION_SIMPLE );
 				}

--- a/neo/d3xp/menus/MenuScreen_Shell_SystemOptions.cpp
+++ b/neo/d3xp/menus/MenuScreen_Shell_SystemOptions.cpp
@@ -686,6 +686,16 @@ idSWFScriptVar idMenuScreen_Shell_SystemOptions::idMenuDataSource_SystemSettings
 			{
 				return "#str_swf_disabled";
 			}
+			// SRS - Added support for displaying borderless modes
+			else if( fullscreen == -1 )
+			{
+				return "Borderless Window";
+			}
+			else if( fullscreen == -2 )
+			{
+				return "Borderless Fullscreen";
+			}
+			// SRS end
 			if( fullscreen < 0 || vidmode < 0 || vidmode >= modeList.Num() )
 			{
 				return "???";

--- a/neo/renderer/RenderCommon.h
+++ b/neo/renderer/RenderCommon.h
@@ -1103,8 +1103,6 @@ extern idCVar r_windowHeight;
 
 extern idCVar r_debugContext;				// enable various levels of context debug
 extern idCVar r_useValidationLayers;
-extern idCVar r_skipAMDWorkarounds;         // skip work arounds for AMD driver bugs
-extern idCVar r_skipIntelWorkarounds;		// skip work arounds for Intel driver bugs
 extern idCVar r_vidMode;					// video mode number
 extern idCVar r_displayRefresh;				// optional display refresh rate option for vid mode
 extern idCVar r_fullscreen;					// 0 = windowed, 1 = full screen

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -72,15 +72,6 @@ idCVar r_debugContext( "r_debugContext", "0", CVAR_RENDERER, "Enable various lev
 
 idCVar r_useValidationLayers( "r_useValidationLayers", "1", CVAR_INTEGER | CVAR_INIT, "1 is just the NVRHI and 2 will turn on additional DX12, VK validation layers" );
 
-// SRS - Added workaround for AMD OSX driver bugs caused by GL_EXT_timer_query when shadow mapping enabled; Intel bugs not present on OSX
-#if defined(__APPLE__)
-	idCVar r_skipIntelWorkarounds( "r_skipIntelWorkarounds", "1", CVAR_RENDERER | CVAR_BOOL, "skip workarounds for Intel driver bugs" );
-	idCVar r_skipAMDWorkarounds( "r_skipAMDWorkarounds", "0", CVAR_RENDERER | CVAR_BOOL, "skip workarounds for AMD driver bugs" );
-#else
-	idCVar r_skipIntelWorkarounds( "r_skipIntelWorkarounds", "0", CVAR_RENDERER | CVAR_BOOL, "skip workarounds for Intel driver bugs" );
-	idCVar r_skipAMDWorkarounds( "r_skipAMDWorkarounds", "1", CVAR_RENDERER | CVAR_BOOL, "skip workarounds for AMD driver bugs" );
-#endif
-// SRS end
 // RB: disabled 16x MSAA
 #if ID_MSAA
 	idCVar r_antiAliasing( "r_antiAliasing", "1", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, " 0 = None\n 1 = TAA 1x\n 2 = TAA + SMAA 1x\n 3 = MSAA 2x\n 4 = MSAA 4x\n", 0, ANTI_ALIASING_MSAA_4X );

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -90,13 +90,10 @@ idCVar r_useValidationLayers( "r_useValidationLayers", "1", CVAR_INTEGER | CVAR_
 // RB end
 idCVar r_vidMode( "r_vidMode", "0", CVAR_ARCHIVE | CVAR_RENDERER | CVAR_INTEGER, "fullscreen video mode number" );
 idCVar r_displayRefresh( "r_displayRefresh", "0", CVAR_RENDERER | CVAR_INTEGER | CVAR_NOCHEAT, "optional display refresh rate option for vid mode", 0.0f, 240.0f );
-#ifdef WIN32
-	idCVar r_fullscreen( "r_fullscreen", "1", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, "0 = windowed, 1 = full screen on monitor 1, 2 = full screen on monitor 2, etc" );
-#else
-	// DG: add mode -2 for SDL, also defaulting to windowed mode, as that causes less trouble on linux
-	idCVar r_fullscreen( "r_fullscreen", "0", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, "-2 = use current monitor, -1 = (reserved), 0 = windowed, 1 = full screen on monitor 1, 2 = full screen on monitor 2, etc" );
-	// DG end
-#endif
+// SRS - redefined mode -2 to be borderless fullscreen, implemented borderless modes -2 and -1 for Windows and linux/macOS (SDL)
+// DG: add mode -2 for SDL, also defaulting to windowed mode, as that causes less trouble on linux
+idCVar r_fullscreen( "r_fullscreen", "0", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, "-2 = borderless fullscreen, -1 = borderless window, 0 = windowed, 1 = full screen on monitor 1, 2 = full screen on monitor 2, etc" );
+// DG end
 idCVar r_customWidth( "r_customWidth", "1280", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, "custom screen width. set r_vidMode to -1 to activate" );
 idCVar r_customHeight( "r_customHeight", "720", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, "custom screen height. set r_vidMode to -1 to activate" );
 idCVar r_windowX( "r_windowX", "0", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, "Non-fullscreen parameter" );
@@ -370,6 +367,7 @@ uint R_GetMSAASamples()
 =============================
 R_SetNewMode
 
+r_fullScreen -2		borderless fullscreen on current monitor at desktop resolution
 r_fullScreen -1		borderless window at exact desktop coordinates
 r_fullScreen 0		bordered window at exact desktop coordinates
 r_fullScreen 1		fullscreen on monitor 1 at r_vidMode
@@ -405,7 +403,7 @@ void R_SetNewMode( const bool fullInit )
 			parms.y = r_windowY.GetInteger();
 			parms.width = r_windowWidth.GetInteger();
 			parms.height = r_windowHeight.GetInteger();
-			// may still be -1 to force a borderless window
+			// may still be -1 or -2 to force a borderless window
 			parms.fullScreen = r_fullscreen.GetInteger();
 			parms.displayHz = 0;		// ignored
 		}
@@ -415,14 +413,14 @@ void R_SetNewMode( const bool fullInit )
 			idList<vidMode_t> modeList;
 			if( !R_GetModeListForDisplay( r_fullscreen.GetInteger() - 1, modeList ) )
 			{
-				idLib::Printf( "r_fullscreen reset from %i to 1 because mode list failed.", r_fullscreen.GetInteger() );
+				idLib::Printf( "r_fullscreen reset from %i to 1 because mode list failed.\n", r_fullscreen.GetInteger() );
 				r_fullscreen.SetInteger( 1 );
 				R_GetModeListForDisplay( r_fullscreen.GetInteger() - 1, modeList );
 			}
 
 			if( modeList.Num() < 1 )
 			{
-				idLib::Printf( "Going to safe mode because mode list failed." );
+				idLib::Printf( "Going to safe mode because mode list failed.\n" );
 				goto safeMode;
 			}
 
@@ -498,7 +496,7 @@ void R_SetNewMode( const bool fullInit )
 			if( GLimp_Init( parms ) )
 #endif
 			{
-				ImGuiHook::Init( parms.width, parms.height );
+				ImGuiHook::Init( glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
 				break;
 			}
 		}
@@ -513,7 +511,7 @@ void R_SetNewMode( const bool fullInit )
 #endif
 			{
 				Framebuffer::ResizeFramebuffers();
-				ImGuiHook::NotifyDisplaySizeChanged( parms.width, parms.height );
+				ImGuiHook::NotifyDisplaySizeChanged( glConfig.nativeScreenWidth, glConfig.nativeScreenHeight );
 				break;
 			}
 		}

--- a/neo/sys/win32/win_wndproc.cpp
+++ b/neo/sys/win32/win_wndproc.cpp
@@ -311,7 +311,7 @@ LONG WINAPI MainWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 			break;
 		}
 		case WM_SYSCOMMAND:
-			if( wParam == SC_SCREENSAVE || wParam == SC_KEYMENU )
+			if( wParam == SC_SCREENSAVE || wParam == SC_KEYMENU || wParam == SC_MAXIMIZE )
 			{
 				return 0;
 			}

--- a/neo/sys/win32/win_wndproc.cpp
+++ b/neo/sys/win32/win_wndproc.cpp
@@ -320,7 +320,17 @@ LONG WINAPI MainWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 		case WM_SYSKEYDOWN:
 			if( wParam == 13 )  	// alt-enter toggles full-screen
 			{
-				cvarSystem->SetCVarBool( "r_fullscreen", !renderSystem->IsFullScreen() );
+				// SRS - Use same functionality and logic as with SDL on linux and macOS
+				// DG: go to fullscreen on current display, instead of always first display
+				int fullscreen = 0;
+				if( !renderSystem->IsFullScreen() )
+				{
+					// this will be handled as "fullscreen on current window"
+					// r_fullscreen 1 means "fullscreen on first window" in d3 bfg
+					fullscreen = -2;
+				}
+				cvarSystem->SetCVarInteger( "r_fullscreen", fullscreen );
+				// DG end
 				cmdSystem->BufferCommandText( CMD_EXEC_APPEND, "vid_restart\n" );
 				return 0;
 			}


### PR DESCRIPTION
This is a rewrite of a now-defunct (retracted) pull request but on top of the new NVRHI base.

It implements Borderless Fullscreen mode (-2) as well as Borderless Windowed mode (-1) for Win32 and linux/macOS.

Borderless Fullscreen is available as a menu option within the Fullscreen Resolution menu, and the semantics are "go into borderless fullscreen mode on the current monitor hosting the window".  Alt-Enter toggles this from the keyboard.  In this mode the mouse can be freed (by opening the console) and Alt-tab works.  In addition, on linux you can use the Maximize window bar widget to put the window into borderless fullscreen mode.  On macOS this works too, but only if you hold down the option key for "Zoom" functionality of the maximize button, and don't try to use or activate macOS Spaces.   I have disabled macOS Spaces via an SDL_HINT but it is not working fully, I suspect there is an SDL bug (see https://github.com/libsdl-org/SDL/issues/7470)

For completeness, I also implemented the Borderless Window mode (-1) which is a custom mode settable via the console only for multi-monitor spanning.  Once selected, the menu will display a read-only "Borderless Window", but it cannot be chosen via the GUI menu.  This mode must be set by adjusting `r_windowX/Y`, and `r_windowWidth/Height` and `r_fullscreen = -1` in the console, followed by `vid_restart`.

In addition, this work cleans up a bunch of error conditions if the window is out of bounds on the desktop by accident, e.g. the multi-monitor config changed, or a monitor is off.  The logic is smart enough to detect this and bring the window back to the primary or default display.  I have tried to make this resilient for both Win32 and SDL.

In addition, I cleaned up a bunch of dead code in `VKimp_Init()` and removed some defunct cvars.

Lastly, I ***think*** these changes should fix #740 but I cannot reproduce this error on my setup.  I suspect what is happening here is due to an SDL oddity when creating the initial window in Fullscreen mode.  Some linux window managers respond poorly to this and have trouble with window dimensions afterwards.  Instead, I now create the window in non-fullscreen mode (bordered or borderless), and then go into fullscreen only after the window, device and swap chain are up and running.  I am hoping this addresses the issue, and if Robert could test on his setup that would be great.

There is one more bug fix for the initialization of `glConfig.isFullscreen` on SDL platforms - at startup it previously would be set to either 0 or 1, which could mess things up on multi-monitor setups.  Now it is properly initialized to the appropriate r_fullscreen mode: -2, -1, 0, 1, 2, ...