### PR TITLE
Fix gcc/clang & MSVC warnings for all platforms

### DIFF
--- a/doomclassic/doom/am_map.cpp
+++ b/doomclassic/doom/am_map.cpp
@@ -429,7 +429,7 @@ void AM_loadPics( void )
 
 	for( i = 0; i < 10; i++ )
 	{
-		sprintf( namebuf, "AMMNUM%d", i );
+		idStr::snPrintf( namebuf, sizeof( namebuf ), "AMMNUM%d", i );
 		::g->marknums[i] = ( patch_t* )W_CacheLumpName( namebuf, PU_STATIC_SHARED );
 	}
 
@@ -635,7 +635,7 @@ AM_Responder
 				::g->amap_plr->message = ::g->grid ? AMSTR_GRIDON : AMSTR_GRIDOFF;
 				break;
 			case AM_MARKKEY:
-				sprintf( ::g->buffer, "%s %d", AMSTR_MARKEDSPOT, ::g->markpointnum );
+				idStr::snPrintf( ::g->buffer, sizeof( ::g->buffer ), "%s %d", AMSTR_MARKEDSPOT, ::g->markpointnum );
 				::g->amap_plr->message = ::g->buffer;
 				AM_addMark();
 				break;

--- a/doomclassic/doom/d_main.cpp
+++ b/doomclassic/doom/d_main.cpp
@@ -612,35 +612,35 @@ void D_DoomMain( void )
 	switch( ::g->gamemode )
 	{
 		case retail:
-			sprintf( ::g->title,
+			idStr::snPrintf( ::g->title, sizeof( ::g->title ),
 					 "                         "
 					 "The Ultimate DOOM Startup v%i.%i"
 					 "                           ",
 					 VERSION / 100, VERSION % 100 );
 			break;
 		case shareware:
-			sprintf( ::g->title,
+			idStr::snPrintf( ::g->title, sizeof( ::g->title ),
 					 "                            "
 					 "DOOM Shareware Startup v%i.%i"
 					 "                           ",
 					 VERSION / 100, VERSION % 100 );
 			break;
 		case registered:
-			sprintf( ::g->title,
+			idStr::snPrintf( ::g->title, sizeof( ::g->title ),
 					 "                            "
 					 "DOOM Registered Startup v%i.%i"
 					 "                           ",
 					 VERSION / 100, VERSION % 100 );
 			break;
 		case commercial:
-			sprintf( ::g->title,
+			idStr::snPrintf( ::g->title, sizeof( ::g->title ),
 					 "                         "
 					 "DOOM 2: Hell on Earth v%i.%i"
 					 "                           ",
 					 VERSION / 100, VERSION % 100 );
 			break;
 		default:
-			sprintf( ::g->title,
+			idStr::snPrintf( ::g->title, sizeof( ::g->title ),
 					 "                     "
 					 "Public DOOM - v%i.%i"
 					 "                           ",
@@ -686,7 +686,7 @@ void D_DoomMain( void )
 
 	if( p && p < ::g->myargc - 1 )
 	{
-		sprintf( file, "d:\\%s.lmp", ::g->myargv[p + 1] );
+		idStr::snPrintf( file, sizeof( file ), "d:\\%s.lmp", ::g->myargv[p + 1] );
 		D_AddFile( file );
 		I_Printf( "Playing demo %s.lmp.\n", ::g->myargv[p + 1] );
 	}
@@ -918,11 +918,11 @@ bool D_DoomMainPoll( void )
 	{
 		if( M_CheckParm( "-cdrom" ) )
 		{
-			sprintf( file, "c:\\doomdata\\" SAVEGAMENAME "%c.dsg", ::g->myargv[p + 1][0] );
+			idStr::snPrintf( file, sizeof( file ), "c:\\doomdata\\" SAVEGAMENAME "%c.dsg", ::g->myargv[p + 1][0] );
 		}
 		else
 		{
-			sprintf( file, SAVEGAMENAME "%c.dsg", ::g->myargv[p + 1][0] );
+			idStr::snPrintf( file, sizeof( file ), SAVEGAMENAME "%c.dsg", ::g->myargv[p + 1][0] );
 		}
 		G_LoadGame( file );
 	}

--- a/doomclassic/doom/doominterface.cpp
+++ b/doomclassic/doom/doominterface.cpp
@@ -327,7 +327,7 @@ void DoomInterface::SetMultiplayerPlayers( int localPlayerIndex, int playerCount
 	strcpy( mpArgV[localPlayerIndex][2], "1" );
 	strcpy( mpArgV[localPlayerIndex][3], "-net" );
 
-	sprintf( mpArgV[localPlayerIndex][4], "%d", localPlayer );
+	idStr::snPrintf( mpArgV[localPlayerIndex][4], sizeof( mpArgV[localPlayerIndex][4] ), "%d", localPlayer );
 	strcpy( mpArgV[localPlayerIndex][5], playerAddresses[localPlayer].c_str() );
 
 	int currentArg = 6;

--- a/doomclassic/doom/f_finale.cpp
+++ b/doomclassic/doom/f_finale.cpp
@@ -884,7 +884,7 @@ void F_BunnyScroll( void )
 		::g->laststage = stage;
 	}
 
-	snprintf( name, name_len, "END%i", stage );
+	idStr::snPrintf( name, name_len, "END%i", stage );
 	V_DrawPatch( ( ORIGINAL_WIDTH - 13 * 8 ) / 2, ( ORIGINAL_HEIGHT - 8 * 8 ) / 2, 0, ( patch_t* )W_CacheLumpName( name, PU_CACHE_SHARED ) );
 }
 

--- a/doomclassic/doom/g_game.cpp
+++ b/doomclassic/doom/g_game.cpp
@@ -1587,7 +1587,7 @@ qboolean G_DoLoadGame()
 
 	// skip the description field
 	memset( vcheck, 0, sizeof( vcheck ) );
-	sprintf( vcheck, "version %i", VERSION );
+	idStr::snPrintf( vcheck, sizeof( vcheck ), "version %i", VERSION );
 	if( strcmp( ( char* )::g->save_p, vcheck ) )
 	{
 		loadingGame = false;
@@ -1679,17 +1679,17 @@ qboolean G_DoSaveGame( void )
 
 	if( common->GetCurrentGame() == DOOM_CLASSIC )
 	{
-		sprintf( name, "DOOM\\%s%d.dsg", SAVEGAMENAME, ::g->savegameslot );
+		idStr::snPrintf( name, sizeof( name ), "DOOM\\%s%d.dsg", SAVEGAMENAME, ::g->savegameslot );
 	}
 	else
 	{
 		if( DoomLib::expansionSelected == doom2 )
 		{
-			sprintf( name, "DOOM2\\%s%d.dsg", SAVEGAMENAME, ::g->savegameslot );
+			idStr::snPrintf( name, sizeof( name ), "DOOM2\\%s%d.dsg", SAVEGAMENAME, ::g->savegameslot );
 		}
 		else
 		{
-			sprintf( name, "DOOM2_NRFTL\\%s%d.dsg", SAVEGAMENAME, ::g->savegameslot );
+			idStr::snPrintf( name, sizeof( name ), "DOOM2_NRFTL\\%s%d.dsg", SAVEGAMENAME, ::g->savegameslot );
 		}
 
 	}
@@ -1700,7 +1700,7 @@ qboolean G_DoSaveGame( void )
 	::g->save_p += SAVESTRINGSIZE;
 
 	memset( name2, 0, sizeof( name2 ) );
-	sprintf( name2, "version %i", VERSION );
+	idStr::snPrintf( name2, sizeof( name2 ), "version %i", VERSION );
 	memcpy( ::g->save_p, name2, VERSIONSIZE );
 	::g->save_p += VERSIONSIZE;
 

--- a/doomclassic/doom/hu_stuff.cpp
+++ b/doomclassic/doom/hu_stuff.cpp
@@ -328,7 +328,7 @@ void HU_Init( void )
 	j = HU_FONTSTART;
 	for( i = 0; i < HU_FONTSIZE; i++ )
 	{
-		snprintf( buffer, buffer_len, "STCFN%03d", j++ );
+		idStr::snPrintf( buffer, buffer_len, "STCFN%03d", j++ );
 		::g->hu_font[i] = ( patch_t* ) W_CacheLumpName( buffer, PU_STATIC_SHARED );
 	}
 

--- a/doomclassic/doom/i_sound_openal.cpp
+++ b/doomclassic/doom/i_sound_openal.cpp
@@ -163,7 +163,7 @@ void* getsfx( const char* sfxname, int* len )
 	//float               scale = 1.0f;
 
 	// Get the sound data from the WAD
-	sprintf( name, "ds%s", sfxname );
+	idStr::snPrintf( name, sizeof( name ), "ds%s", sfxname );
 
 	// Scale down the plasma gun, it clips
 	//if ( strcmp( sfxname, "plasma" ) == 0 ) {
@@ -243,7 +243,7 @@ I_GetSfxLumpNum
 int I_GetSfxLumpNum( sfxinfo_t* sfx )
 {
 	char namebuf[9];
-	sprintf( namebuf, "ds%s", sfx->name );
+	idStr::snPrintf( namebuf, sizeof( namebuf ), "ds%s", sfx->name );
 	return W_GetNumForName( namebuf );
 }
 

--- a/doomclassic/doom/i_system.cpp
+++ b/doomclassic/doom/i_system.cpp
@@ -135,7 +135,7 @@ void I_Printf( const char* msg, ... )
 	if( debugOutput )
 	{
 		va_start( argptr, msg );
-		vsprintf( pmsg, msg, argptr );
+		idStr::vsnPrintf( pmsg, sizeof( pmsg ), msg, argptr );
 
 		safeOutputDebug( pmsg );
 
@@ -153,7 +153,7 @@ void I_PrintfE( const char* msg, ... )
 	if( debugOutput )
 	{
 		va_start( argptr, msg );
-		vsprintf( pmsg, msg, argptr );
+		idStr::vsnPrintf( pmsg, sizeof( pmsg ), msg, argptr );
 
 		safeOutputDebug( "ERROR: " );
 		safeOutputDebug( pmsg );

--- a/doomclassic/doom/m_menu.cpp
+++ b/doomclassic/doom/m_menu.cpp
@@ -261,17 +261,17 @@ void M_ReadSaveStrings( void )
 	{
 		if( common->GetCurrentGame() == DOOM_CLASSIC )
 		{
-			sprintf( name, "DOOM\\%s%d.dsg",  SAVEGAMENAME, i );
+			idStr::snPrintf( name, sizeof( name ), "DOOM\\%s%d.dsg",  SAVEGAMENAME, i );
 		}
 		else
 		{
 			if( DoomLib::idealExpansion == doom2 )
 			{
-				sprintf( name, "DOOM2\\%s%d.dsg",  SAVEGAMENAME, i );
+				idStr::snPrintf( name, sizeof( name ), "DOOM2\\%s%d.dsg",  SAVEGAMENAME, i );
 			}
 			else
 			{
-				sprintf( name, "DOOM2_NRFTL\\%s%d.dsg",  SAVEGAMENAME, i );
+				idStr::snPrintf( name, sizeof( name ), "DOOM2_NRFTL\\%s%d.dsg",  SAVEGAMENAME, i );
 			}
 
 		}
@@ -520,7 +520,7 @@ void M_QuickSave( void )
 		::g->quickSaveSlot = -2;	// means to pick a slot now
 		return;
 	}
-	sprintf( ::g->tempstring, QSPROMPT, ::g->savegamestrings[::g->quickSaveSlot] );
+	idStr::snPrintf( ::g->tempstring, sizeof( ::g->tempstring ), QSPROMPT, ::g->savegamestrings[::g->quickSaveSlot] );
 	M_StartMessage( ::g->tempstring, M_QuickSaveResponse, true );
 }
 
@@ -552,7 +552,7 @@ void M_QuickLoad( void )
 		M_StartMessage( QSAVESPOT, NULL, false );
 		return;
 	}
-	sprintf( ::g->tempstring, QLPROMPT, ::g->savegamestrings[::g->quickSaveSlot] );
+	idStr::snPrintf( ::g->tempstring, sizeof( ::g->tempstring ), QLPROMPT, ::g->savegamestrings[::g->quickSaveSlot] );
 	M_StartMessage( ::g->tempstring, M_QuickLoadResponse, true );
 }
 

--- a/doomclassic/doom/p_pspr.cpp
+++ b/doomclassic/doom/p_pspr.cpp
@@ -618,7 +618,7 @@ extern "C" {
 								 ::g->linetarget->x, ::g->linetarget->y );
 		if( angle - player->mo->angle > ANG180 )
 		{
-			if( angle - player->mo->angle < -ANG90 / 20 )
+			if( angle - player->mo->angle < UINT_MAX - ANG90 / 20 + 1 )	// SRS - make uint math explicit
 			{
 				player->mo->angle = angle + ANG90 / 21;
 			}

--- a/doomclassic/doom/p_setup.cpp
+++ b/doomclassic/doom/p_setup.cpp
@@ -687,11 +687,11 @@ P_SetupLevel
 	{
 		if( map < 10 )
 		{
-			sprintf( lumpname, "map0%i", map % 100 );
+			idStr::snPrintf( lumpname, sizeof( lumpname ), "map0%i", map % 100 );
 		}
 		else
 		{
-			sprintf( lumpname, "map%i", map % 100 );
+			idStr::snPrintf( lumpname, sizeof( lumpname ), "map%i", map % 100 );
 		}
 	}
 	else

--- a/doomclassic/doom/p_user.cpp
+++ b/doomclassic/doom/p_user.cpp
@@ -225,7 +225,7 @@ void P_DeathThink( player_t* player )
 
 		delta = angle - player->mo->angle;
 
-		if( delta < ANG5 || delta > ( unsigned ) - ANG5 )
+		if( delta < ANG5 || delta > UINT_MAX - ANG5 + 1 )	// SRS - make uint math explicit
 		{
 			// Looking at killer,
 			//  so fade damage flash down.

--- a/doomclassic/doom/r_bsp.cpp
+++ b/doomclassic/doom/r_bsp.cpp
@@ -308,7 +308,7 @@ void R_AddLine( seg_t*	line )
 		{
 			return;
 		}
-		angle2 = -::g->clipangle; // ALANHACK UNSIGNED
+		angle2 = UINT_MAX - ::g->clipangle + 1; // ALANHACK UNSIGNED, SRS - make uint math explicit
 	}
 
 	// The seg is in the view range,
@@ -477,7 +477,7 @@ qboolean R_CheckBBox( fixed_t*	bspcoord )
 			return false;
 		}
 
-		angle2 = -::g->clipangle;// ALANHACK UNSIGNED
+		angle2 = UINT_MAX - ::g->clipangle + 1;	// ALANHACK UNSIGNED, SRS - make uint math explicit
 	}
 
 

--- a/doomclassic/doom/r_main.cpp
+++ b/doomclassic/doom/r_main.cpp
@@ -331,7 +331,7 @@ R_PointToAngle
 			if( x > y )
 			{
 				// octant 8
-				return -tantoangle[SlopeDiv( y, x )]; // // ALANHACK UNSIGNED
+				return UINT_MAX - tantoangle[SlopeDiv( y, x )] + 1; // ALANHACK UNSIGNED, SRS - make uint math explicit
 			}
 			else
 			{

--- a/doomclassic/doom/r_segs.cpp
+++ b/doomclassic/doom/r_segs.cpp
@@ -638,7 +638,7 @@ R_StoreWallRange
 
 		if( offsetangle > ANG180 )
 		{
-			offsetangle = -offsetangle;    // ALANHACK UNSIGNED
+			offsetangle = UINT_MAX - offsetangle + 1;	// ALANHACK UNSIGNED, SRS - make uint math explicit
 		}
 
 		if( offsetangle > ANG90 )

--- a/doomclassic/doom/st_stuff.cpp
+++ b/doomclassic/doom/st_stuff.cpp
@@ -540,7 +540,7 @@ ST_Responder( event_t* ev )
 			else if( cht_CheckCheat( &cheat_mypos, ev->data1 ) )
 			{
 				static char	buf[ST_MSGWIDTH];
-				sprintf( buf, "ang=0x%x;x,y=(0x%x,0x%x)",
+				idStr::snPrintf( buf, sizeof( buf ), "ang=0x%x;x,y=(0x%x,0x%x)",
 						 ::g->players[::g->consoleplayer].mo->angle,
 						 ::g->players[::g->consoleplayer].mo->x,
 						 ::g->players[::g->consoleplayer].mo->y );
@@ -1069,7 +1069,7 @@ void ST_loadGraphics( void )
 	// key cards
 	for( i = 0; i < NUMCARDS; i++ )
 	{
-		sprintf( namebuf, "STKEYS%d", i );
+		idStr::snPrintf( namebuf, sizeof( namebuf ), "STKEYS%d", i );
 		::g->keys[i] = ( patch_t* ) W_CacheLumpName( namebuf, PU_STATIC_SHARED );
 	}
 
@@ -1079,7 +1079,7 @@ void ST_loadGraphics( void )
 	// ::g->arms ownership widgets
 	for( i = 0; i < 6; i++ )
 	{
-		sprintf( namebuf, "STGNUM%d", i + 2 );
+		idStr::snPrintf( namebuf, sizeof( namebuf ), "STGNUM%d", i + 2 );
 
 		// gray #
 		::g->arms[i][0] = ( patch_t* ) W_CacheLumpName( namebuf, PU_STATIC_SHARED );
@@ -1089,7 +1089,7 @@ void ST_loadGraphics( void )
 	}
 
 	// face backgrounds for different color ::g->players
-	sprintf( namebuf, "STFB%d", ::g->consoleplayer );
+	idStr::snPrintf( namebuf, sizeof( namebuf ), "STFB%d", ::g->consoleplayer );
 	::g->faceback = ( patch_t* ) W_CacheLumpName( namebuf, PU_STATIC_SHARED );
 
 	// status bar background bits
@@ -1101,18 +1101,18 @@ void ST_loadGraphics( void )
 	{
 		for( j = 0; j < ST_NUMSTRAIGHTFACES; j++ )
 		{
-			sprintf( namebuf, "STFST%d%d", i, j );
+			idStr::snPrintf( namebuf, sizeof( namebuf ), "STFST%d%d", i, j );
 			::g->faces[facenum++] = ( patch_t* )W_CacheLumpName( namebuf, PU_STATIC_SHARED );
 		}
-		sprintf( namebuf, "STFTR%d0", i );	// turn right
+		idStr::snPrintf( namebuf, sizeof( namebuf ), "STFTR%d0", i );	// turn right
 		::g->faces[facenum++] = ( patch_t* )W_CacheLumpName( namebuf, PU_STATIC_SHARED );
-		sprintf( namebuf, "STFTL%d0", i );	// turn left
+		idStr::snPrintf( namebuf, sizeof( namebuf ), "STFTL%d0", i );	// turn left
 		::g->faces[facenum++] = ( patch_t* )W_CacheLumpName( namebuf, PU_STATIC_SHARED );
-		sprintf( namebuf, "STFOUCH%d", i );	// ouch!
+		idStr::snPrintf( namebuf, sizeof( namebuf ), "STFOUCH%d", i );	// ouch!
 		::g->faces[facenum++] = ( patch_t* )W_CacheLumpName( namebuf, PU_STATIC_SHARED );
-		sprintf( namebuf, "STFEVL%d", i );	// evil grin ;)
+		idStr::snPrintf( namebuf, sizeof( namebuf ), "STFEVL%d", i );	// evil grin ;)
 		::g->faces[facenum++] = ( patch_t* )W_CacheLumpName( namebuf, PU_STATIC_SHARED );
-		sprintf( namebuf, "STFKILL%d", i );	// pissed off
+		idStr::snPrintf( namebuf, sizeof( namebuf ), "STFKILL%d", i );	// pissed off
 		::g->faces[facenum++] = ( patch_t* )W_CacheLumpName( namebuf, PU_STATIC_SHARED );
 	}
 	::g->faces[facenum++] = ( patch_t* )W_CacheLumpName( "STFGOD0", PU_STATIC_SHARED );
@@ -1516,7 +1516,7 @@ CONSOLE_COMMAND_SHIP( idmypos, "for player position", 0 )
 	}
 
 	static char	buf[ST_MSGWIDTH];
-	sprintf( buf, "ang=0x%x;x,y=(0x%x,0x%x)",
+	idStr::snPrintf( buf, sizeof( buf ), "ang=0x%x;x,y=(0x%x,0x%x)",
 			 ::g->players[::g->consoleplayer].mo->angle,
 			 ::g->players[::g->consoleplayer].mo->x,
 			 ::g->players[::g->consoleplayer].mo->y );

--- a/doomclassic/doom/wi_stuff.cpp
+++ b/doomclassic/doom/wi_stuff.cpp
@@ -1720,7 +1720,7 @@ void WI_loadData( void )
 		::g->lnames = ( patch_t** ) DoomLib::Z_Malloc( sizeof( patch_t* ) * ( NUMMAPS ), PU_LEVEL_SHARED, 0 );
 		for( i = 0 ; i < NUMMAPS ; i++ )
 		{
-			sprintf( name, "WILV%d%d", ::g->wbs->epsd, i );
+			idStr::snPrintf( name, sizeof( name ), "WILV%d%d", ::g->wbs->epsd, i );
 			::g->lnames[i] = ( patch_t* )W_CacheLumpName( name, PU_LEVEL_SHARED );
 		}
 
@@ -1763,7 +1763,7 @@ void WI_loadData( void )
 	for( i = 0; i < 10; i++ )
 	{
 		// numbers 0-9
-		sprintf( name, "WINUM%d", i );
+		idStr::snPrintf( name, sizeof( name ), "WINUM%d", i );
 		::g->num[i] = ( patch_t* )W_CacheLumpName( name, PU_LEVEL_SHARED );
 	}
 
@@ -1820,11 +1820,11 @@ void WI_loadData( void )
 	for( i = 0 ; i < MAXPLAYERS ; i++ )
 	{
 		// "1,2,3,4"
-		sprintf( name, "STPB%d", i );
+		idStr::snPrintf( name, sizeof( name ), "STPB%d", i );
 		::g->wistuff_p[i] = ( patch_t* )W_CacheLumpName( name, PU_LEVEL_SHARED );
 
 		// "1,2,3,4"
-		sprintf( name, "WIBP%d", i + 1 );
+		idStr::snPrintf( name, sizeof( name ), "WIBP%d", i + 1 );
 		::g->wistuff_bp[i] = ( patch_t* )W_CacheLumpName( name, PU_LEVEL_SHARED );
 	}
 

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -182,8 +182,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
 		# add clang-specific settings for warnings (the second one make sure clang doesn't complain
 		# about unknown -W flags, like -Wno-unused-but-set-variable)
-		# SRS - Add -Wno-expansion-to-defined to list of warning settings
-		add_definitions(-Wno-local-type-template-args -Wno-unknown-warning-option -Wno-inline-new-delete -Wno-switch-enum -Wno-expansion-to-defined -Wno-nullability-completeness)
+		# SRS - Add -Wno-expansion-to-defined, Wno-nullability-completeness and -Wno-shorten-64-to-32 to list of warning settings
+		add_definitions(-Wno-local-type-template-args -Wno-unknown-warning-option -Wno-inline-new-delete -Wno-switch-enum -Wno-expansion-to-defined -Wno-nullability-completeness -Wno-shorten-64-to-32)
 	endif()
 	
 	if(NOT CMAKE_CROSSCOMPILING AND ONATIVE)

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -1539,6 +1539,15 @@ if(MSVC)
 		)
 	endif()
 	
+	# SRS - disable certain MSVC-specific warnings for select third-party source libraries, consider updating versions in the future?
+	set_source_files_properties(
+			${JPEG_SOURCES}
+			${PNG_SOURCES}
+			${OGGVORBIS_SOURCES}
+			PROPERTIES
+			COMPILE_FLAGS "/wd4101 /wd4267"	# C4101: unreferenced local variable, C4267: type conversion with possible loss of data
+		)
+	
 	list(APPEND RBDOOM3_SOURCES ${WIN32_RESOURCES})
 	
 	add_executable(RBDoom3BFG WIN32 ${RBDOOM3_INCLUDES} ${RBDOOM3_SOURCES})

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -314,33 +314,10 @@ if(STANDALONE)
 	set(DOOM_CLASSIC OFF)
 endif()
 
-if (USE_SYSTEM_ZLIB)
-  find_package(ZLIB REQUIRED)
-endif(USE_SYSTEM_ZLIB)
-
-if (ZLIB_FOUND)
-    include_directories(${ZLIB_INCLUDE_DIRS})
-    set(ZLIB_LIBRARY ${ZLIB_LIBRARIES})
-else (ZLIB_FOUND)
-    include_directories("libs/zlib")
-    set(ZLIB_LIBRARY "" )
-endif (ZLIB_FOUND)
-
-if(USE_SYSTEM_LIBPNG)
-	find_package(PNG REQUIRED)
-endif (USE_SYSTEM_LIBPNG)
-
-if (PNG_FOUND)
-    include_directories(${PNG_INCLUDE_DIRS})
-    set(PNG_LIBRARY ${PNG_LIBRARIES})
-else (PNG_FOUND)
-    include_directories("libs/png")
-    set(PNG_LIBRARY "" )
-endif (PNG_FOUND)
-
-if(USE_SYSTEM_LIBJPEG)
-	find_package(JPEG REQUIRED)
-endif(USE_SYSTEM_LIBJPEG)
+# SRS - set libjpeg as first include path to prioritize bundled format_message() fix
+if (USE_SYSTEM_LIBJPEG)
+	find_package(JPEG)
+endif (USE_SYSTEM_LIBJPEG)
 
 if (JPEG_FOUND)
     include_directories(${JPEG_INCLUDE_DIRS})
@@ -350,6 +327,44 @@ else (JPEG_FOUND)
     include_directories("libs/jpeg-6")
     set(JPEG_LIBRARY "" )
 endif (JPEG_FOUND)
+
+if (USE_SYSTEM_LIBPNG)
+	find_package(PNG)
+endif (USE_SYSTEM_LIBPNG)
+
+# SRS - if system libpng was found, then system zlib was also found via cmake dependency
+if (PNG_FOUND)
+    include_directories(${PNG_INCLUDE_DIRS})
+    set(PNG_LIBRARY ${PNG_LIBRARIES})
+else (PNG_FOUND)
+    include_directories("libs/png")
+    set(PNG_LIBRARY "" )
+
+	# SRS - search for system zlib only if we have not already searched via system libpng
+	if (USE_SYSTEM_ZLIB AND NOT USE_SYSTEM_LIBPNG)
+	  find_package(ZLIB)
+	endif (USE_SYSTEM_ZLIB AND NOT USE_SYSTEM_LIBPNG)
+
+	if (USE_SYSTEM_ZLIB AND ZLIB_FOUND)
+		include_directories(${ZLIB_INCLUDE_DIRS})
+		set(ZLIB_LIBRARY ${ZLIB_LIBRARIES})
+	else (USE_SYSTEM_ZLIB AND ZLIB_FOUND)
+		include_directories("libs/zlib")
+		set(ZLIB_LIBRARY "" )
+	endif (USE_SYSTEM_ZLIB AND ZLIB_FOUND)
+endif (PNG_FOUND)
+
+#SRS - move rapidjson before vulkan and other includes to prioritize bundled iterator fixes
+if (USE_SYSTEM_RAPIDJSON)
+	find_package(rapidjson)
+endif (USE_SYSTEM_RAPIDJSON)
+
+if (RAPIDJSON_FOUND)
+	include_directories("${RAPIDJSON_INCLUDE_DIRS}")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${RAPIDJSON_CXX_FLAGS}")
+else (RAPIDJSON_FOUND)
+	include_directories("libs/rapidjson/include")
+endif (RAPIDJSON_FOUND)
 
 include_directories("libs/imgui")
 
@@ -440,19 +455,6 @@ if(USE_VULKAN)
 endif()
 
 include_directories(${NVRHI_DIR}/include)
-
-
-if(USE_SYSTEM_RAPIDJSON)
-	find_package(rapidjson REQUIRED)
-endif(USE_SYSTEM_RAPIDJSON)
-
-if (RAPIDJSON_FOUND)
-	include_directories("${RAPIDJSON_INCLUDE_DIRS}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${RAPIDJSON_CXX_FLAGS}")
-else (RAPIDJSON_FOUND)
-	include_directories("libs/rapidjson/include")
-endif (RAPIDJSON_FOUND)
-
 
 include_directories("libs/optick")
 
@@ -1539,14 +1541,14 @@ if(MSVC)
 		)
 	endif()
 	
-	# SRS - disable certain MSVC-specific warnings for select third-party source libraries, consider updating versions in the future?
+	# SRS - disable certain MSVC warnings for select third-party source libraries, consider updating versions in the future?
 	set_source_files_properties(
 			${JPEG_SOURCES}
 			${PNG_SOURCES}
 			${OGGVORBIS_SOURCES}
 			PROPERTIES
 			COMPILE_FLAGS "/wd4101 /wd4267"	# C4101: unreferenced local variable, C4267: type conversion with possible loss of data
-		)
+			)
 	
 	list(APPEND RBDOOM3_SOURCES ${WIN32_RESOURCES})
 	
@@ -1685,6 +1687,15 @@ else()
 			LIST(APPEND _compiler_FLAGS " -I${item}")
 		ENDFOREACH(item)
 	endif()
+
+	# SRS - disable certain gcc/clang warnings for select third-party source libraries, consider updating versions in the future?
+	set_source_files_properties(
+			${JPEG_SOURCES}
+			${ZLIB_SOURCES}
+			${MINIZIP_SOURCES}
+			PROPERTIES
+			COMPILE_FLAGS "-Wno-stringop-overread -Wno-deprecated-non-prototype"
+			)
 		
 	GET_DIRECTORY_PROPERTY(_directory_flags DEFINITIONS)
 	LIST(APPEND _compiler_FLAGS ${_directory_flags})

--- a/neo/cm/CollisionModel_debug.cpp
+++ b/neo/cm/CollisionModel_debug.cpp
@@ -511,11 +511,11 @@ void idCollisionModelManagerLocal::DebugOutput( const idVec3& origin )
 	total_translation += t;
 	if( cm_testTimes.GetInteger() > 9999 )
 	{
-		sprintf( buf, "%3dK", ( int )( cm_testTimes.GetInteger() / 1000 ) );
+		idStr::snPrintf( buf, sizeof( buf ), "%3dK", ( int )( cm_testTimes.GetInteger() / 1000 ) );
 	}
 	else
 	{
-		sprintf( buf, "%4d", cm_testTimes.GetInteger() );
+		idStr::snPrintf( buf, sizeof( buf ), "%4d", cm_testTimes.GetInteger() );
 	}
 	common->Printf( "%s translations: %4d milliseconds, (min = %d, max = %d, av = %1.1f)\n", buf, t, min_translation, max_translation, ( float ) total_translation / num_translation );
 
@@ -571,11 +571,11 @@ void idCollisionModelManagerLocal::DebugOutput( const idVec3& origin )
 		total_rotation += t;
 		if( cm_testTimes.GetInteger() > 9999 )
 		{
-			sprintf( buf, "%3dK", ( int )( cm_testTimes.GetInteger() / 1000 ) );
+			idStr::snPrintf( buf, sizeof( buf ), "%3dK", ( int )( cm_testTimes.GetInteger() / 1000 ) );
 		}
 		else
 		{
-			sprintf( buf, "%4d", cm_testTimes.GetInteger() );
+			idStr::snPrintf( buf, sizeof( buf ), "%4d", cm_testTimes.GetInteger() );
 		}
 		common->Printf( "%s rotation: %4d milliseconds, (min = %d, max = %d, av = %1.1f)\n", buf, t, min_rotation, max_rotation, ( float ) total_rotation / num_rotation );
 	}

--- a/neo/d3xp/MultiplayerGame.cpp
+++ b/neo/d3xp/MultiplayerGame.cpp
@@ -653,7 +653,7 @@ const char* idMultiplayerGame::GameTime()
 		}
 		else
 		{
-			sprintf( buff, "WMP %i", s );
+			idStr::snPrintf( buff, sizeof( buff ), "WMP %i", s );
 		}
 	}
 	else

--- a/neo/d3xp/Weapon.cpp
+++ b/neo/d3xp/Weapon.cpp
@@ -3052,7 +3052,7 @@ const char* idWeapon::GetAmmoNameForNum( ammo_t ammonum )
 		return NULL;
 	}
 
-	sprintf( text, "%d", ammonum );
+	idStr::snPrintf( text, sizeof( text ), "%d", ammonum );
 
 	num = ammoDict->GetNumKeyVals();
 	for( i = 0; i < num; i++ )

--- a/neo/d3xp/ai/AAS_routing.cpp
+++ b/neo/d3xp/ai/AAS_routing.cpp
@@ -190,8 +190,8 @@ void idAASLocal::CalculateAreaTravelTimes()
 		}
 	}
 
