### PR TITLE
Fix a number of memory leaks

### DIFF
--- a/neo/cm/CollisionModel_load.cpp
+++ b/neo/cm/CollisionModel_load.cpp
@@ -3558,11 +3558,15 @@ cm_model_t* idCollisionModelManagerLocal::LoadBinaryModelFromFile( idFile* file,
 	}
 
 	file->ReadBig( model->polygonMemory );
+	// SRS - Boost polygonMemory to handle in-memory (ptr) vs. on-disk (int) size for cm_polygon_t.material, otherwise AllocPolygon() leaks
+	model->polygonMemory += ( sizeof( idMaterial* ) - sizeof( int ) ) * model->numPolygons;
 	model->polygonBlock = ( cm_polygonBlock_t* ) Mem_ClearedAlloc( sizeof( cm_polygonBlock_t ) + model->polygonMemory, TAG_COLLISION );
 	model->polygonBlock->bytesRemaining = model->polygonMemory;
 	model->polygonBlock->next = ( ( byte* ) model->polygonBlock ) + sizeof( cm_polygonBlock_t );
 
 	file->ReadBig( model->brushMemory );
+	// SRS - Boost brushMemory to handle in-memory (ptr) vs. on-disk (int) size for cm_brush_t.material, otherwise AllocBrush() leaks
+	model->brushMemory += ( sizeof( idMaterial* ) - sizeof( int ) ) * model->numBrushes;
 	model->brushBlock = ( cm_brushBlock_t* ) Mem_ClearedAlloc( sizeof( cm_brushBlock_t ) + model->brushMemory, TAG_COLLISION );
 	model->brushBlock->bytesRemaining = model->brushMemory;
 	model->brushBlock->next = ( ( byte* ) model->brushBlock ) + sizeof( cm_brushBlock_t );

--- a/neo/d3xp/Game_local.cpp
+++ b/neo/d3xp/Game_local.cpp
@@ -168,7 +168,7 @@ TestGameAPI
 */
 void TestGameAPI()
 {
-	gameImport_t testImport;
+	gameImport_t testImport = {};
 	gameExport_t testExport;
 
 	testImport.sys						= ::sys;

--- a/neo/d3xp/Trigger.cpp
+++ b/neo/d3xp/Trigger.cpp
@@ -1292,6 +1292,17 @@ idTrigger_Touch::idTrigger_Touch()
 
 /*
 ================
+idTrigger_Touch::~idTrigger_Touch
+================
+*/
+idTrigger_Touch::~idTrigger_Touch()
+{
+	// SRS - Delete clipModel on cleanup, otherwise will leak
+	delete clipModel;
+}
+
+/*
+================
 idTrigger_Touch::Spawn
 ================
 */

--- a/neo/d3xp/Trigger.h
+++ b/neo/d3xp/Trigger.h
@@ -272,6 +272,7 @@ private:
 class idTrigger_Touch : public idTrigger
 {
 public:
+	~idTrigger_Touch();
 
 	CLASS_PROTOTYPE( idTrigger_Touch );
 

--- a/neo/d3xp/ai/AI_pathing.cpp
+++ b/neo/d3xp/ai/AI_pathing.cpp
@@ -953,7 +953,7 @@ float PathLength( idVec2 optimizedPath[MAX_OBSTACLE_PATH], int numPathPoints, co
 	}
 
 	// add penalty if this path does not go in the current direction
-	if( curDir * ( optimizedPath[1] - optimizedPath[0] ) < 0.0f )
+	if( numPathPoints > 1 && curDir * ( optimizedPath[1] - optimizedPath[0] ) < 0.0f )
 	{
 		pathLength += 100.0f;
 	}

--- a/neo/d3xp/script/Script_Program.cpp
+++ b/neo/d3xp/script/Script_Program.cpp
@@ -2142,7 +2142,7 @@ bool idProgram::CompileText( const char* source, const char* text, bool console 
 	try
 #endif
 	{
-		compiler.CompileFile( text, source, console );
+		compiler.CompileFile( text, ospath.c_str(), console );
 
 		// check to make sure all functions prototyped have code
 		for( i = 0; i < varDefs.Num(); i++ )

--- a/neo/d3xp/script/Script_Program.cpp
+++ b/neo/d3xp/script/Script_Program.cpp
@@ -2142,7 +2142,7 @@ bool idProgram::CompileText( const char* source, const char* text, bool console 
 	try
 #endif
 	{
-		compiler.CompileFile( text, filename, console );
+		compiler.CompileFile( text, source, console );
 
 		// check to make sure all functions prototyped have code
 		for( i = 0; i < varDefs.Num(); i++ )

--- a/neo/framework/Common.cpp
+++ b/neo/framework/Common.cpp
@@ -920,6 +920,7 @@ void idCommonLocal::RenderBink( const char* path )
 	materialText.Format( "{ translucent { videoMap %s } }", path );
 
 	idMaterial* material = const_cast<idMaterial*>( declManager->FindMaterial( "splashbink" ) );
+	material->FreeData();	// SRS - always free data before parsing, otherwise leaks occur
 	material->Parse( materialText.c_str(), materialText.Length(), false );
 	material->ResetCinematicTime( Sys_Milliseconds() );
 

--- a/neo/framework/Common_demos.cpp
+++ b/neo/framework/Common_demos.cpp
@@ -164,6 +164,9 @@ void idCommonLocal::StopPlayingRenderDemo()
 
 	readDemo->Close();
 
+	// SRS - free entity joints allocated by demo playback, otherwise will leak
+	R_FreeDerivedData();
+
 	soundWorld->StopAllSounds();
 	soundSystem->SetPlayingSoundWorld( menuSoundWorld );
 

--- a/neo/framework/DeclManager.cpp
+++ b/neo/framework/DeclManager.cpp
@@ -1303,15 +1303,14 @@ const idDecl* idDeclManagerLocal::FindType( declType_t type, const char* name, b
 		}
 #endif
 		decl->ParseLocal();
+
+		// SRS - set non-purgeable flag only after ParseLocal(), don't reset if declState is parsed or defaulted
+		decl->parsedOutsideLevelLoad = !insideLevelLoad;
 	}
 
 	// mark it as referenced
 	decl->referencedThisLevel = true;
 	decl->everReferenced = true;
-	if( insideLevelLoad )
-	{
-		decl->parsedOutsideLevelLoad = false;
-	}
 
 	return decl->self;
 }
@@ -1451,7 +1450,11 @@ void idDeclManagerLocal::ListType( const idCmdArgs& args, declType_t type )
 			continue;
 		}
 
-		if( decl->referencedThisLevel )
+		if( decl->parsedOutsideLevelLoad )
+		{
+			common->Printf( "!" );
+		}
+		else if( decl->referencedThisLevel )
 		{
 			common->Printf( "*" );
 		}
@@ -4056,7 +4059,8 @@ idDeclLocal* idDeclManagerLocal::FindTypeWithoutParsing( declType_t type, const 
 	decl->sourceFile = &implicitDecls;
 	decl->referencedThisLevel = false;
 	decl->everReferenced = false;
-	decl->parsedOutsideLevelLoad = !insideLevelLoad;
+	// SRS - initialize to false, otherwise all decls will be set to non-purgeable during Init()
+	decl->parsedOutsideLevelLoad = false;	// !insideLevelLoad;
 
 	// add it to the linear list and hash table
 	decl->index = linearLists[typeIndex].Num();

--- a/neo/framework/FileSystem.cpp
+++ b/neo/framework/FileSystem.cpp
@@ -2881,6 +2881,7 @@ int idFileSystemLocal::AddResourceFile( const char* resourceFileName )
 		common->Printf( "Loaded resource file %s\n", resourceFile.c_str() );
 		return resourceFiles.Num() - 1;
 	}
+	delete rc;
 	return -1;
 }
 

--- a/neo/idlib/math/Polynomial.cpp
+++ b/neo/idlib/math/Polynomial.cpp
@@ -231,7 +231,6 @@ void idPolynomial::Test()
 		value = p.GetValue( roots[i] );
 		assert( idMath::Fabs( value ) < 1e-4f );
 	}
-	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( -5.0f, 4.0f, 3.0f );
 	num = p.GetRoots( roots );
@@ -240,7 +239,6 @@ void idPolynomial::Test()
 		value = p.GetValue( roots[i] );
 		assert( idMath::Fabs( value ) < 1e-4f );
 	}
