### PR TITLE
Disable DXGI automatic mode switching for alt-enter fullscreen

### DIFF
--- a/neo/sys/DeviceManager.h
+++ b/neo/sys/DeviceManager.h
@@ -47,7 +47,7 @@ struct DeviceCreationParameters
 {
 	bool startMaximized = false;
 	bool startFullscreen = false;
-	bool allowModeSwitch = true;
+	bool allowModeSwitch = false;
 	int windowPosX = -1;            // -1 means use default placement
 	int windowPosY = -1;
 	uint32_t backBufferWidth = 1280;


### PR DESCRIPTION
This was a stupid miss on my part when implementing alt-enter borderless fullscreen transitions for DX12.  Without this change when using alt-enter to enter borderless fullscreen, DXGI first switches the display mode to the current windowed resolution, and then finally moves back to the native fullscreen resolution.  This was ok when alt-enter was used for entering dedicated fullscreen mode, but not so much for the current implementation.  This causes unnesessary delays on alt-enter, and the display resolution can be seen to be changing needlessly.

Prior to the 1.5 release I tested and solved part of the problem that addressed this on the Vulkan side, but missed this issue for DXGI swap chains.  Oh well...