-	// RB: 64 bit fixes, changed unsigned int to ptrdiff_t
-	assert( ( ( ptrdiff_t ) bytePtr - ( ptrdiff_t ) areaTravelTimes ) <= numAreaTravelTimes * sizeof( unsigned short ) );
+	// RB: 64 bit fixes, changed unsigned int to ptrdiff_t, SRS - added ptrdiff_t casts on RHS for type consistency across compare operator
+	assert( ( ( ptrdiff_t ) bytePtr - ( ptrdiff_t ) areaTravelTimes ) <= ( ptrdiff_t ) numAreaTravelTimes * ( ptrdiff_t ) sizeof( unsigned short ) );
 	// RB end
 
 }

--- a/neo/d3xp/gamesys/Event.cpp
+++ b/neo/d3xp/gamesys/Event.cpp
@@ -84,7 +84,7 @@ idEventDef::idEventDef( const char* command, const char* formatspec, char return
 	if( numargs > D_EVENT_MAXARGS )
 	{
 		eventError = true;
-		sprintf( eventErrorMsg, "idEventDef::idEventDef : Too many args for '%s' event.", name );
+		idStr::snPrintf( eventErrorMsg, sizeof( eventErrorMsg ), "idEventDef::idEventDef : Too many args for '%s' event.", name );
 		return;
 	}
 
@@ -138,7 +138,7 @@ idEventDef::idEventDef( const char* command, const char* formatspec, char return
 
 			default :
 				eventError = true;
-				sprintf( eventErrorMsg, "idEventDef::idEventDef : Invalid arg format '%s' string for '%s' event.", formatspec, name );
+				idStr::snPrintf( eventErrorMsg, sizeof( eventErrorMsg ), "idEventDef::idEventDef : Invalid arg format '%s' string for '%s' event.", formatspec, name );
 				return;
 				break;
 		}
@@ -158,7 +158,7 @@ idEventDef::idEventDef( const char* command, const char* formatspec, char return
 			if( strcmp( formatspec, ev->formatspec ) != 0 )
 			{
 				eventError = true;
-				sprintf( eventErrorMsg, "idEvent '%s' defined twice with same name but differing format strings ('%s'!='%s').",
+				idStr::snPrintf( eventErrorMsg, sizeof( eventErrorMsg ), "idEvent '%s' defined twice with same name but differing format strings ('%s'!='%s').",
 						 command, formatspec, ev->formatspec );
 				return;
 			}
@@ -166,7 +166,7 @@ idEventDef::idEventDef( const char* command, const char* formatspec, char return
 			if( ev->returnType != returnType )
 			{
 				eventError = true;
-				sprintf( eventErrorMsg, "idEvent '%s' defined twice with same name but differing return types ('%c'!='%c').",
+				idStr::snPrintf( eventErrorMsg, sizeof( eventErrorMsg ), "idEvent '%s' defined twice with same name but differing return types ('%c'!='%c').",
 						 command, returnType, ev->returnType );
 				return;
 			}
@@ -181,7 +181,7 @@ idEventDef::idEventDef( const char* command, const char* formatspec, char return
 	if( numEventDefs >= MAX_EVENTS )
 	{
 		eventError = true;
-		sprintf( eventErrorMsg, "numEventDefs >= MAX_EVENTS" );
+		idStr::snPrintf( eventErrorMsg, sizeof( eventErrorMsg ), "numEventDefs >= MAX_EVENTS" );
 		return;
 	}
 	eventDefList[numEventDefs] = ev;

--- a/neo/d3xp/gamesys/SaveGame.cpp
+++ b/neo/d3xp/gamesys/SaveGame.cpp
@@ -1085,7 +1085,7 @@ void idRestoreGame::Error( const char* fmt, ... )
 	char	text[ 1024 ];
 
 	va_start( argptr, fmt );
-	vsprintf( text, fmt, argptr );
+	idStr::vsnPrintf( text, sizeof( text ), fmt, argptr );
 	va_end( argptr );
 
 	objects.DeleteContents( true );

--- a/neo/d3xp/gamesys/SysCmds.cpp
+++ b/neo/d3xp/gamesys/SysCmds.cpp
@@ -1437,7 +1437,7 @@ static void PrintFloat( float f )
 	char buf[128];
 	int i;
 
-	for( i = sprintf( buf, "%3.2f", f ); i < 7; i++ )
+	for( i = idStr::snPrintf( buf, sizeof( buf ), "%3.2f", f ); i < 7; i++ )
 	{
 		buf[i] = ' ';
 	}

--- a/neo/d3xp/gamesys/SysCvar.cpp
+++ b/neo/d3xp/gamesys/SysCvar.cpp
@@ -43,7 +43,7 @@ All game cvars should be defined here.
 */
 
 struct gameVersion_s {
-	gameVersion_s() { sprintf( string, "%s.%d%s %s %s %s", ENGINE_VERSION, BUILD_NUMBER, BUILD_DEBUG, BUILD_STRING, __DATE__, __TIME__ ); }
+	gameVersion_s() { idStr::snPrintf( string, sizeof( string ), "%s.%d%s %s %s %s", ENGINE_VERSION, BUILD_NUMBER, BUILD_DEBUG, BUILD_STRING, __DATE__, __TIME__ ); }
 	char	string[256];
 } gameVersion;
 

--- a/neo/d3xp/script/Script_Compiler.cpp
+++ b/neo/d3xp/script/Script_Compiler.cpp
@@ -264,7 +264,7 @@ void idCompiler::Error( const char* message, ... ) const
 	char	string[ 1024 ];
 
 	va_start( argptr, message );
-	vsprintf( string, message, argptr );
+	idStr::vsnPrintf( string, sizeof( string ), message, argptr );
 	va_end( argptr );
 
 #if defined(USE_EXCEPTIONS)
@@ -287,7 +287,7 @@ void idCompiler::Warning( const char* message, ... ) const
 	char	string[ 1024 ];
 
 	va_start( argptr, message );
-	vsprintf( string, message, argptr );
+	idStr::vsnPrintf( string, sizeof( string ), message, argptr );
 	va_end( argptr );
 
 	parserPtr->Warning( "%s", string );

--- a/neo/d3xp/script/Script_Interpreter.cpp
+++ b/neo/d3xp/script/Script_Interpreter.cpp
@@ -504,7 +504,7 @@ void idInterpreter::Error( const char* fmt, ... ) const
 	char	text[ 1024 ];
 
 	va_start( argptr, fmt );
-	vsprintf( text, fmt, argptr );
+	idStr::vsnPrintf( text, sizeof( text ), fmt, argptr );
 	va_end( argptr );
 
 	StackTrace();
@@ -533,7 +533,7 @@ void idInterpreter::Warning( const char* fmt, ... ) const
 	char	text[ 1024 ];
 
 	va_start( argptr, fmt );
-	vsprintf( text, fmt, argptr );
+	idStr::vsnPrintf( text, sizeof( text ), fmt, argptr );
 	va_end( argptr );
 
 	if( ( instructionPointer >= 0 ) && ( instructionPointer < gameLocal.program.NumStatements() ) )

--- a/neo/d3xp/script/Script_Interpreter.h
+++ b/neo/d3xp/script/Script_Interpreter.h
@@ -207,11 +207,11 @@ ID_INLINE const char* idInterpreter::FloatToString( float value )
 
 	if( value == ( float )( int )value )
 	{
-		sprintf( text, "%d", ( int )value );
+		idStr::snPrintf( text, sizeof( text ), "%d", ( int )value );
 	}
 	else
 	{
-		sprintf( text, "%f", value );
+		idStr::snPrintf( text, sizeof( text ), "%f", value );
 	}
 	return text;
 }

--- a/neo/d3xp/script/Script_Thread.cpp
+++ b/neo/d3xp/script/Script_Thread.cpp
@@ -892,7 +892,7 @@ void idThread::Error( const char* fmt, ... ) const
 	char	text[ 1024 ];
 
 	va_start( argptr, fmt );
-	vsprintf( text, fmt, argptr );
+	idStr::vsnPrintf( text, sizeof( text ), fmt, argptr );
 	va_end( argptr );
 
 	interpreter.Error( text );
@@ -909,7 +909,7 @@ void idThread::Warning( const char* fmt, ... ) const
 	char	text[ 1024 ];
 
 	va_start( argptr, fmt );
-	vsprintf( text, fmt, argptr );
+	idStr::vsnPrintf( text, sizeof( text ), fmt, argptr );
 	va_end( argptr );
 
 	interpreter.Warning( text );

--- a/neo/framework/Common.cpp
+++ b/neo/framework/Common.cpp
@@ -63,7 +63,7 @@ struct version_s
 {
 	version_s()
 	{
-		sprintf( string, "%s.%d%s %s %s %s", ENGINE_VERSION, BUILD_NUMBER, BUILD_DEBUG, BUILD_STRING, __DATE__, __TIME__ );
+		idStr::snPrintf( string, sizeof( string ), "%s.%d%s %s %s %s", ENGINE_VERSION, BUILD_NUMBER, BUILD_DEBUG, BUILD_STRING, __DATE__, __TIME__ );
 	}
 	char	string[256];
 } version;

--- a/neo/framework/Common_printf.cpp
+++ b/neo/framework/Common_printf.cpp
@@ -125,11 +125,11 @@ void idCommonLocal::VPrintf( const char* fmt, va_list args )
 		int	t = Sys_Milliseconds();
 		if( com_timestampPrints.GetInteger() == 1 )
 		{
-			sprintf( msg, "[%5.2f]", t * 0.001f );
+			idStr::snPrintf( msg, sizeof( msg ), "[%5.2f]", t * 0.001f );
 		}
 		else
 		{
-			sprintf( msg, "[%i]", t );
+			idStr::snPrintf( msg, sizeof( msg ), "[%i]", t );
 		}
 	}
 	timeLength = strlen( msg );

--- a/neo/framework/Console.cpp
+++ b/neo/framework/Console.cpp
@@ -200,6 +200,10 @@ void idConsoleLocal::DrawTextRightAlign( float x, float& y, const char* text, ..
 	va_start( argptr, text );
 	int i = idStr::vsnPrintf( string, sizeof( string ), text, argptr );
 	va_end( argptr );
+	if( i < 0 )
+	{
+		i = sizeof( string ) - 1;
+	}
 	renderSystem->DrawSmallStringExt( x - i * SMALLCHAR_WIDTH, y + 2, string, colorWhite, true );
 	y += SMALLCHAR_HEIGHT + 4;
 }

--- a/neo/framework/DeclAF.cpp
+++ b/neo/framework/DeclAF.cpp
@@ -250,7 +250,7 @@ const char* idAFVector::ToString( idStr& str, const int precision )
 		case idAFVector::VEC_COORDS:
 		{
 			char format[128];
-			sprintf( format, "( %%.%df, %%.%df, %%.%df )", precision, precision, precision );
+			idStr::snPrintf( format, sizeof( format ), "( %%.%df, %%.%df, %%.%df )", precision, precision, precision );
 			sprintf( str, format, vec.x, vec.y, vec.z );
 			break;
 		}

--- a/neo/framework/DeclManager.cpp
+++ b/neo/framework/DeclManager.cpp
@@ -1757,7 +1757,7 @@ void idDeclManagerLocal::WritePrecacheCommands( idFile* f )
 			}
 
 			char	str[1024];
-			sprintf( str, "touch %s %s\n", declTypes[i]->typeName.c_str(), decl->GetName() );
+			idStr::snPrintf( str, sizeof( str ), "touch %s %s\n", declTypes[i]->typeName.c_str(), decl->GetName() );
 			common->Printf( "%s", str );
 			f->Printf( "%s", str );
 		}

--- a/neo/framework/File.cpp
+++ b/neo/framework/File.cpp
@@ -38,7 +38,7 @@ If you have questions concerning this license or the applicable additional terms
 FS_WriteFloatString
 =================
 */
-int FS_WriteFloatString( char* buf, const char* fmt, va_list argPtr )
+int FS_WriteFloatString( char* buf, int bufsize, const char* fmt, va_list argPtr )
 {
 	// DG: replaced long with int for 64bit compatibility in the whole function
 	int i;
@@ -77,44 +77,44 @@ int FS_WriteFloatString( char* buf, const char* fmt, va_list argPtr )
 							sprintf( tmp, "%1.10f", f );
 							tmp.StripTrailing( '0' );
 							tmp.StripTrailing( '.' );
-							index += sprintf( buf + index, "%s", tmp.c_str() );
+							index += idStr::snPrintf( buf + index, bufsize - index, "%s", tmp.c_str() );
 						}
 						else
 						{
-							index += sprintf( buf + index, format.c_str(), f );
+							index += idStr::snPrintf( buf + index, bufsize - index, format.c_str(), f );
 						}
 						break;
 					case 'd':
 					case 'i':
 						i = va_arg( argPtr, int );
-						index += sprintf( buf + index, format.c_str(), i );
+						index += idStr::snPrintf( buf + index, bufsize - index, format.c_str(), i );
 						break;
 					case 'u':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf + index, format.c_str(), u );
+						index += idStr::snPrintf( buf + index, bufsize - index, format.c_str(), u );
 						break;
 					case 'o':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf + index, format.c_str(), u );