-	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( 1.0f, 4.0f, 3.0f, -2.0f );
 	num = p.GetRoots( roots );
@@ -249,7 +247,6 @@ void idPolynomial::Test()
 		value = p.GetValue( roots[i] );
 		assert( idMath::Fabs( value ) < 1e-4f );
 	}
-	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( 5.0f, 4.0f, 3.0f, -2.0f );
 	num = p.GetRoots( roots );
@@ -258,7 +255,6 @@ void idPolynomial::Test()
 		value = p.GetValue( roots[i] );
 		assert( idMath::Fabs( value ) < 1e-4f );
 	}
-	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( -5.0f, 4.0f, 3.0f, 2.0f, 1.0f );
 	num = p.GetRoots( roots );
@@ -267,7 +263,6 @@ void idPolynomial::Test()
 		value = p.GetValue( roots[i] );
 		assert( idMath::Fabs( value ) < 1e-4f );
 	}
-	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( 1.0f, 4.0f, 3.0f, -2.0f );
 	num = p.GetRoots( complexRoots );
@@ -276,7 +271,6 @@ void idPolynomial::Test()
 		complexValue = p.GetValue( complexRoots[i] );
 		assert( idMath::Fabs( complexValue.r ) < 1e-4f && idMath::Fabs( complexValue.i ) < 1e-4f );
 	}
-	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( 5.0f, 4.0f, 3.0f, -2.0f );
 	num = p.GetRoots( complexRoots );
@@ -285,5 +279,4 @@ void idPolynomial::Test()
 		complexValue = p.GetValue( complexRoots[i] );
 		assert( idMath::Fabs( complexValue.r ) < 1e-4f && idMath::Fabs( complexValue.i ) < 1e-4f );
 	}
-	Mem_Free16( p.coefficient );
 }

--- a/neo/idlib/math/Polynomial.cpp
+++ b/neo/idlib/math/Polynomial.cpp
@@ -231,6 +231,7 @@ void idPolynomial::Test()
 		value = p.GetValue( roots[i] );
 		assert( idMath::Fabs( value ) < 1e-4f );
 	}
+	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( -5.0f, 4.0f, 3.0f );
 	num = p.GetRoots( roots );
@@ -239,6 +240,7 @@ void idPolynomial::Test()
 		value = p.GetValue( roots[i] );
 		assert( idMath::Fabs( value ) < 1e-4f );
 	}
+	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( 1.0f, 4.0f, 3.0f, -2.0f );
 	num = p.GetRoots( roots );
@@ -247,6 +249,7 @@ void idPolynomial::Test()
 		value = p.GetValue( roots[i] );
 		assert( idMath::Fabs( value ) < 1e-4f );
 	}
+	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( 5.0f, 4.0f, 3.0f, -2.0f );
 	num = p.GetRoots( roots );
@@ -255,6 +258,7 @@ void idPolynomial::Test()
 		value = p.GetValue( roots[i] );
 		assert( idMath::Fabs( value ) < 1e-4f );
 	}
+	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( -5.0f, 4.0f, 3.0f, 2.0f, 1.0f );
 	num = p.GetRoots( roots );
@@ -263,6 +267,7 @@ void idPolynomial::Test()
 		value = p.GetValue( roots[i] );
 		assert( idMath::Fabs( value ) < 1e-4f );
 	}
+	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( 1.0f, 4.0f, 3.0f, -2.0f );
 	num = p.GetRoots( complexRoots );
@@ -271,6 +276,7 @@ void idPolynomial::Test()
 		complexValue = p.GetValue( complexRoots[i] );
 		assert( idMath::Fabs( complexValue.r ) < 1e-4f && idMath::Fabs( complexValue.i ) < 1e-4f );
 	}
