### PR TITLE
Fix clang compile failure and memory issues in debug tools

### DIFF
--- a/neo/framework/File_SaveGame.cpp
+++ b/neo/framework/File_SaveGame.cpp
@@ -71,8 +71,6 @@ class idSGFcompressThread : public idSysThread
 public:
 	virtual int			Run()
 	{
-		OPTICK_THREAD( "idSGFcompressThread" );
-
 		sgf->CompressBlock();
 		return 0;
 	}
@@ -83,8 +81,6 @@ class idSGFdecompressThread : public idSysThread
 public:
 	virtual int			Run()
 	{
-		OPTICK_THREAD( "idSGFdecompressThread" );
-
 		sgf->DecompressBlock();
 		return 0;
 	}
@@ -95,8 +91,6 @@ class idSGFwriteThread : public idSysThread
 public:
 	virtual int			Run()
 	{
-		OPTICK_THREAD( "idSGFwriteThread" );
-
 		sgf->WriteBlock();
 		return 0;
 	}
@@ -107,8 +101,6 @@ class idSGFreadThread : public idSysThread
 public:
 	virtual int			Run()
 	{
-		OPTICK_THREAD( "idSGFreadThread" );
-
 		sgf->ReadBlock();
 		return 0;
 	}

--- a/neo/framework/common_frame.cpp
+++ b/neo/framework/common_frame.cpp
@@ -90,12 +90,6 @@ be called directly in the foreground thread for comparison.
 */
 int idGameThread::Run()
 {
-	if( com_smp.GetBool() )
-	{
-		// SRS - label thread in smp mode only, otherwise CPU frame number is missing
-		OPTICK_THREAD( "idGameThread" );
-	}
-
 	commonLocal.frameTiming.startGameTime = Sys_Microseconds();
 
 	// debugging tool to test frame dropping behavior

--- a/neo/idlib/ParallelJobList.cpp
+++ b/neo/idlib/ParallelJobList.cpp
@@ -1145,8 +1145,6 @@ idJobThread::Run
 */
 int idJobThread::Run()
 {
-	OPTICK_THREAD( GetName() );
-
 	threadJobListState_t threadJobListState[MAX_JOBLISTS];
 	int numJobLists = 0;
 	int lastStalledJobList = -1;

--- a/neo/idlib/Thread.cpp
+++ b/neo/idlib/Thread.cpp
@@ -237,12 +237,18 @@ int idSysThread::ThreadProc( idSysThread* thread )
 					break;
 				}
 
+				// SRS - generalize thread instrumentation with correct Run() scope
+				OPTICK_THREAD( thread->GetName() );
+
 				retVal = thread->Run();
 			}
 			thread->signalWorkerDone.Raise();
 		}
 		else
 		{
+			// SRS - generalize thread instrumentation with correct Run() scope
+			OPTICK_THREAD( thread->GetName() );
+
 			retVal = thread->Run();
 		}
 	}

--- a/neo/libs/optick/optick_core.h
+++ b/neo/libs/optick/optick_core.h
@@ -342,6 +342,9 @@ struct ThreadEntry
 		{
 			*threadTLS = nullptr;
         }
+
+		// SRS - make sure thread storage is empty before thread entry terminates
+		storage.Clear(false);
     }
 	void Activate(Mode::Type mode);
 	void Sort();

--- a/neo/libs/optick/optick_gpu.vulkan.cpp
+++ b/neo/libs/optick/optick_gpu.vulkan.cpp
@@ -150,6 +150,7 @@ namespace Optick
 		queryPoolCreateInfo.flags = 0;
 		queryPoolCreateInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
 		queryPoolCreateInfo.queryCount = MAX_QUERIES_COUNT + 1;
+		queryPoolCreateInfo.pipelineStatistics = 0;
 
 		VkCommandPoolCreateInfo commandPoolCreateInfo;
 		commandPoolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;

--- a/neo/renderer/GuiModel.cpp
+++ b/neo/renderer/GuiModel.cpp
@@ -395,9 +395,9 @@ void idGuiModel::EmitImGui( ImDrawData* drawData )
 			idScreenRect clipRect =
 			{
 				static_cast<short>( pcmd->ClipRect.x ),
-				io.DisplaySize.y - static_cast<short>( pcmd->ClipRect.w ),
+				static_cast<short>( io.DisplaySize.y - pcmd->ClipRect.w ),
 				static_cast<short>( pcmd->ClipRect.z ),
-				io.DisplaySize.y - static_cast<short>( pcmd->ClipRect.y ),
+				static_cast<short>( io.DisplaySize.y - pcmd->ClipRect.y ),
 				0.0f,
 				1.0f
 			};

--- a/neo/renderer/ImmediateMode.h
+++ b/neo/renderer/ImmediateMode.h
@@ -86,7 +86,7 @@ private:
 	static idIndexBuffer			indexBuffer;
 
 	bool		geometryOnly;
-	float		currentTexCoord[2];
+	float		currentTexCoord[2] = {};
 	GFXenum		currentMode;
 	byte		currentColor[4];
 	idImage*	currentTexture;

--- a/neo/sys/common/savegame.cpp
+++ b/neo/sys/common/savegame.cpp
@@ -747,8 +747,6 @@ idSaveGameThread::Run
 */
 int idSaveGameThread::Run()
 {
-	OPTICK_THREAD( "idSaveGameThread" );
-
 	int ret = ERROR_SUCCESS;
 
 	try


### PR DESCRIPTION
Fixes #842

This also fixes a few memory issues found by valgrind in debug tools/Optick:

1. Fix memory leak in Optick thread storage on exit while thread is still in scope (e.g. `MainThread`)
2. Fix uninitialized variables in ImmediateMode (for debug tools) and Optick

This PR also simplifies / generalizes `OPTICK_THREAD()` instrumentation for RBDoom3BFG and fixes an Optick thread scope problem in `idGameThread::Run()`.  I previously tested `com_smp` to enable/disable the thread instrumentation based on smp mode, but stupidly put this inside a conditional scope - something you shouldn't do with Optick.  This change eliminates the need for this check and allows Optick to see the full scope for `idGameThread::Run()` when operating in smp mode, as well as all other `<xxx>::Run()` threads. Note that In non-smp mode, `idGameThread::Run()` executes on the main thread and calling `OPTICK_THREAD()` is not required or desired (e.g. prevents labeling of frame number in main thread).