+						index += idStr::snPrintf( buf + index, bufsize - index, format.c_str(), u );
 						break;
 					case 'x':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf + index, format.c_str(), u );
+						index += idStr::snPrintf( buf + index, bufsize - index, format.c_str(), u );
 						break;
 					case 'X':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf + index, format.c_str(), u );
+						index += idStr::snPrintf( buf + index, bufsize - index, format.c_str(), u );
 						break;
 					case 'c':
 						i = va_arg( argPtr, int );
-						index += sprintf( buf + index, format.c_str(), ( char ) i );
+						index += idStr::snPrintf( buf + index, bufsize - index, format.c_str(), ( char ) i );
 						break;
 					case 's':
 						str = va_arg( argPtr, char* );
-						index += sprintf( buf + index, format.c_str(), str );
+						index += idStr::snPrintf( buf + index, bufsize - index, format.c_str(), str );
 						break;
 					case '%':
-						index += sprintf( buf + index, "%s", format.c_str() );
+						index += idStr::snPrintf( buf + index, bufsize - index, "%s", format.c_str() );
 						break;
 					default:
 						common->Error( "FS_WriteFloatString: invalid format %s", format.c_str() );
@@ -127,16 +127,16 @@ int FS_WriteFloatString( char* buf, const char* fmt, va_list argPtr )
 				switch( *fmt )
 				{
 					case 't':
-						index += sprintf( buf + index, "\t" );
+						index += idStr::snPrintf( buf + index, bufsize - index, "\t" );
 						break;
 					case 'v':
-						index += sprintf( buf + index, "\v" );
+						index += idStr::snPrintf( buf + index, bufsize - index, "\v" );
 						break;
 					case 'n':
-						index += sprintf( buf + index, "\n" );
+						index += idStr::snPrintf( buf + index, bufsize - index, "\n" );
 						break;
 					case '\\':
-						index += sprintf( buf + index, "\\" );
+						index += idStr::snPrintf( buf + index, bufsize - index, "\\" );
 						break;
 					default:
 						common->Error( "FS_WriteFloatString: unknown escape character \'%c\'", *fmt );
@@ -145,7 +145,7 @@ int FS_WriteFloatString( char* buf, const char* fmt, va_list argPtr )
 				fmt++;
 				break;
 			default:
-				index += sprintf( buf + index, "%c", *fmt );
+				index += idStr::snPrintf( buf + index, bufsize - index, "%c", *fmt );
 				fmt++;
 				break;
 		}