+	Mem_Free16( p.coefficient );
 
 	p = idPolynomial( 5.0f, 4.0f, 3.0f, -2.0f );
 	num = p.GetRoots( complexRoots );
@@ -279,4 +285,5 @@ void idPolynomial::Test()
 		complexValue = p.GetValue( complexRoots[i] );
 		assert( idMath::Fabs( complexValue.r ) < 1e-4f && idMath::Fabs( complexValue.i ) < 1e-4f );
 	}
+	Mem_Free16( p.coefficient );
 }

--- a/neo/idlib/math/Polynomial.h
+++ b/neo/idlib/math/Polynomial.h
@@ -190,6 +190,8 @@ ID_INLINE idPolynomial idPolynomial::operator-() const
 
 ID_INLINE idPolynomial& idPolynomial::operator=( const idPolynomial& p )
 {
+	allocated = p.allocated;
+	coefficient = p.coefficient;
 	Resize( p.degree, false );
 	for( int i = 0; i <= degree; i++ )
 	{

--- a/neo/idlib/math/Polynomial.h
+++ b/neo/idlib/math/Polynomial.h
@@ -48,6 +48,12 @@ public:
 	explicit idPolynomial( float a, float b, float c, float d );
 	explicit idPolynomial( float a, float b, float c, float d, float e );
 
+	// SRS - Added destructor, otherwise idPolynomial() will leak memory
+	~idPolynomial()
+	{
+		Mem_Free16( coefficient );
+	};
+
 	float			operator[]( int index ) const;
 	float& 			operator[]( int index );
 
@@ -190,8 +196,6 @@ ID_INLINE idPolynomial idPolynomial::operator-() const
 
 ID_INLINE idPolynomial& idPolynomial::operator=( const idPolynomial& p )
 {
-	allocated = p.allocated;
-	coefficient = p.coefficient;
 	Resize( p.degree, false );
 	for( int i = 0; i <= degree; i++ )
 	{

--- a/neo/libs/libbinkdec/src/BinkDecoder.cpp
+++ b/neo/libs/libbinkdec/src/BinkDecoder.cpp
@@ -175,6 +175,8 @@ BinkDecoder::~BinkDecoder()
 		delete[] planes[i].last;
 	}
 
+	FreeBundles();
+
 	for (uint32_t i = 0; i < audioTracks.size(); i++)
 	{
 		delete[] audioTracks[i]->buffer;

--- a/neo/renderer/BinaryImage.cpp
+++ b/neo/renderer/BinaryImage.cpp
@@ -903,6 +903,13 @@ bool idBinaryImage::LoadFromGeneratedFile( idFile* bFile, ID_TIME_T sourceTimeSt
 		{
 			img.Alloc( img.dataSize * 2 );
 		}
+		// SRS - For compressed formats, match allocation to what nvrhi expects for the texture's mip variants
+		else if( ( textureFormat_t )fileData.format == FMT_DXT1 || ( textureFormat_t )fileData.format == FMT_DXT5 )
+		{
+		    int mipCols = ( ( ( ( fileData.width + 3 ) & ~3 ) >> img.level ) + 3 ) / 4;
+            int mipRows = ( ( ( ( fileData.height + 3 ) & ~3 ) >> img.level ) + 3 ) / 4;
+		    img.Alloc( Max( img.dataSize, mipCols * mipRows * BlockSizeForFormat( ( textureFormat_t )fileData.format ) ) );
+		}
 		else
 		{
 			img.Alloc( img.dataSize );

--- a/neo/renderer/BinaryImage.cpp
+++ b/neo/renderer/BinaryImage.cpp
@@ -906,9 +906,9 @@ bool idBinaryImage::LoadFromGeneratedFile( idFile* bFile, ID_TIME_T sourceTimeSt
 		// SRS - For compressed formats, match allocation to what nvrhi expects for the texture's mip variants
 		else if( ( textureFormat_t )fileData.format == FMT_DXT1 || ( textureFormat_t )fileData.format == FMT_DXT5 )
 		{
-		    int mipCols = ( ( ( ( fileData.width + 3 ) & ~3 ) >> img.level ) + 3 ) / 4;
+			int rowPitch = GetRowPitch( ( textureFormat_t )fileData.format, img.width );
             int mipRows = ( ( ( ( fileData.height + 3 ) & ~3 ) >> img.level ) + 3 ) / 4;
-		    img.Alloc( Max( img.dataSize, mipCols * mipRows * BlockSizeForFormat( ( textureFormat_t )fileData.format ) ) );
+		    img.Alloc( Max( img.dataSize, rowPitch * mipRows ) );
 		}
 		else
 		{

--- a/neo/renderer/Font.cpp
+++ b/neo/renderer/Font.cpp
@@ -86,6 +86,14 @@ idFont::~idFont
 */
 idFont::~idFont()
 {
+	// SRS - Free glyph data before deleting fontInfo, otherwise will leak
+	if( fontInfo )
+	{
+		Mem_Free( fontInfo->glyphData );
+		fontInfo->glyphData = NULL;
+		Mem_Free( fontInfo->charIndex );
+		fontInfo->charIndex = NULL;
+	}
 	delete fontInfo;
 }
 

--- a/neo/renderer/Image.h
+++ b/neo/renderer/Image.h
@@ -114,7 +114,7 @@ enum textureFormat_t
 };
 
 int BitsForFormat( textureFormat_t format );
-int BlockSizeForFormat( const textureFormat_t& format );
+int GetRowPitch( const textureFormat_t& format, int width );
 
 /*
 ================================================

--- a/neo/renderer/Image.h
+++ b/neo/renderer/Image.h
@@ -114,6 +114,7 @@ enum textureFormat_t
 };
 
 int BitsForFormat( textureFormat_t format );
+int BlockSizeForFormat( const textureFormat_t& format );
 
 /*
 ================================================

--- a/neo/renderer/Image_load.cpp
+++ b/neo/renderer/Image_load.cpp
@@ -717,7 +717,7 @@ void idImage::FinalizeImage( bool fromBackEnd, nvrhi::ICommandList* commandList 
 				bufferW = ( img.width + 3 ) & ~3;
 			}
 
-			commandList->writeTexture( texture, img.destZ, img.level, pic, GetRowPitch( opts.format, img.width ) );
+			commandList->writeTexture( texture, img.destZ, img.level, pic, GetRowPitch( opts.format, bufferW ) );
 		}
 	}
 	commandList->setPermanentTextureState( texture, nvrhi::ResourceStates::ShaderResource );

--- a/neo/renderer/Image_load.cpp
+++ b/neo/renderer/Image_load.cpp
@@ -120,7 +120,7 @@ GetRowBytes
 Returns the row bytes for the given image.
 =========================
 */
-static int GetRowPitch( const textureFormat_t& format, int width )
+int GetRowPitch( const textureFormat_t& format, int width )
 {
 	bool bc = ( format == FMT_DXT1 || format == FMT_DXT5 );
 
@@ -717,7 +717,7 @@ void idImage::FinalizeImage( bool fromBackEnd, nvrhi::ICommandList* commandList 
 				bufferW = ( img.width + 3 ) & ~3;
 			}
 
-			commandList->writeTexture( texture, img.destZ, img.level, pic, GetRowPitch( opts.format, bufferW ) );
+			commandList->writeTexture( texture, img.destZ, img.level, pic, GetRowPitch( opts.format, img.width ) );
 		}
 	}
 	commandList->setPermanentTextureState( texture, nvrhi::ResourceStates::ShaderResource );

--- a/neo/renderer/Interaction.cpp
+++ b/neo/renderer/Interaction.cpp
@@ -661,7 +661,7 @@ void idInteraction::CreateStaticInteraction( nvrhi::ICommandList* commandList )
 			{
 				// make a static index cache
 				sint->numLightTrisIndexes = lightTris->numIndexes;
-				sint->lightTrisIndexCache = vertexCache.AllocStaticIndex( lightTris->indexes, ALIGN( lightTris->numIndexes * sizeof( lightTris->indexes[0] ), INDEX_CACHE_ALIGN ), commandList );
+				sint->lightTrisIndexCache = vertexCache.AllocStaticIndex( lightTris->indexes, lightTris->numIndexes * sizeof( lightTris->indexes[0] ), commandList );
 
 				interactionGenerated = true;
 				R_FreeStaticTriSurf( lightTris );

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -41,6 +41,7 @@ If you have questions concerning this license or the applicable additional terms
 #include "nvrhi/utils.h"
 #include <sys/DeviceManager.h>
 extern DeviceManager* deviceManager;
+extern idCVar r_graphicsAPI;
 
 idCVar r_drawFlickerBox( "r_drawFlickerBox", "0", CVAR_RENDERER | CVAR_BOOL, "visual test for dropping frames" );
 idCVar stereoRender_warp( "stereoRender_warp", "0", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_BOOL, "use the optical warping renderprog instead of stereoDeGhost" );
@@ -160,6 +161,18 @@ void idRenderBackend::Init()
 	{
 		common->FatalError( "R_InitOpenGL called while active" );
 	}
+
+	// SRS - create deviceManager here to prevent allocation loop via R_SetNewMode( true )
+	nvrhi::GraphicsAPI api = nvrhi::GraphicsAPI::D3D12;
+	if( !idStr::Icmp( r_graphicsAPI.GetString(), "vulkan" ) )
+	{
+		api = nvrhi::GraphicsAPI::VULKAN;
+	}
+	else if( !idStr::Icmp( r_graphicsAPI.GetString(), "dx12" ) )
+	{
+		api = nvrhi::GraphicsAPI::D3D12;
+	}
+	deviceManager = DeviceManager::Create( api );
 
 	// DG: make sure SDL has setup video so getting supported modes in R_SetNewMode() works
 #if defined( VULKAN_USE_PLATFORM_SDL )
@@ -282,10 +295,17 @@ void idRenderBackend::Shutdown()
 	fhImmediateMode::Shutdown();
 
 #if defined( VULKAN_USE_PLATFORM_SDL )
-	VKimp_Shutdown();
+	VKimp_Shutdown( true );		// SRS - shutdown SDL on quit
 #else
 	GLimp_Shutdown();
 #endif
+
+	// SRS - delete deviceManager instance on backend shutdown
+	if( deviceManager )
+	{
+		delete deviceManager;
+		deviceManager = NULL;
+	}
 }
 
 /*

--- a/neo/renderer/NVRHI/RenderProgs_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderProgs_NVRHI.cpp
@@ -287,7 +287,7 @@ void idRenderProgManager::KillAllShaders()
 idRenderProgManager::SetUniformValue
 ================================================================================================
 */
-void idRenderProgManager::SetUniformValue( const renderParm_t rp, const float* value )
+void idRenderProgManager::SetUniformValue( const renderParm_t rp, const float value[4] )
 {
 	for( int i = 0; i < 4; i++ )
 	{

--- a/neo/renderer/NVRHI/RenderProgs_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderProgs_NVRHI.cpp
@@ -160,6 +160,9 @@ void idRenderProgManager::LoadShader( shader_t& shader )
 									   ( constants.Num() > 0 ) ? &constants[0] : shaderConstant, uint32_t( constants.Num() ) );
 
 	shader.handle = shaderHandle;
+	
+	// SRS - Free the shader blob data, otherwise a leak will occur
+	Mem_Free( shaderBlob.data );
 }
 
 /*

--- a/neo/renderer/Passes/GeometryPasses.cpp
+++ b/neo/renderer/Passes/GeometryPasses.cpp
@@ -35,20 +35,20 @@ If you have questions concerning this license or the applicable additional terms
 #include "nvrhi/utils.h"
 
 #if 0
-static ID_INLINE void SetVertexParm( renderParm_t rp, const float* value )
+static ID_INLINE void SetVertexParm( renderParm_t rp, const float value[4] )
 {
 	renderProgManager.SetUniformValue( rp, value );
 }
 
-static ID_INLINE void SetVertexParms( renderParm_t rp, const float* value, int num )
+static ID_INLINE void SetVertexParms( renderParm_t rp, const float values[], int num )
 {
 	for( int i = 0; i < num; i++ )
 	{
-		renderProgManager.SetUniformValue( ( renderParm_t )( rp + i ), value + ( i * 4 ) );
+		renderProgManager.SetUniformValue( ( renderParm_t )( rp + i ), values + ( i * 4 ) );
 	}
 }
 
-static ID_INLINE void SetFragmentParm( renderParm_t rp, const float* value )
+static ID_INLINE void SetFragmentParm( renderParm_t rp, const float value[4] )
 {
 	renderProgManager.SetUniformValue( rp, value );
 }

--- a/neo/renderer/RenderBackend.cpp
+++ b/neo/renderer/RenderBackend.cpp
@@ -64,7 +64,7 @@ bool drawView3D;
 SetVertexParm
 ================
 */
-static ID_INLINE void SetVertexParm( renderParm_t rp, const float* value )
+static ID_INLINE void SetVertexParm( renderParm_t rp, const float value[4] )
 {
 	renderProgManager.SetUniformValue( rp, value );
 }
@@ -74,11 +74,11 @@ static ID_INLINE void SetVertexParm( renderParm_t rp, const float* value )
 SetVertexParms
 ================
 */
-static ID_INLINE void SetVertexParms( renderParm_t rp, const float* value, int num )
+static ID_INLINE void SetVertexParms( renderParm_t rp, const float values[], int num )
 {
 	for( int i = 0; i < num; i++ )
 	{
-		renderProgManager.SetUniformValue( ( renderParm_t )( rp + i ), value + ( i * 4 ) );
+		renderProgManager.SetUniformValue( ( renderParm_t )( rp + i ), values + ( i * 4 ) );
 	}
 }
 
@@ -87,7 +87,7 @@ static ID_INLINE void SetVertexParms( renderParm_t rp, const float* value, int n
 SetFragmentParm
 ================
 */
-static ID_INLINE void SetFragmentParm( renderParm_t rp, const float* value )
+static ID_INLINE void SetFragmentParm( renderParm_t rp, const float value[4] )
 {
 	renderProgManager.SetUniformValue( rp, value );
 }
@@ -1652,6 +1652,8 @@ void idRenderBackend::RenderInteractions( const drawSurf_t* surfList, const view
 			{
 				shadowOffsets[ i ].x = vLight->imageAtlasOffset[ i ].x * ( 1.0f / r_shadowMapAtlasSize.GetInteger() );
 				shadowOffsets[ i ].y = vLight->imageAtlasOffset[ i ].y * ( 1.0f / r_shadowMapAtlasSize.GetInteger() );
+				shadowOffsets[ i ].z = 0.0f;
+				shadowOffsets[ i ].w = 0.0f;
 			}
 
 			SetVertexParms( RENDERPARM_SHADOW_ATLAS_OFFSET_0, &shadowOffsets[0][0], 6 );

--- a/neo/renderer/RenderCommon.h
+++ b/neo/renderer/RenderCommon.h
@@ -1387,8 +1387,8 @@ bool		VKimp_Init( glimpParms_t parms );
 bool		VKimp_SetScreenParms( glimpParms_t parms );
 
 // Destroys the rendering context, closes the window, resets the resolution,
-// and resets the gamma ramps.
-void		VKimp_Shutdown();
+// and resets the gamma ramps.  SRS - Optionally shuts down SDL for quit.
+void		VKimp_Shutdown( bool shutdownSDL );
 
 // Sets the hardware gamma ramps for gamma and brightness adjustment.
 // These are now taken as 16 bit values, so we can take full advantage

--- a/neo/renderer/RenderEntity.cpp
+++ b/neo/renderer/RenderEntity.cpp
@@ -165,7 +165,9 @@ int RenderEnvprobeLocal::GetIndex()
 void idRenderEntityLocal::ReadFromDemoFile( class idDemoFile* f )
 {
 	int i;
-	renderEntity_t ent = {};
+	renderEntity_t ent;
+	// SRS - fully initialize ent so that memcmp() in UpdateEntityDef() works properly
+	memset( &ent, 0, sizeof( renderEntity_t ) );
 	/* Initialize Pointers */
 	decals = NULL;
 	overlays = NULL;

--- a/neo/renderer/RenderEntity.cpp
+++ b/neo/renderer/RenderEntity.cpp
@@ -165,7 +165,7 @@ int RenderEnvprobeLocal::GetIndex()
 void idRenderEntityLocal::ReadFromDemoFile( class idDemoFile* f )
 {
 	int i;
-	renderEntity_t ent;
+	renderEntity_t ent = {};
 	/* Initialize Pointers */
 	decals = NULL;
 	overlays = NULL;

--- a/neo/renderer/RenderProgs.cpp
+++ b/neo/renderer/RenderProgs.cpp
@@ -831,11 +831,11 @@ bool idRenderProgManager::IsShaderBound() const
 idRenderProgManager::SetRenderParms
 ================================================================================================
 */
-void idRenderProgManager::SetRenderParms( renderParm_t rp, const float* value, int num )
+void idRenderProgManager::SetRenderParms( renderParm_t rp, const float values[], int num )
 {
 	for( int i = 0; i < num; i++ )
 	{
-		SetRenderParm( ( renderParm_t )( rp + i ), value + ( i * 4 ) );
+		SetRenderParm( ( renderParm_t )( rp + i ), values + ( i * 4 ) );
 	}
 }
 
@@ -844,7 +844,7 @@ void idRenderProgManager::SetRenderParms( renderParm_t rp, const float* value, i
 idRenderProgManager::SetRenderParm
 ================================================================================================
 */
-void idRenderProgManager::SetRenderParm( renderParm_t rp, const float* value )
+void idRenderProgManager::SetRenderParm( renderParm_t rp, const float value[4] )
 {
 	SetUniformValue( rp, value );
 }

--- a/neo/renderer/RenderProgs.h
+++ b/neo/renderer/RenderProgs.h
@@ -430,8 +430,8 @@ public:
 
 	void	StartFrame();
 
-	void	SetRenderParm( renderParm_t rp, const float* value );
-	void	SetRenderParms( renderParm_t rp, const float* values, int numValues );
+	void	SetRenderParm( renderParm_t rp, const float value[4] );
+	void	SetRenderParms( renderParm_t rp, const float values[], int numValues );
 
 	int		FindShader( const char* name, rpStage_t stage );
 	int		FindShader( const char* name, rpStage_t stage, const char* nameOutSuffix, uint32 features, bool builtin, vertexLayoutType_t vertexLayout = LAYOUT_DRAW_VERT );
@@ -954,7 +954,7 @@ public:
 	static const int	MAX_GLSL_USER_PARMS = 8;
 	const char*	GetGLSLParmName( int rp ) const;
 
-	void		SetUniformValue( const renderParm_t rp, const float* value );
+	void		SetUniformValue( const renderParm_t rp, const float value[4] );
 	void		CommitUniforms( uint64 stateBits );
 	int			FindProgram( const char* name, int vIndex, int fIndex, bindingLayoutType_t bindingType = BINDING_LAYOUT_DEFAULT );
 	void		ZeroUniforms();

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -308,7 +308,7 @@ const char* fileExten[4] = { "tga", "png", "jpg", "exr" };
 const char* envDirection[6] = { "_px", "_nx", "_py", "_ny", "_pz", "_nz" };
 const char* skyDirection[6] = { "_forward", "_back", "_left", "_right", "_up", "_down" };
 
-DeviceManager* deviceManager;
+DeviceManager* deviceManager = NULL;
 
 
 bool R_UseTemporalAA()
@@ -473,17 +473,6 @@ void R_SetNewMode( const bool fullInit )
 		if( fullInit )
 		{
 			// create the context as well as setting up the window
-
-			nvrhi::GraphicsAPI api = nvrhi::GraphicsAPI::D3D12;
-			if( !idStr::Icmp( r_graphicsAPI.GetString(), "vulkan" ) )
-			{
-				api = nvrhi::GraphicsAPI::VULKAN;
-			}
-			else if( !idStr::Icmp( r_graphicsAPI.GetString(), "dx12" ) )
-			{
-				api = nvrhi::GraphicsAPI::D3D12;
-			}
-			deviceManager = DeviceManager::Create( api );
 
 #if defined( VULKAN_USE_PLATFORM_SDL )
 			if( VKimp_Init( parms ) )

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -1751,24 +1751,32 @@ void idRenderSystemLocal::Clear()
 
 	if( unitSquareTriangles != NULL )
 	{
+	    Mem_Free( unitSquareTriangles->verts );
+	    Mem_Free( unitSquareTriangles->indexes );
 		Mem_Free( unitSquareTriangles );
 		unitSquareTriangles = NULL;
 	}
 
 	if( zeroOneCubeTriangles != NULL )
 	{
+	    Mem_Free( zeroOneCubeTriangles->verts );
+	    Mem_Free( zeroOneCubeTriangles->indexes );
 		Mem_Free( zeroOneCubeTriangles );
 		zeroOneCubeTriangles = NULL;
 	}
 
 	if( zeroOneSphereTriangles != NULL )
 	{
+	    Mem_Free( zeroOneSphereTriangles->verts );
+	    Mem_Free( zeroOneSphereTriangles->indexes );
 		Mem_Free( zeroOneSphereTriangles );
 		zeroOneSphereTriangles = NULL;
 	}
 
 	if( testImageTriangles != NULL )
 	{
+	    Mem_Free( testImageTriangles->verts );
+	    Mem_Free( testImageTriangles->indexes );
 		Mem_Free( testImageTriangles );
 		testImageTriangles = NULL;
 	}

--- a/neo/renderer/RenderWorld.cpp
+++ b/neo/renderer/RenderWorld.cpp
@@ -690,6 +690,7 @@ void idRenderWorldLocal::UpdateEnvprobeDef( qhandle_t envprobeHandle, const rend
 
 		probe->world = this;
 		probe->index = envprobeHandle;
+		probe->viewCount = 0;
 	}
 
 	probe->parms = *ep;

--- a/neo/renderer/RenderWorld_demo.cpp
+++ b/neo/renderer/RenderWorld_demo.cpp
@@ -721,7 +721,7 @@ ReadRenderLight
 */
 void	idRenderWorldLocal::ReadRenderLight()
 {
-	renderLight_t	light;
+	renderLight_t	light = {};
 	int				index, i;
 
 	common->ReadDemo()->ReadInt( index );

--- a/neo/renderer/RenderWorld_load.cpp
+++ b/neo/renderer/RenderWorld_load.cpp
@@ -57,6 +57,9 @@ void idRenderWorldLocal::FreeWorld()
 			R_StaticFree( portal );
 		}
 
+		// SRS - release the lightGridPoints idList or it will leak
+		area->lightGrid.lightGridPoints.Clear();
+
 		// there shouldn't be any remaining lightRefs or entityRefs
 		if( area->lightRefs.areaNext != &area->lightRefs )
 		{

--- a/neo/renderer/tr_trisurf.cpp
+++ b/neo/renderer/tr_trisurf.cpp
@@ -1819,8 +1819,8 @@ Uploads static vertices to the vertex cache.
 */
 void R_CreateDeformStaticVertices( deformInfo_t* deform, nvrhi::ICommandList* commandList )
 {
-	deform->staticAmbientCache = vertexCache.AllocStaticVertex( deform->verts, ALIGN( deform->numOutputVerts * sizeof( idDrawVert ), VERTEX_CACHE_ALIGN ), commandList );
-	deform->staticIndexCache = vertexCache.AllocStaticIndex( deform->indexes, ALIGN( deform->numIndexes * sizeof( triIndex_t ), INDEX_CACHE_ALIGN ), commandList );
+	deform->staticAmbientCache = vertexCache.AllocStaticVertex( deform->verts, deform->numOutputVerts * sizeof( idDrawVert ), commandList );
+	deform->staticIndexCache = vertexCache.AllocStaticIndex( deform->indexes, deform->numIndexes * sizeof( triIndex_t ), commandList );
 }
 
 /*
@@ -1948,13 +1948,13 @@ void R_CreateStaticBuffersForTri( srfTriangles_t& tri, nvrhi::ICommandList* comm
 	// index cache
 	if( tri.indexes != NULL )
 	{
-		tri.indexCache = vertexCache.AllocStaticIndex( tri.indexes, ALIGN( tri.numIndexes * sizeof( tri.indexes[0] ), INDEX_CACHE_ALIGN ), commandList );
+		tri.indexCache = vertexCache.AllocStaticIndex( tri.indexes, tri.numIndexes * sizeof( tri.indexes[0] ), commandList );
 	}
 
 	// vertex cache
 	if( tri.verts != NULL )
 	{
-		tri.ambientCache = vertexCache.AllocStaticVertex( tri.verts, ALIGN( tri.numVerts * sizeof( tri.verts[0] ), VERTEX_CACHE_ALIGN ), commandList );
+		tri.ambientCache = vertexCache.AllocStaticVertex( tri.verts, tri.numVerts * sizeof( tri.verts[0] ), commandList );
 	}
 }
 

--- a/neo/swf/SWF_ScriptFunction.h
+++ b/neo/swf/SWF_ScriptFunction.h
@@ -112,7 +112,7 @@ public:
 		}
 	}
 private:
-	int refCount;
+	std::atomic<int> refCount;
 };
 
 /*
@@ -281,7 +281,7 @@ private:
 	// RB end
 
 private:
-	int					refCount;
+	std::atomic<int>	refCount;
 
 	uint16				flags;
 	const  byte* 		data;

--- a/neo/swf/SWF_ScriptObject.h
+++ b/neo/swf/SWF_ScriptObject.h
@@ -184,7 +184,7 @@ public:
 	void					PrintToConsole() const;
 
 private:
-	int refCount;
+	std::atomic<int> refCount;
 	bool noAutoDelete;
 
 	enum swfNamedVarFlags_t

--- a/neo/swf/SWF_ScriptVar.h
+++ b/neo/swf/SWF_ScriptVar.h
@@ -58,7 +58,7 @@ public:
 	}
 
 private:
-	int refCount;
+	std::atomic<int> refCount;
 };
 
 /*

--- a/neo/sys/DeviceManager_VK.cpp
+++ b/neo/sys/DeviceManager_VK.cpp
@@ -1243,7 +1243,10 @@ void DeviceManager_VK::DestroyDeviceAndSwapChain()
 {
 	OPTICK_SHUTDOWN();
 
-	m_VulkanDevice.waitIdle();
+	if( m_VulkanDevice )
+	{
+		m_VulkanDevice.waitIdle();
+	}
 
 	m_FrameWaitQuery = nullptr;
 

--- a/neo/sys/common/savegame.cpp
+++ b/neo/sys/common/savegame.cpp
@@ -525,6 +525,7 @@ int idSaveGameThread::Enumerate()
 				// DG: just use the idFile object's timestamp - the windows code gets file attributes and
 				//  other complicated stuff like that.. I'm wonderin what that was good for.. this seems to work.
 				details->date = file->Timestamp();
+				delete file;
 #endif // DG end
 			}
 			else

--- a/neo/sys/common/socket_net.cpp
+++ b/neo/sys/common/socket_net.cpp
@@ -1021,6 +1021,7 @@ void Sys_InitNetworking()
 		// DG end
 		num_interfaces++;
 	}
+	free( ifap );
 #else // not _WIN32, OSX or FreeBSD
 	int		s;
 	char	buf[ MAX_INTERFACES * sizeof( ifreq ) ];

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -100,7 +100,7 @@ const char* Sys_DefaultSavePath()
 	char* base_path = SDL_GetPrefPath( "", "RBDOOM-3-BFG" );
 	if( base_path )
 	{
-		savepath = SDL_strdup( base_path );
+		savepath = base_path;
 		savepath.StripTrailing( '/' );
 		SDL_free( base_path );
 	}

--- a/neo/sys/sdl/sdl_vkimp.cpp
+++ b/neo/sys/sdl/sdl_vkimp.cpp
@@ -558,6 +558,10 @@ void VKimp_Shutdown()
 		window = nullptr;
 	}
 
+	if( SDL_WasInit( 0 ) )
+	{
+		SDL_Quit();
+	}
 }
 
 /* Eric: Is this needed/used for Vulkan?

--- a/neo/sys/sdl/sdl_vkimp.cpp
+++ b/neo/sys/sdl/sdl_vkimp.cpp
@@ -275,6 +275,7 @@ bool VKimp_Init( glimpParms_t parms )
 	if( !deviceManager->CreateWindowDeviceAndSwapChain( createParms, GAME_NAME ) )
 	{
 		common->Warning( "Couldn't initialize Vulkan subsystem for r_fullscreen = %i", parms.fullScreen );
+		VKimp_Shutdown( false );
 		return false;
 	}
 
@@ -543,15 +544,13 @@ void DeviceManager::Shutdown()
 VKimp_Shutdown
 ===================
 */
-void VKimp_Shutdown()
+void VKimp_Shutdown( bool shutdownSDL )
 {
 	common->Printf( "Shutting down Vulkan subsystem\n" );
 
 	if( deviceManager )
 	{
 		deviceManager->Shutdown();
-		delete deviceManager;
-		deviceManager = NULL;
 	}
 
 	if( window )
@@ -560,7 +559,7 @@ void VKimp_Shutdown()
 		window = nullptr;
 	}
 
-	if( SDL_WasInit( 0 ) )
+	if( shutdownSDL && SDL_WasInit( 0 ) )
 	{
 		SDL_Quit();
 	}

--- a/neo/sys/sdl/sdl_vkimp.cpp
+++ b/neo/sys/sdl/sdl_vkimp.cpp
@@ -550,6 +550,8 @@ void VKimp_Shutdown()
 	if( deviceManager )
 	{
 		deviceManager->Shutdown();
+		delete deviceManager;
+		deviceManager = NULL;
 	}
 
 	if( window )

--- a/neo/sys/sys_profile.cpp
+++ b/neo/sys/sys_profile.cpp
@@ -342,15 +342,7 @@ bool idSaveGameProcessorSaveProfile::InitSaveProfile( idPlayerProfile* profile_,
 	// Serialize the profile and pass a file to the processor
 	profileFile = new( TAG_SAVEGAMES ) idFile_SaveGame( SAVEGAME_PROFILE_FILENAME, SAVEGAMEFILE_BINARY | SAVEGAMEFILE_AUTO_DELETE );
 	profileFile->MakeWritable();
-	// SRS - Use SetLength()/TruncateData() vs. SetMaxLength() to avoid setting maxSize to non-zero value
-	//	   - maxSize seems to have overloaded semantics that implies an externally-managed buffer: see
-	//	     	a) idFile_Memory::idFile_Memory( const char* name, char* data, int length ), and
-	//			b) idFile_Memory::~idFile_Memory()
-	//	   - This change avoids a leak caused by skipping internally-managed file memory cleanup in the
-	//		 idFile_Memory::~idFile_Memory() destructor (on write completion) when maxSize is non-zero
-	//	   - Note the serializer already enforces MAX_PROFILE_SIZE so file system enforcement not needed
-	profileFile->SetLength( MAX_PROFILE_SIZE );
-	profileFile->TruncateData( 0 );
+	profileFile->SetMaxLength( MAX_PROFILE_SIZE );
 
 	// Create a serialization object and let the game serialize the settings into the buffer
 	const int serializeSize = MAX_PROFILE_SIZE - 8;	// -8 for checksum (all platforms) and length (on 360)
@@ -368,7 +360,7 @@ bool idSaveGameProcessorSaveProfile::InitSaveProfile( idPlayerProfile* profile_,
 
 	// Add data to the file and prepare for save
 	profileFile->Write( msg.GetReadData(), msg.GetSize() );
-	profileFile->MakeReadOnly();
+	profileFile->TakeDataOwnership();	// SRS - this makes the file read-only and enables data buffer release
 
 	saveFileEntryList_t files;
 	files.Append( profileFile );


### PR DESCRIPTION
This pull request fixes a number of memory leaks spread throughout the code.  Most of the changes are applicable to all platforms, with only a few applicable to non-Windows and/or macOS only.  The changes are:

1. Fix a tricky leak with polygon and brush memory in the Collision Model, where insufficient memory was being allocated due to differences in on-disk vs. in-memory footprint of `cm_polygon_t.material` and `cm_brush_t.material`.  The result was a bunch of singleton allocations that would run, but were orphaned and not deallocated on level changes.
2. Fixed a leak inside `RenderBink()` where material data was not being freed before parsing.
3. Fixed a leak in `AddResourceFile()` when the file was not found.
4. Fixed a leak in `idPolynomial()` due to a missing destructor.
5. Fixed a leak inside the **BinkDecoder** library where bundles were not being freed in the `~BinkDecoder()` destructor.
6. Fixed a leak inside `LoadShader()` where shader blob data was not being released (bad one).
7. Fixed a leak in `idSaveGameThread::Enumerate()` where the file handle was not being deleted for Linux & macOS.
8. Fixed a leak in `Sys_InitNetworking()` where a network interface address structure was not being released for macOS.
9. Fixed a leak in `Sys_DefaultSavePath()` where save path string memory was not being released for macOS.
10. Fixed a leak in `idRenderWorldLocal::FreeWorld()` where the `lightGridPoints` idList was not being released.  This would happen across all platforms on any map change during normal gameplay or demo playback.
11. Fixed a leak on completion of demo playback where the entity joints were not being released.
12. **UPDATED**: Fixed a leak in SWF Scripts where refCounts for script object deletes could get confused due to multi-threading, solved using `std::atomic<int>` for refCounts.
13. **UPDATED**: Fixed a leak in `idTrigger_Touch()` where the clipModel was not being released on level cleanup. 
14. **UPDATED**: Fixed a leak in `idFont`, where the glyph data was not being released on cleanup/quit.
15. **UPDATED**: Fixed a leak in `InitSaveProfile()` by replacing `MakeReadOnly()` with `TakeDataOwnership()`.  This makes the file read-only and enables automatic cleanup of file memory on save complete.
16. **UPDATED**: Ran `valgrind` on linux and fixed leaks and memory access errors: a) free verts and indexes for basic surface triangles, b) free allocations for multiplayer networking, c) fix uninitialized variables used in decision logic, d) use correct array dimensions for float[4] renderparms, and e) properly shutdown SDL on exit via `SDL_Quit()`.
17. **UPDATED**: Allocate `deviceManger` instance in `idRenderBackend::Init()` vs. `R_SetNewMode()` to avoid repeated reallocations without delete when looping for viable display resolutions.  Delete `deviceManger` instance during final cleanup in `idRenderBackend::Shutdown()`

With these changes I can run with zero leaks detected for game startup, level load, level exit, change games, optick profiling, demo playback and recording, and quit for macOS and Linux.  I used Xcode Instruments and valgrind leak detection tools for my work, but changes 1-6, 10-15, 16 (items a to d), 17 are applicable to all platforms.  Items 7-9, 16 (item e) are Linux and/or macOS-specific.  I don't have expertise in running similar leak tools on Windows, so I can't guarantee zero leaks on that platform.  However, I have tested the above changes on all platforms and they run correctly without error.

Tested on Windows 10, Linux Manjaro, and macOS Ventura (latest).

**Update**: I just looked at leaks for demo playback, and unfortunately there is something lurking there.  ~~I will try to add an additional fix to this PR if I can find it.~~  **_Issue is now fixed_** (see items 10 and 11 above).