### PR TITLE
Add libvulkan-dev dependency to ubuntu/debian compilation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Recommended in this case is `cmake-vs2022-64bit-no-ffmpeg.bat`
 
 	On Debian or Ubuntu:
 
-		> apt-get install cmake libsdl2-dev libopenal-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
+		> apt-get install cmake libsdl2-dev libopenal-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libvulkan-dev
 	
 	On Fedora
 		


### PR DESCRIPTION
libvulkan-dev should be a documented dependency. 