@@ -285,7 +285,7 @@ int idFile::Printf( const char* fmt, ... )
 	va_list argptr;
 
 	va_start( argptr, fmt );
-	length = idStr::vsnPrintf( buf, MAX_PRINT_MSG - 1, fmt, argptr );
+	length = idStr::vsnPrintf( buf, sizeof( buf ), fmt, argptr );
 	va_end( argptr );
 
 	// so notepad formats the lines correctly
@@ -305,7 +305,11 @@ int idFile::VPrintf( const char* fmt, va_list args )
 	char buf[MAX_PRINT_MSG];
 	int length;
 
-	length = idStr::vsnPrintf( buf, MAX_PRINT_MSG - 1, fmt, args );
+	length = idStr::vsnPrintf( buf, sizeof( buf ), fmt, args );
+	if( length < 0 )
+	{
+		length = sizeof( buf ) - 1;
+	}
 	return Write( buf, length );
 }
 
@@ -321,7 +325,7 @@ int idFile::WriteFloatString( const char* fmt, ... )
 	va_list argPtr;
 
 	va_start( argPtr, fmt );
-	len = FS_WriteFloatString( buf, fmt, argPtr );
+	len = FS_WriteFloatString( buf, sizeof( buf ), fmt, argPtr );
 	va_end( argPtr );
 
 	return Write( buf, len );

