### PR TITLE
Fix Doom Classic crash on quit, fix Sync timer for timedemo "twice" mode

### DIFF
--- a/neo/framework/Common_demos.cpp
+++ b/neo/framework/Common_demos.cpp
@@ -312,13 +312,11 @@ void idCommonLocal::TimeRenderDemo( const char* demoName, bool twice, bool quit 
 		while( readDemo )
 		{
 			BusyWait();                         // SRS - BusyWait() calls UpdateScreen() which draws and renders out-of-sequence but still supports frame timing
-			commonLocal.frameTiming.finishSyncTime_EndFrame = Sys_Microseconds();
 			commonLocal.mainFrameTiming = commonLocal.frameTiming;
 			// ** End of current logical frame **
 
 			// ** Start of next logical frame **
-			commonLocal.frameTiming.startSyncTime = Sys_Microseconds();
-			commonLocal.frameTiming.finishSyncTime = commonLocal.frameTiming.startSyncTime;
+			commonLocal.frameTiming.finishSyncTime = Sys_Microseconds();
 			commonLocal.frameTiming.startGameTime = commonLocal.frameTiming.finishSyncTime;
 
 			AdvanceRenderDemo( true );          // SRS - Advance demo commands to manually run the next game frame during first pass of the timedemo

--- a/neo/framework/Common_demos.cpp
+++ b/neo/framework/Common_demos.cpp
@@ -301,7 +301,6 @@ idCommonLocal::TimeRenderDemo
 */
 void idCommonLocal::TimeRenderDemo( const char* demoName, bool twice, bool quit )
 {
-	extern idCVar com_smp;
 	idStr demo = demoName;
 
 	StartPlayingRenderDemo( demo );
@@ -309,9 +308,6 @@ void idCommonLocal::TimeRenderDemo( const char* demoName, bool twice, bool quit 
 	if( twice && readDemo )
 	{
 		timeDemo = TD_YES;                      // SRS - Set timeDemo to TD_YES to disable time demo playback pause when window not in focus
-
-		bool smp_mode = com_smp.GetBool();
-		com_smp.SetBool( false );                // SRS - First pass of timedemo is effectively in com_smp == 0 mode, so set this for ImGui timings to be correct
 
 		while( readDemo )
 		{
@@ -330,8 +326,6 @@ void idCommonLocal::TimeRenderDemo( const char* demoName, bool twice, bool quit 
 
 			eventLoop->RunEventLoop( false );   // SRS - Run event loop (with no commands) to allow keyboard escape to cancel first pass of the timedemo
 		}
-
-		com_smp.SetBool( smp_mode );         // SRS - Restore original com_smp mode before second pass of timedemo which runs within normal rendering loop
 
 		StartPlayingRenderDemo( demo );
 	}

--- a/neo/framework/common_frame.cpp
+++ b/neo/framework/common_frame.cpp
@@ -437,10 +437,10 @@ void idCommonLocal::UpdateScreen( bool captureToImage, bool releaseMouse )
 	}
 
 	// this should exit right after vsync, with the GPU idle and ready to draw
+	frameTiming.startRenderTime = Sys_Microseconds();   // SRS - Added frame timing for out-of-sequence updates (e.g. used in timedemo "twice" mode)
 	const emptyCommand_t* cmd = renderSystem->SwapCommandBuffers( &time_frontend, &time_backend, &time_shadows, &time_gpu, &stats_backend, &stats_frontend );
 
 	// get the GPU busy with new commands
-	frameTiming.startRenderTime = Sys_Microseconds();   // SRS - Added frame timing for out-of-sequence updates (e.g. used in timedemo "twice" mode)
 	renderSystem->RenderCommandBuffers( cmd );
 	frameTiming.finishRenderTime = Sys_Microseconds();  // SRS - Added frame timing for out-of-sequence updates (e.g. used in timedemo "twice" mode)
 

--- a/neo/renderer/RenderLog.cpp
+++ b/neo/renderer/RenderLog.cpp
@@ -127,6 +127,8 @@ void idRenderLog::Init()
 
 void idRenderLog::Shutdown()
 {
+	commandList = nullptr;
+
 	for( int i = 0; i < MRB_TOTAL * NUM_FRAME_DATA; i++ )
 	{
 		timerQueries[i].Reset();

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -2165,8 +2165,6 @@ idRenderSystemLocal::Shutdown
 */
 void idRenderSystemLocal::Shutdown()
 {
-	extern idCVar com_smp;
-
 	common->Printf( "idRenderSystem::Shutdown()\n" );
 
 	fonts.DeleteContents();

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -2199,8 +2199,8 @@ void idRenderSystemLocal::Shutdown()
 	UnbindBufferObjects();
 
 	// SRS - wait for fence to hit before freeing any resources the GPU may be using, otherwise get Vulkan validation layer errors on shutdown
-	// SRS - skip this step if we are in Doom 3 mode (com_smp = -1) which has already finished and presented
-	if( com_smp.GetInteger() != -1 )
+	// SRS - skip this step if we are in a Doom Classic game
+	if( common->GetCurrentGame() == DOOM3_BFG )
 	{
 		backend.GL_BlockingSwapBuffers();
 	}


### PR DESCRIPTION
This PR solves several things:

1. Solves #792 by synchronizing selectively on exit, i.e. only call `backend.GL_BlockingSwapBuffers()` on quit when in Doom3 mode, skip when quitting from a Classic game
2. Also solves a Doom Classic change game hang/crash on linux and macOS by zeroing out the commandList refcount within `idRenderLog::Shutdown()`. Windows seems more tolerant of this, but the fix is general.
3. Fixes the "Sync" timer during demo playback first pass when using "timedemo <demo_name> **twice**" mode.  Previously the Sync timer was inaccurate for that specific case (it's fine for all other cases)
4. Also removed unneeded references to the **com_smp** cvar
