### PR TITLE
Fix Vulkan swapchain extent and buffer count issues, Implement Vulkan mailbox mode option

### DIFF
--- a/neo/sys/DeviceManager.h
+++ b/neo/sys/DeviceManager.h
@@ -54,7 +54,7 @@ struct DeviceCreationParameters
 	uint32_t backBufferHeight = 720;
 	uint32_t backBufferSampleCount = 1;  // optional HDR Framebuffer MSAA
 	uint32_t refreshRate = 0;
-	uint32_t swapChainBufferCount = 3;	// SRS - hardcode to 3 for Vsync modes and linux surfaceCaps.minImageCount = 3
+	uint32_t swapChainBufferCount = NUM_FRAME_DATA;	// SRS - default matches GPU frames, can be overridden by renderer
 	nvrhi::Format swapChainFormat = nvrhi::Format::RGBA8_UNORM; // RB: don't do the sRGB gamma ramp with the swapchain
 	uint32_t swapChainSampleCount = 1;
 	uint32_t swapChainSampleQuality = 0;

--- a/neo/sys/DeviceManager_VK.cpp
+++ b/neo/sys/DeviceManager_VK.cpp
@@ -559,13 +559,9 @@ bool DeviceManager_VK::pickPhysicalDevice()
 		auto surfaceFmts = dev.getSurfaceFormatsKHR( m_WindowSurface );
 		auto surfacePModes = dev.getSurfacePresentModesKHR( m_WindowSurface );
 
-		if( surfaceCaps.minImageCount > m_DeviceParams.swapChainBufferCount ||
-				( surfaceCaps.maxImageCount < m_DeviceParams.swapChainBufferCount && surfaceCaps.maxImageCount > 0 ) )
-		{
-			errorStream << std::endl << "  - cannot support the requested swap chain image count:";
-			errorStream << " requested " << m_DeviceParams.swapChainBufferCount << ", available " << surfaceCaps.minImageCount << " - " << surfaceCaps.maxImageCount;
-			deviceIsGood = false;
-		}
+		// SRS/Ricardo Garcia rg3 - clamp swapChainBufferCount to the min/max capabilities of the surface
+		m_DeviceParams.swapChainBufferCount = Max( surfaceCaps.minImageCount, m_DeviceParams.swapChainBufferCount );
+		m_DeviceParams.swapChainBufferCount = surfaceCaps.maxImageCount > 0 ? Min( m_DeviceParams.swapChainBufferCount, surfaceCaps.maxImageCount ) : m_DeviceParams.swapChainBufferCount;
 
 		if( surfaceCaps.minImageExtent.width > requestedExtent.width ||
 				surfaceCaps.minImageExtent.height > requestedExtent.height ||


### PR DESCRIPTION
This PR fixes #765 and #783 and hopefully addresses #740.

It also implements `eMailbox` presentation mode for Vulkan as an optional alternative to `eImmediate` mode, based on the setting of a new **r_preferFastSync** cvar (default on = true).   This setting will change the meaning of Vulkan VSync Off in the GUI to mean "run full out without tearing" (Fast Sync) vs. "run full out with tearing".  Vulkan `eMailbox` mode achieves this by dropping frames to line up with vsync.  If supported on their platform, users will have an option for fast frame rates and low latency with a choice of tearing or skipping.  This is really only valuable if your graphics card is fast and can exceed vsync rates by a factor of 2-3X.  Note if the Vulkan `eMailbox` present mode is not available on a platform, the VSync Off GUI selection falls back to mean `eImmediate` (i.e. status quo with tearing).

Finally, this PR aligns the window type, size handling, and error reporting logic between SDL and Windows.  Hopefully this will make it easier to maintain going forward.

I have tested these changes on all platforms: Windows 10, linux Manjaro, and macOS Monterey.  In addition, I have tried the updated window resizing / Vulkan swapchain extent logic with tiling window managers on linux (xfce tiling settings) and macOS (magnet tiling manager).  Hopefully this may solve the above issues.

I would appreciate testing and validation of this PR against the reported issues.  If your problems are not solved, please report against your original issue and hopefully I can address it.  Thanks.

1. :white_check_mark: @sjnewbury and @rg3 (thanks for your code!) for #765
2. :white_check_mark: @Oreolek for #783
3. :grey_question: @vide0hanz and @RobertBeckebans for #740