--- a/neo/framework/TokenParser.cpp
+++ b/neo/framework/TokenParser.cpp
@@ -252,7 +252,7 @@ void idTokenParser::Error( VERIFY_FORMAT_STRING const char* str, ... )
 	va_list ap;
 
 	va_start( ap, str );
-	vsprintf( text, str, ap );
+	idStr::vsnPrintf( text, sizeof( text ), str, ap );
 	va_end( ap );
 
 	idLib::common->Warning( text );
@@ -263,7 +263,7 @@ void idTokenParser::Warning( VERIFY_FORMAT_STRING const char* str, ... )
 	va_list ap;
 
 	va_start( ap, str );
-	vsprintf( text, str, ap );
+	idStr::vsnPrintf( text, sizeof( text ), str, ap );
 	va_end( ap );
 
 	idLib::common->Warning( text );

--- a/neo/idlib/Heap.h
+++ b/neo/idlib/Heap.h
@@ -67,6 +67,10 @@ void* 		Mem_ClearedAlloc( const size_t size, const memTag_t tag );
 char* 		Mem_CopyString( const char* in );
 // RB end
 
+#ifdef _MSC_VER						// SRS: #pragma warning is MSVC specific
+#pragma warning( push )
+#pragma warning( disable : 4595 )	// C4595: non-member operator new or delete functions may not be declared inline
+#endif
 ID_INLINE void* operator new( size_t s )
 {
 	return Mem_Alloc( s, TAG_NEW );
@@ -87,6 +91,9 @@ ID_INLINE void operator delete[]( void* p ) noexcept
 {
 	Mem_Free( p );
 }
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif
 
 ID_INLINE void* operator new( size_t s, memTag_t tag )
 {

--- a/neo/idlib/Lexer.cpp
+++ b/neo/idlib/Lexer.cpp
@@ -247,7 +247,7 @@ void idLexer::Error( const char* str, ... )
 	}
 
 	va_start( ap, str );
-	vsprintf( text, str, ap );
+	idStr::vsnPrintf( text, sizeof( text ), str, ap );
 	va_end( ap );
 
 	if( idLexer::flags & LEXFL_NOFATALERRORS )
@@ -276,7 +276,7 @@ void idLexer::Warning( const char* str, ... )
 	}
 
 	va_start( ap, str );
-	vsprintf( text, str, ap );
+	idStr::vsnPrintf( text, sizeof( text ), str, ap );
 	va_end( ap );
 	idLib::common->Warning( "file %s, line %d: %s", idLexer::filename.c_str(), idLexer::line, text );
 }

--- a/neo/idlib/MapFile.cpp
+++ b/neo/idlib/MapFile.cpp
@@ -2777,7 +2777,7 @@ void MapPolygonMesh::SetContents()
 
 unsigned int MapPolygonMesh::GetGeometryCRC() const
 {
-	unsigned int i;
+	int i;
 	unsigned int crc = 0;
 	for( i = 0; i < verts.Num(); i++ )
 	{

--- a/neo/idlib/Parser.cpp
+++ b/neo/idlib/Parser.cpp
@@ -367,7 +367,7 @@ void idParser::Error( const char* str, ... ) const
 	va_list ap;
 
 	va_start( ap, str );
-	vsprintf( text, str, ap );
+	idStr::vsnPrintf( text, sizeof( text ), str, ap );
 	va_end( ap );
 	if( idParser::scriptstack )
 	{
@@ -386,7 +386,7 @@ void idParser::Warning( const char* str, ... ) const
 	va_list ap;
 
 	va_start( ap, str );
-	vsprintf( text, str, ap );
+	idStr::vsnPrintf( text, sizeof( text ), str, ap );
 	va_end( ap );
 	if( idParser::scriptstack )
 	{
@@ -836,7 +836,7 @@ int idParser::ExpandBuiltinDefine( idToken* deftoken, define_t* define, idToken*
 	{
 		case BUILTIN_LINE:
 		{
-			sprintf( buf, "%d", deftoken->line );
+			idStr::snPrintf( buf, sizeof( buf ), "%d", deftoken->line );
 			( *token ) = buf;
 			token->intvalue = deftoken->line;
 			token->floatvalue = deftoken->line;
@@ -2680,7 +2680,7 @@ int idParser::Directive_eval()
 	token.whiteSpaceEnd_p = NULL;
 	token.linesCrossed = 0;
 	token.flags = 0;
-	sprintf( buf, "%d", abs( value ) );
+	idStr::snPrintf( buf, sizeof( buf ), "%d", abs( value ) );
 	token = buf;
 	token.type = TT_NUMBER;
 	token.subtype = TT_INTEGER | TT_LONG | TT_DECIMAL;
@@ -2713,7 +2713,7 @@ int idParser::Directive_evalfloat()
 	token.whiteSpaceEnd_p = NULL;
 	token.linesCrossed = 0;
 	token.flags = 0;
-	sprintf( buf, "%1.2f", idMath::Fabs( value ) );
+	idStr::snPrintf( buf, sizeof( buf ), "%1.2f", idMath::Fabs( value ) );
 	token = buf;
 	token.type = TT_NUMBER;
 	token.subtype = TT_FLOAT | TT_LONG | TT_DECIMAL;
@@ -2850,7 +2850,7 @@ int idParser::DollarDirective_evalint()
 	token.whiteSpaceEnd_p = NULL;
 	token.linesCrossed = 0;
 	token.flags = 0;
-	sprintf( buf, "%d", abs( value ) );
+	idStr::snPrintf( buf, sizeof( buf ), "%d", abs( value ) );
 	token = buf;
 	token.type = TT_NUMBER;
 	token.subtype = TT_INTEGER | TT_LONG | TT_DECIMAL | TT_VALUESVALID;
@@ -2885,7 +2885,7 @@ int idParser::DollarDirective_evalfloat()
 	token.whiteSpaceEnd_p = NULL;
 	token.linesCrossed = 0;
 	token.flags = 0;
-	sprintf( buf, "%1.2f", fabs( value ) );
+	idStr::snPrintf( buf, sizeof( buf ), "%1.2f", fabs( value ) );
 	token = buf;
 	token.type = TT_NUMBER;
 	token.subtype = TT_FLOAT | TT_LONG | TT_DECIMAL | TT_VALUESVALID;

--- a/neo/idlib/Str.cpp
+++ b/neo/idlib/Str.cpp
@@ -1917,7 +1917,8 @@ void idStr::Copynz( char* dest, const char* src, int destsize )
 		return;
 	}
 
-	strncpy( dest, src, destsize - 1 );
+	// SRS - added size_t cast for 64-bit type consistency
+	strncpy( dest, src, (size_t)destsize - 1 );
 	dest[destsize - 1] = 0;
 }
 
@@ -2285,7 +2286,8 @@ int idStr::vsnPrintf( char* dest, int size, const char* fmt, va_list argptr )
 // RB begin
 #ifdef _WIN32
 #undef _vsnprintf
-	ret = _vsnprintf( dest, size - 1, fmt, argptr );
+	// SRS - added size_t cast for 64-bit type consistency
+	ret = _vsnprintf( dest, (size_t)size - 1, fmt, argptr );
 #define _vsnprintf	use_idStr_vsnPrintf
 #else
 #undef vsnprintf

--- a/neo/idlib/Str.h
+++ b/neo/idlib/Str.h
@@ -610,7 +610,7 @@ ID_INLINE idStr::idStr( const int i )
 	char text[ 64 ];
 	int l;
 
-	l = sprintf( text, "%d", i );
+	l = idStr::snPrintf( text, sizeof( text ), "%d", i );
 	EnsureAlloced( l + 1 );
 	strcpy( data, text );
 	len = l;
@@ -622,7 +622,7 @@ ID_INLINE idStr::idStr( const unsigned u )
 	char text[ 64 ];
 	int l;
 
-	l = sprintf( text, "%u", u );
+	l = idStr::snPrintf( text, sizeof( text ), "%u", u );
 	EnsureAlloced( l + 1 );
 	strcpy( data, text );
 	len = l;
@@ -758,7 +758,7 @@ ID_INLINE idStr operator+( const idStr& a, const float b )
 	char	text[ 64 ];
 	idStr	result( a );
 
-	sprintf( text, "%f", b );
+	idStr::snPrintf( text, sizeof( text ), "%f", b );
 	result.Append( text );
 
 	return result;
@@ -769,7 +769,7 @@ ID_INLINE idStr operator+( const idStr& a, const int b )
 	char	text[ 64 ];
 	idStr	result( a );
 
-	sprintf( text, "%d", b );
+	idStr::snPrintf( text, sizeof( text ), "%d", b );
 	result.Append( text );
 
 	return result;
@@ -780,7 +780,7 @@ ID_INLINE idStr operator+( const idStr& a, const unsigned b )
 	char	text[ 64 ];
 	idStr	result( a );
 
-	sprintf( text, "%u", b );
+	idStr::snPrintf( text, sizeof( text ), "%u", b );
 	result.Append( text );
 
 	return result;
@@ -790,7 +790,7 @@ ID_INLINE idStr& idStr::operator+=( const float a )
 {
 	char text[ 64 ];
 
-	sprintf( text, "%f", a );
+	idStr::snPrintf( text, sizeof( text ), "%f", a );
 	Append( text );
 
 	return *this;
@@ -800,7 +800,7 @@ ID_INLINE idStr& idStr::operator+=( const int a )
 {
 	char text[ 64 ];
 
-	sprintf( text, "%d", a );
+	idStr::snPrintf( text, sizeof( text ), "%d", a );
 	Append( text );
 
 	return *this;
@@ -810,7 +810,7 @@ ID_INLINE idStr& idStr::operator+=( const unsigned a )
 {
 	char text[ 64 ];
 
-	sprintf( text, "%u", a );
+	idStr::snPrintf( text, sizeof( text ), "%u", a );
 	Append( text );
 
 	return *this;

--- a/neo/libs/jpeg-6/jerror.cpp
+++ b/neo/libs/jpeg-6/jerror.cpp
@@ -68,7 +68,7 @@ error_exit( j_common_ptr cinfo )
 	char buffer[JMSG_LENGTH_MAX];
 
 	/* Create the message */
-	( *cinfo->err->format_message )( cinfo, buffer );
+	( *cinfo->err->format_message )( cinfo, buffer, sizeof( buffer ) );
 
 	/* Let the memory manager delete any temp files before we die */
 	jpeg_destroy( cinfo );
@@ -89,7 +89,7 @@ output_message( j_common_ptr cinfo )
 	char buffer[JMSG_LENGTH_MAX];
 
 	/* Create the message */
-	( *cinfo->err->format_message )( cinfo, buffer );
+	( *cinfo->err->format_message )( cinfo, buffer, sizeof( buffer ) );
 
 	/* Send it to stderr, adding a newline */
 	jpg_Printf( "%s\n", buffer );
@@ -144,7 +144,7 @@ emit_message( j_common_ptr cinfo, int msg_level )
  */
 
 METHODDEF void
-format_message( j_common_ptr cinfo, char* buffer )
+format_message( j_common_ptr cinfo, char* buffer, int bufsize )
 {
 	struct jpeg_error_mgr* err = cinfo->err;
 	int msg_code = err->msg_code;
@@ -190,11 +190,11 @@ format_message( j_common_ptr cinfo, char* buffer )
 	/* Format the message into the passed buffer */
 	if( isstring )
 	{
-		sprintf( buffer, msgtext, err->msg_parm.s );
+		snprintf( buffer, bufsize, msgtext, err->msg_parm.s );
 	}
 	else
 	{
-		sprintf( buffer, msgtext,
+		snprintf( buffer, bufsize, msgtext,
 				 err->msg_parm.i[0], err->msg_parm.i[1],
 				 err->msg_parm.i[2], err->msg_parm.i[3],
 				 err->msg_parm.i[4], err->msg_parm.i[5],

--- a/neo/libs/jpeg-6/jpeglib.h
+++ b/neo/libs/jpeg-6/jpeglib.h
@@ -646,7 +646,7 @@ struct jpeg_error_mgr
 	/* Routine that actually outputs a trace or error message */
 	JMETHOD( void, output_message, ( j_common_ptr cinfo ) );
 	/* Format a message string for the most recent JPEG error or message */
-	JMETHOD( void, format_message, ( j_common_ptr cinfo, char* buffer ) );
+	JMETHOD( void, format_message, ( j_common_ptr cinfo, char* buffer, int bufsize ) );
 #define JMSG_LENGTH_MAX  200	/* recommended size of format_message buffer */
 	/* Reset error state variables at start of a new image */
 	JMETHOD( void, reset_error_mgr, ( j_common_ptr cinfo ) );

--- a/neo/libs/libbinkdec/src/BinkAudio.cpp
+++ b/neo/libs/libbinkdec/src/BinkAudio.cpp
@@ -280,9 +280,10 @@ void BinkDecoder::DecodeAudioBlock(uint32_t trackIndex, BinkCommon::BitReader &b
             width = bits.GetBits(4);
             if (width == 0) 
 			{
-                memset(coeffs + i, 0, (j - i) * sizeof(*coeffs));
+				// SRS - added size_t and uint32_t casts for type consistency
+                memset(coeffs + i, 0, ((size_t)j - i) * sizeof(*coeffs));
                 i = j;
-                while (track->bands[k] < i)
+                while (track->bands[k] < (uint32_t)i)
                     q = quant[k++];
             }
 			else
@@ -317,7 +318,8 @@ void BinkDecoder::DecodeAudioBlock(uint32_t trackIndex, BinkCommon::BitReader &b
 			coeffs[0] /= 0.5f;
 			track->trans.dct.dct_calc(&track->trans.dct,  coeffs);
 
-			float mul = track->frameLength;
+			// SRS - added float cast for type consistency
+			float mul = (float)track->frameLength;
 
 			// vector_fmul_scalar()
 			for (int i = 0; i < track->frameLength; i++)
@@ -342,7 +344,8 @@ void BinkDecoder::DecodeAudioBlock(uint32_t trackIndex, BinkCommon::BitReader &b
 
 uint32_t BinkDecoder::GetNumAudioTracks()
 {
-	return audioTracks.size();
+	// SRS - added uint32_t cast for type consistency
+	return (uint32_t)audioTracks.size();
 }
 
 AudioInfo BinkDecoder::GetAudioTrackDetails(uint32_t trackIndex)

--- a/neo/libs/libbinkdec/src/BinkDecoder.cpp
+++ b/neo/libs/libbinkdec/src/BinkDecoder.cpp
@@ -78,7 +78,8 @@ BinkHandle Bink_Open(const char* fileName)
 	classInstances.push_back(newDecoder);
 
 	// get a handle ID
-	newHandle.instanceIndex = classInstances.size() - 1;
+	// SRS - added int cast for type consistency
+	newHandle.instanceIndex = (int)classInstances.size() - 1;
 	
 	return newHandle;
 }

--- a/neo/libs/libbinkdec/src/HuffmanVLC.cpp
+++ b/neo/libs/libbinkdec/src/HuffmanVLC.cpp
@@ -65,7 +65,8 @@ void VLC_InitTable(VLCtable &table, uint32_t maxLength, uint32_t size, const uin
 
 uint32_t VLC_GetSize(VLCtable &table)
 {
-	return table.size();
+	// SRS - added uint32_t cast for type consistency
+	return (uint32_t)table.size();
 }
 
 } // close namespace BinkCommon

--- a/neo/libs/libbinkdec/src/dct.c
+++ b/neo/libs/libbinkdec/src/dct.c
@@ -205,14 +205,19 @@ av_cold int ff_dct_init(DCTContext *s, int nbits, enum DCTTransformType inverse)
 
         s->csc2 = (FFTSample*)malloc(n/2 * sizeof(FFTSample));
 
+        // SRS - added check for failed malloc
+        if (!s->csc2)
+            return -1;
+
         if (ff_rdft_init(&s->rdft, nbits, inverse == DCT_III) < 0) {
             free(s->csc2);
             s->csc2 = 0;
             return -1;
         }
 
+		// SRS - added FFTSample and size_t casts for type consistency / 64-bit handling
         for (i = 0; i < n/2; i++)
-            s->csc2[i] = 0.5f / sin((M_PI / (2*n) * (2*i + 1)));
+            s->csc2[i] = (FFTSample)(0.5f / sin((M_PI / ((size_t)2*n) * ((size_t)2*i + 1))));
 
         switch(inverse) {
         case DCT_I  : s->dct_calc = ff_dct_calc_I_c; break;

--- a/neo/libs/libbinkdec/src/fft.c
+++ b/neo/libs/libbinkdec/src/fft.c
@@ -96,8 +96,9 @@ av_cold void ff_init_ff_cos_tabs(int index)
     int m = 1<<index;
     double freq = 2*M_PI/m;
     FFTSample *tab = FFT_NAME(ff_cos_tabs)[index];
+	// SRS - added FFTSample cast for type consistency
     for(i=0; i<=m/4; i++)
-        tab[i] = FIX15(cos(i*freq));
+        tab[i] = (FFTSample)FIX15(cos(i*freq));
     for(i=1; i<m/4; i++)
         tab[m/2-i] = tab[i];
 #endif

--- a/neo/libs/libbinkdec/src/mdct.c
+++ b/neo/libs/libbinkdec/src/mdct.c
@@ -84,10 +84,11 @@ av_cold int ff_mdct_init(FFTContext *s, int nbits, int inverse, double scale)
 
     theta = 1.0 / 8.0 + (scale < 0 ? n4 : 0);
     scale = sqrt(fabs(scale));
+	// SRS - added FFTSample casts for type consistency
     for(i=0;i<n4;i++) {
         alpha = 2 * M_PI * (i + theta) / n;
-        s->tcos[i*tstep] = FIX15(-cos(alpha) * scale);
-        s->tsin[i*tstep] = FIX15(-sin(alpha) * scale);
+        s->tcos[i*tstep] = (FFTSample)FIX15(-cos(alpha) * scale);
+        s->tsin[i*tstep] = (FFTSample)FIX15(-sin(alpha) * scale);
     }
     return 0;
  fail:

--- a/neo/libs/libbinkdec/src/rdft.c
+++ b/neo/libs/libbinkdec/src/rdft.c
@@ -107,7 +107,8 @@ av_cold int ff_rdft_init(RDFTContext *s, int nbits, enum RDFTransformType trans)
 {
     int n = 1 << nbits;
     int i;
-    const double theta = (trans == DFT_R2C || trans == DFT_C2R ? -1 : 1)*2*M_PI/n;
+    // SRS - added double cast for type consistency
+    const double theta = (double)(trans == DFT_R2C || trans == DFT_C2R ? -1 : 1)*2*M_PI/n;
 
     s->nbits           = nbits;
     s->inverse         = trans == IDFT_C2R || trans == DFT_C2R;
@@ -121,10 +122,12 @@ av_cold int ff_rdft_init(RDFTContext *s, int nbits, enum RDFTransformType trans)
 
     ff_init_ff_cos_tabs(nbits);
     s->tcos = ff_cos_tabs[nbits];
-    s->tsin = ff_sin_tabs[nbits]+(trans == DFT_R2C || trans == DFT_C2R)*(n>>2);
+    // SRS - added size_t cast for 64-bit handling without overflow
+    s->tsin = ff_sin_tabs[nbits]+(size_t)(trans == DFT_R2C || trans == DFT_C2R)*(n>>2);
 #if !CONFIG_HARDCODED_TABLES
+	// SRS - added FFTSample cast for type consistency
     for (i = 0; i < (n>>2); i++) {
-        s->tsin[i] = sin(i*theta);
+        s->tsin[i] = (FFTSample)sin(i*theta);
     }
 #endif
     s->rdft_calc   = ff_rdft_calc_c;

--- a/neo/libs/optick/optick_core.cpp
+++ b/neo/libs/optick/optick_core.cpp
@@ -840,7 +840,8 @@ void Core::DumpProgressFormatted(const char* format, ...)
 #ifdef OPTICK_MSVC
 	vsprintf_s(buffer, format, arglist);
 #else
-	vsprintf(buffer, format, arglist);
+	// SRS - use vsnprintf() for buffer security and to eliminate warning
+	vsnprintf(buffer, sizeof(buffer), format, arglist);
 #endif
 	va_end(arglist);
 	DumpProgress(buffer);

--- a/neo/libs/rapidjson/include/rapidjson/document.h
+++ b/neo/libs/rapidjson/include/rapidjson/document.h
@@ -106,16 +106,13 @@ struct GenericMember {
     \see GenericMember, GenericValue::MemberIterator, GenericValue::ConstMemberIterator
  */
 template <bool Const, typename Encoding, typename Allocator>
-class GenericMemberIterator
-    : public std::iterator<std::random_access_iterator_tag
-        , typename internal::MaybeAddConst<Const,GenericMember<Encoding,Allocator> >::Type> {
+class GenericMemberIterator {
 
     friend class GenericValue<Encoding,Allocator>;
     template <bool, typename, typename> friend class GenericMemberIterator;
 
     typedef GenericMember<Encoding,Allocator> PlainType;
     typedef typename internal::MaybeAddConst<Const,PlainType>::Type ValueType;
-    typedef std::iterator<std::random_access_iterator_tag,ValueType> BaseType;
 
 public:
     //! Iterator type itself
@@ -125,12 +122,21 @@ public:
     //! Non-constant iterator type
     typedef GenericMemberIterator<false,Encoding,Allocator> NonConstIterator;
 
-    //! Pointer to (const) GenericMember
-    typedef typename BaseType::pointer         Pointer;
+	/** \name std::iterator_traits support */
+	//@{
+	typedef ValueType      value_type;
+	typedef ValueType *    pointer;
+	typedef ValueType &    reference;
+	typedef std::ptrdiff_t difference_type;
+	typedef std::random_access_iterator_tag iterator_category;
+	//@}
+
+	//! Pointer to (const) GenericMember
+    typedef pointer         Pointer;
     //! Reference to (const) GenericMember
-    typedef typename BaseType::reference       Reference;
+    typedef reference       Reference;
     //! Signed integer type (e.g. \c ptrdiff_t)
-    typedef typename BaseType::difference_type DifferenceType;
+    typedef difference_type DifferenceType;
 
     //! Default constructor (singular value)
     /*! Creates an iterator pointing to no element.

--- a/neo/libs/tinyexr/tinyexr.h
+++ b/neo/libs/tinyexr/tinyexr.h
@@ -10520,7 +10520,8 @@ for( ; im <= iM; im++ )
 			unsigned int* p = pl->p;
 			pl->p = new unsigned int[pl->lit];
 
-			for( int i = 0; i < pl->lit - 1; ++i )
+			// SRS - changed to unsigned int for type consistency
+			for( unsigned int i = 0; i < pl->lit - 1; ++i )
 			{
 				pl->p[i] = p[i];
 			}
@@ -10824,7 +10825,8 @@ while( in < ie )
 			// Search long code
 			//
 
-			int j;
+			// SRS - changed to unsigned int for type consistency
+			unsigned int j;
 
 			for( j = 0; j < pl.lit; j++ )
 			{

--- a/neo/renderer/ImageManager.cpp
+++ b/neo/renderer/ImageManager.cpp
@@ -685,7 +685,7 @@ void R_CombineCubeImages_f( const idCmdArgs& args )
 		int		orderRemap[6] = { 1, 3, 4, 2, 5, 6 };
 		for( side = 0 ; side < 6 ; side++ )
 		{
-			sprintf( filename, "%s%i%04i.tga", baseName.c_str(), orderRemap[side], frameNum );
+			idStr::snPrintf( filename, sizeof( filename ), "%s%i%04i.tga", baseName.c_str(), orderRemap[side], frameNum );
 
 			idLib::Printf( "reading %s\n", filename );
 			R_LoadImage( filename, &pics[side], &width, &height, NULL, true, NULL );
@@ -738,7 +738,7 @@ void R_CombineCubeImages_f( const idCmdArgs& args )
 			memcpy( combined + width * height * 4 * side, pics[side], width * height * 4 );
 			Mem_Free( pics[side] );
 		}
-		sprintf( filename, "%sCM%04i.tga", baseName.c_str(), frameNum );
+		idStr::snPrintf( filename, sizeof( filename ), "%sCM%04i.tga", baseName.c_str(), frameNum );
 
 		idLib::Printf( "writing %s\n", filename );
 		R_WriteTGA( filename, combined, width, height * 6 );

--- a/neo/renderer/Image_files.cpp
+++ b/neo/renderer/Image_files.cpp
@@ -73,7 +73,7 @@ void jpg_Error( const char* fmt, ... )
 	char		msg[2048];
 
 	va_start( argptr, fmt );
-	vsprintf( msg, fmt, argptr );
+	idStr::vsnPrintf( msg, sizeof( msg ), fmt, argptr );
 	va_end( argptr );
 
 	common->FatalError( "%s", msg );
@@ -85,7 +85,7 @@ void jpg_Printf( const char* fmt, ... )
 	char		msg[2048];
 
 	va_start( argptr, fmt );
-	vsprintf( msg, fmt, argptr );
+	idStr::vsnPrintf( msg, sizeof( msg ), fmt, argptr );
 	va_end( argptr );
 
 	common->Printf( "%s", msg );

--- a/neo/renderer/ModelManager.cpp
+++ b/neo/renderer/ModelManager.cpp
@@ -228,7 +228,7 @@ void idRenderModelManagerLocal::WritePrecacheCommands( idFile* f )
 		}
 
 		char	str[1024];
-		sprintf( str, "touchModel %s\n", model->Name() );
+		idStr::snPrintf( str, sizeof( str ), "touchModel %s\n", model->Name() );
 		common->Printf( "%s", str );
 		f->Printf( "%s", str );
 	}

--- a/neo/renderer/Passes/TemporalAntiAliasingPass.cpp
+++ b/neo/renderer/Passes/TemporalAntiAliasingPass.cpp
@@ -112,6 +112,9 @@ void TemporalAntiAliasingPass::Init(
 			m_TemporalAntiAliasingCS = taaResolveShaderInfo.cs;
 			break;
 		}
+#elif defined( _MSC_VER )			// SRS: #pragma warning is MSVC specific
+#pragma warning( push )
+#pragma warning( disable : 4065 )	// C4065: switch statement contains 'default' but no 'case'
 #endif
 
 		default:
@@ -121,6 +124,9 @@ void TemporalAntiAliasingPass::Init(
 			break;
 		}
 	}
+#if !ID_MSAA && defined( _MSC_VER )
+#pragma warning( pop )
+#endif
 
 	nvrhi::SamplerDesc samplerDesc;
 	samplerDesc.addressU = samplerDesc.addressV = samplerDesc.addressW = nvrhi::SamplerAddressMode::Border;

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -448,12 +448,18 @@ void R_SetNewMode( const bool fullInit )
 			case ANTI_ALIASING_MSAA_4X:
 				parms.multiSamples = 4;
 				break;
+#elif defined( _MSC_VER )			// SRS: #pragma warning is MSVC specific
+#pragma warning( push )
+#pragma warning( disable : 4065 )	// C4065: switch statement contains 'default' but no 'case'
 #endif
 
 			default:
 				parms.multiSamples = 1;
 				break;
 		}
+#if !ID_MSAA && defined( _MSC_VER )
+#pragma warning( pop )
+#endif
 
 		if( i == 0 )
 		{
@@ -838,7 +844,8 @@ bool R_ReadPixelsRGB8( nvrhi::IDevice* device, CommonRenderPasses* pPasses, nvrh
 #endif
 
 	// fix alpha
-	for( int i = 0; i < ( desc.width * desc.height ); i++ )
+	// SRS - changed to uint32_t for type consistency
+	for( uint32_t i = 0; i < ( desc.width * desc.height ); i++ )
 	{
 		data[ i * 4 + 3 ] = 0xff;
 	}
@@ -952,7 +959,8 @@ bool R_ReadPixelsRGB16F( nvrhi::IDevice* device, CommonRenderPasses* pPasses, nv
 	}
 #endif
 
-	for( int i = 0; i < ( desc.width * desc.height ); i++ )
+	// SRS - changed to uint32_t for type consistency
+	for( uint32_t i = 0; i < ( desc.width * desc.height ); i++ )
 	{
 		outData[ i * 3 + 0 ] = data[ i * 4 + 0 ];
 		outData[ i * 3 + 1 ] = data[ i * 4 + 1 ];
@@ -966,7 +974,8 @@ bool R_ReadPixelsRGB16F( nvrhi::IDevice* device, CommonRenderPasses* pPasses, nv
 	const idVec3 LUMINANCE_LINEAR( 0.299f, 0.587f, 0.144f );
 	idVec3 rgb;
 
-	for( int i = 0; i < ( desc.width * desc.height ); i++ )
+	// SRS - changed to uint32_t for type consistency
+	for( uint32_t i = 0; i < ( desc.width * desc.height ); i++ )
 	{
 		rgb.x = F16toF32( outData[ i * 3 + 0 ] );
 		rgb.y = F16toF32( outData[ i * 3 + 1 ] );
@@ -990,7 +999,8 @@ bool R_ReadPixelsRGB16F( nvrhi::IDevice* device, CommonRenderPasses* pPasses, nv
 
 	if( isCorrupted )
 	{
-		for( int i = 0; i < ( desc.width * desc.height ); i++ )
+		// SRS - changed to uint32_t for type consistency
+		for( uint32_t i = 0; i < ( desc.width * desc.height ); i++ )
 		{
 			outData[ i * 3 + 0 ] = F32toF16( 0 );
 			outData[ i * 3 + 1 ] = F32toF16( 0 );

--- a/neo/swf/SWF_Image.cpp
+++ b/neo/swf/SWF_Image.cpp
@@ -43,13 +43,25 @@ These are the static callback functions the jpeg library calls
 void swf_jpeg_error_exit( jpeg_common_struct* cinfo )
 {
 	char buffer[JMSG_LENGTH_MAX] = {0};
+#ifdef USE_NEWER_JPEG
+	// SRS - use system jpeg lib with standard format_message() API
+	( *cinfo->err->format_message )( cinfo, buffer );
+#else
+	// SRS - use bundled jpeg lib with secure format_message() API
 	( *cinfo->err->format_message )( cinfo, buffer, sizeof( buffer ) );
+#endif
 	throw idException( buffer );
 }
 void swf_jpeg_output_message( jpeg_common_struct* cinfo )
 {
 	char buffer[JMSG_LENGTH_MAX] = {0};
+#ifdef USE_NEWER_JPEG
+	// SRS - use system jpeg lib with standard format_message() API
+	( *cinfo->err->format_message )( cinfo, buffer );
+#else
+	// SRS - use bundled jpeg lib with secure format_message() API
 	( *cinfo->err->format_message )( cinfo, buffer, sizeof( buffer ) );
+#endif
 	idLib::Printf( "%s\n", buffer );
 }
 void swf_jpeg_init_source( jpeg_decompress_struct* cinfo )

--- a/neo/swf/SWF_Image.cpp
+++ b/neo/swf/SWF_Image.cpp
@@ -43,13 +43,13 @@ These are the static callback functions the jpeg library calls
 void swf_jpeg_error_exit( jpeg_common_struct* cinfo )
 {
 	char buffer[JMSG_LENGTH_MAX] = {0};
-	( *cinfo->err->format_message )( cinfo, buffer );
+	( *cinfo->err->format_message )( cinfo, buffer, sizeof( buffer ) );
 	throw idException( buffer );
 }
 void swf_jpeg_output_message( jpeg_common_struct* cinfo )
 {
 	char buffer[JMSG_LENGTH_MAX] = {0};
-	( *cinfo->err->format_message )( cinfo, buffer );
+	( *cinfo->err->format_message )( cinfo, buffer, sizeof( buffer ) );
 	idLib::Printf( "%s\n", buffer );
 }
 void swf_jpeg_init_source( jpeg_decompress_struct* cinfo )

--- a/neo/sys/sdl/sdl_cpu.cpp
+++ b/neo/sys/sdl/sdl_cpu.cpp
@@ -305,11 +305,11 @@ static bitFlag_t statusWordFlags[] =
 Sys_FPU_PrintStateFlags
 ===============
 */
-int Sys_FPU_PrintStateFlags( char* ptr, int ctrl, int stat, int tags, int inof, int inse, int opof, int opse )
+int Sys_FPU_PrintStateFlags( char* buf, int bufsize, int ctrl, int stat, int tags, int inof, int inse, int opof, int opse )
 {
 	int i, length = 0;
 
-	length += sprintf( ptr + length,	"CTRL = %08x\n"
+	length += idStr::snPrintf( buf + length, bufsize - length,	"CTRL = %08x\n"
 					   "STAT = %08x\n"
 					   "TAGS = %08x\n"
 					   "INOF = %08x\n"
@@ -319,21 +319,21 @@ int Sys_FPU_PrintStateFlags( char* ptr, int ctrl, int stat, int tags, int inof, 
 					   "\n",
 					   ctrl, stat, tags, inof, inse, opof, opse );
 
-	length += sprintf( ptr + length, "Control Word:\n" );
+	length += idStr::snPrintf( buf + length, bufsize - length, "Control Word:\n" );
 	for( i = 0; controlWordFlags[i].name[0]; i++ )
 	{
-		length += sprintf( ptr + length, "  %-30s = %s\n", controlWordFlags[i].name, ( ctrl & ( 1 << controlWordFlags[i].bit ) ) ? "true" : "false" );
+		length += idStr::snPrintf( buf + length, bufsize - length, "  %-30s = %s\n", controlWordFlags[i].name, ( ctrl & ( 1 << controlWordFlags[i].bit ) ) ? "true" : "false" );
 	}
-	length += sprintf( ptr + length, "  %-30s = %s\n", "Precision control", precisionControlField[( ctrl >> 8 ) & 3] );
-	length += sprintf( ptr + length, "  %-30s = %s\n", "Rounding control", roundingControlField[( ctrl >> 10 ) & 3] );
+	length += idStr::snPrintf( buf + length, bufsize - length, "  %-30s = %s\n", "Precision control", precisionControlField[( ctrl >> 8 ) & 3] );
+	length += idStr::snPrintf( buf + length, bufsize - length, "  %-30s = %s\n", "Rounding control", roundingControlField[( ctrl >> 10 ) & 3] );
 
-	length += sprintf( ptr + length, "Status Word:\n" );
+	length += idStr::snPrintf( buf + length, bufsize - length, "Status Word:\n" );
 	for( i = 0; statusWordFlags[i].name[0]; i++ )
 	{
-		ptr += sprintf( ptr + length, "  %-30s = %s\n", statusWordFlags[i].name, ( stat & ( 1 << statusWordFlags[i].bit ) ) ? "true" : "false" );
+		length += idStr::snPrintf( buf + length, bufsize - length, "  %-30s = %s\n", statusWordFlags[i].name, ( stat & ( 1 << statusWordFlags[i].bit ) ) ? "true" : "false" );
 	}
-	length += sprintf( ptr + length, "  %-30s = %d%d%d%d\n", "Condition code", ( stat >> 8 ) & 1, ( stat >> 9 ) & 1, ( stat >> 10 ) & 1, ( stat >> 14 ) & 1 );
-	length += sprintf( ptr + length, "  %-30s = %d\n", "Top of stack pointer", ( stat >> 11 ) & 7 );
+	length += idStr::snPrintf( buf + length, bufsize - length, "  %-30s = %d%d%d%d\n", "Condition code", ( stat >> 8 ) & 1, ( stat >> 9 ) & 1, ( stat >> 10 ) & 1, ( stat >> 14 ) & 1 );
+	length += idStr::snPrintf( buf + length, bufsize - length, "  %-30s = %d\n", "Top of stack pointer", ( stat >> 11 ) & 7 );
 
 	return length;
 }

--- a/neo/sys/sys_local.cpp
+++ b/neo/sys/sys_local.cpp
@@ -248,15 +248,15 @@ const char* Sys_SecToStr( int sec )
 
 	if( weeks > 0 )
 	{
-		sprintf( timeString, "%dw, %dd, %d:%02d:%02d", weeks, days, hours, min, sec );
+		idStr::snPrintf( timeString, sizeof( timeString ), "%dw, %dd, %d:%02d:%02d", weeks, days, hours, min, sec );
 	}
 	else if( days > 0 )
 	{
-		sprintf( timeString, "%dd, %d:%02d:%02d", days, hours, min, sec );
+		idStr::snPrintf( timeString, sizeof( timeString ), "%dd, %d:%02d:%02d", days, hours, min, sec );
 	}
 	else
 	{
-		sprintf( timeString, "%d:%02d:%02d", hours, min, sec );
+		idStr::snPrintf( timeString, sizeof( timeString ), "%d:%02d:%02d", hours, min, sec );
 	}
 
 	return timeString;

--- a/neo/sys/sys_session_local.cpp
+++ b/neo/sys/sys_session_local.cpp
@@ -89,7 +89,7 @@ struct netVersion_s
 {
 	netVersion_s()
 	{
-		sprintf( string, "%s.%d", ENGINE_VERSION, BUILD_NUMBER );
+		idStr::snPrintf( string, sizeof( string ), "%s.%d", ENGINE_VERSION, BUILD_NUMBER );
 	}
 	char	string[256];
 } netVersion;

--- a/neo/sys/win32/win_syscon.cpp
+++ b/neo/sys/win32/win_syscon.cpp
@@ -95,7 +95,8 @@ typedef struct
 
 static WinConData s_wcd;
 
-static LONG WINAPI ConWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
+// SRS - use LRESULT vs LONG for type consistency with 64-bit and 32-bit
+static LRESULT WINAPI ConWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 	char* cmdString;
 	static bool s_timePolarity;
@@ -124,7 +125,8 @@ static LONG WINAPI ConWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 			{
 				SetBkColor( ( HDC ) wParam, RGB( 0x00, 0x00, 0x80 ) );
 				SetTextColor( ( HDC ) wParam, RGB( 0xff, 0xff, 0x00 ) );
-				return ( long ) s_wcd.hbrEditBackground;
+				// SRS - use LRESULT vs long for type consistency with 64-bit and 32-bit
+				return ( LRESULT ) s_wcd.hbrEditBackground;
 			}
 			else if( ( HWND ) lParam == s_wcd.hwndErrorBox )
 			{
@@ -138,7 +140,8 @@ static LONG WINAPI ConWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 					SetBkColor( ( HDC ) wParam, RGB( 0x80, 0x80, 0x80 ) );
 					SetTextColor( ( HDC ) wParam, RGB( 0x00, 0x0, 0x00 ) );
 				}
-				return ( long ) s_wcd.hbrErrorBackground;
+				// SRS - use LRESULT vs long for type consistency with 64-bit and 32-bit
+				return ( LRESULT ) s_wcd.hbrErrorBackground;
 			}
 			break;
 		case WM_SYSCOMMAND:
@@ -212,7 +215,8 @@ static LONG WINAPI ConWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 	return DefWindowProc( hWnd, uMsg, wParam, lParam );
 }
 
-LONG WINAPI InputLineWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
+// SRS - use LRESULT vs LONG for type consistency with 64-bit and 32-bit
+LRESULT WINAPI InputLineWndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 	int key, cursor;
 	switch( uMsg )
@@ -426,9 +430,9 @@ void Sys_CreateConsole()
 									 win32.hInstance, NULL );
 	SendMessage( s_wcd.hwndBuffer, WM_SETFONT, ( WPARAM ) s_wcd.hfBufferFont, 0 );
 
-	// RB begin
+	// RB begin, SRS - use SetWindowLongPtr() for 64-bit
 #if defined(_WIN64)
-	s_wcd.SysInputLineWndProc = ( WNDPROC ) SetWindowLong( s_wcd.hwndInputLine, GWLP_WNDPROC, ( LONG_PTR ) InputLineWndProc );
+	s_wcd.SysInputLineWndProc = ( WNDPROC ) SetWindowLongPtr( s_wcd.hwndInputLine, GWLP_WNDPROC, ( LONG_PTR ) InputLineWndProc );
 #else
 	s_wcd.SysInputLineWndProc = ( WNDPROC ) SetWindowLong( s_wcd.hwndInputLine, GWL_WNDPROC, ( LONG ) InputLineWndProc );
 #endif

--- a/neo/tools/compilers/aas/Brush.cpp
+++ b/neo/tools/compilers/aas/Brush.cpp
@@ -55,7 +55,7 @@ void DisplayRealTimeString( const char* string, ... )
 	if( time > lastUpdateTime + OUTPUT_UPDATE_TIME )
 	{
 		va_start( argPtr, string );
-		vsprintf( buf, string, argPtr );
+		idStr::vsnPrintf( buf, sizeof( buf ), string, argPtr );
 		va_end( argPtr );
 		common->Printf( buf );
 		lastUpdateTime = time;

--- a/neo/ui/DeviceContext.cpp
+++ b/neo/ui/DeviceContext.cpp
@@ -1005,9 +1005,10 @@ char* idRectangle::String() const
 
 	// use an array so that multiple toString's won't collide
 	s = str[ index ];
-	index = ( index + 1 ) & 7;
 
-	sprintf( s, "%.2f %.2f %.2f %.2f", x, y, w, h );
+	idStr::snPrintf( s, sizeof( str[ index ] ), "%.2f %.2f %.2f %.2f", x, y, w, h );
+
+	index = ( index + 1 ) & 7;
 
 	return s;
 }

--- a/neo/ui/UserInterface.cpp
+++ b/neo/ui/UserInterface.cpp
@@ -110,7 +110,7 @@ void idUserInterfaceManagerLocal::WritePrecacheCommands( idFile* f )
 	for( int i = 0; i < c; i++ )
 	{
 		char	str[1024];
-		sprintf( str, "touchGui %s\n", guis[i]->Name() );
+		idStr::snPrintf( str, sizeof( str ), "touchGui %s\n", guis[i]->Name() );
 		common->Printf( "%s", str );
 		f->Printf( "%s", str );
 	}

--- a/neo/ui/Window.cpp
+++ b/neo/ui/Window.cpp
@@ -1138,16 +1138,16 @@ void idWindow::DebugDraw( int time, float x, float y )
 
 			if( str.Length() )
 			{
-				sprintf( buff, "%s\n", str.c_str() );
+				idStr::snPrintf( buff, sizeof( buff ), "%s\n", str.c_str() );
 			}
 
-			sprintf( out, "Rect: %0.1f, %0.1f, %0.1f, %0.1f\n", rect.x(), rect.y(), rect.w(), rect.h() );
+			idStr::snPrintf( out, sizeof( out ), "Rect: %0.1f, %0.1f, %0.1f, %0.1f\n", rect.x(), rect.y(), rect.w(), rect.h() );
 			strcat( buff, out );
-			sprintf( out, "Draw Rect: %0.1f, %0.1f, %0.1f, %0.1f\n", drawRect.x, drawRect.y, drawRect.w, drawRect.h );
+			idStr::snPrintf( out, sizeof( out ), "Draw Rect: %0.1f, %0.1f, %0.1f, %0.1f\n", drawRect.x, drawRect.y, drawRect.w, drawRect.h );
 			strcat( buff, out );
-			sprintf( out, "Client Rect: %0.1f, %0.1f, %0.1f, %0.1f\n", clientRect.x, clientRect.y, clientRect.w, clientRect.h );
+			idStr::snPrintf( out, sizeof( out ), "Client Rect: %0.1f, %0.1f, %0.1f, %0.1f\n", clientRect.x, clientRect.y, clientRect.w, clientRect.h );
 			strcat( buff, out );
-			sprintf( out, "Cursor: %0.1f : %0.1f\n", gui->CursorX(), gui->CursorY() );
+			idStr::snPrintf( out, sizeof( out ), "Cursor: %0.1f : %0.1f\n", gui->CursorX(), gui->CursorY() );
 			strcat( buff, out );
 
 


### PR DESCRIPTION
This is a relatively simple, but medium-sized pull request that solves most compiler warnings.  It was motivated by me moving my dev machine to macOS Ventura with Xcode 14 / Apple clang 14.0.3 which is based on LLVM 15.  This resulted in tons of new compiler warnings, fortunately concentrated on a small number of things.  After solving those, I decided to attack linux gcc and clang 15 warnings and finally Visual Studio 2019's MSVC warnings.  Solutions are in three broad categories:

1. Fix deprecations in core RBDoom3BFG and rapidjson, e.g. `sprintf()` and `vsprintf()`, `std::iterator`
2. Fix type mismatches in core RBDoom3BFG and a few third-party source libs, e.g. libbinkdec, tinyexr
3. Apply targeted warning suppression where warranted, e.g. heap inline new/delete, int 64 to 32, switch statements with default but no case, and specific warnings for some third-party source libs (jpeg, png, oggvorbis, zlib, minizip) where I didn't feel the effort was worth it, or could be solved by up-versioning libs in the future.

as well as fixes for several specific areas:

4. Make Classic Doom implicit uint math operations more explicit, and in the process eliminate warnings
5. Fix 64-bit vs 32-bit return type handling in **win_syscon.cpp** by using `LRESULT` and `SetWindowLongPtr()`
6. Minimize header include path interaction between system libs vs bundled libs (i.e. libjpeg, libpng and zlib, rapidjson). I'm not sure if this capability is still important in the nvrhi world, but nonetheless it works better now.

One of the main issues involving many files was the unexpected deprecation of `sprintf()` and `vsprintf()` by the Apple clang 14.0.3 compiler.  This seems a little aggressive on Apple's part, but I guess is the right thing to do for buffer security.  Fortunately there is a relatively easy solution with `idStr::snPrintf()` and `idStr::vsnPrintf()` which are cross platform portable implementations with consistent length, null termination and error reporting behaviour.  As part of this fix, I updated the implementation of `idStr::snPrintf()` to be based on `idStr::vsnPrintf()` without need for an internal buffer versus the old implementation using `vsprintf()` with a large 32K internal buffer.  This should make things a little more memory efficient for all platforms.