### PR TITLE
Free idLobby memory inside destructor

### DIFF
--- a/neo/sys/common/session_local.cpp
+++ b/neo/sys/common/session_local.cpp
@@ -253,6 +253,10 @@ void idSessionLocalWin::Shutdown()
 		Pump();
 	}
 
+	GetPartyLobby().Free();
+	GetGameLobby().Free();
+	GetGameStateLobby().Free();
+
 	if( achievementSystem != NULL )
 	{
 		achievementSystem->Shutdown();

--- a/neo/sys/common/session_local.cpp
+++ b/neo/sys/common/session_local.cpp
@@ -253,10 +253,6 @@ void idSessionLocalWin::Shutdown()
 		Pump();
 	}
 
-	GetPartyLobby().Free();
-	GetGameLobby().Free();
-	GetGameStateLobby().Free();
-
 	if( achievementSystem != NULL )
 	{
 		achievementSystem->Shutdown();

--- a/neo/sys/sys_lobby.cpp
+++ b/neo/sys/sys_lobby.cpp
@@ -120,6 +120,20 @@ idLobby::idLobby()
 
 /*
 ========================
+idLobby::~idLobby
+========================
+ */
+idLobby::~idLobby()
+{
+	// SRS - cleanup any allocations made for multiplayer networking support
+	Mem_Free( objMemory );
+	objMemory = NULL;
+	Mem_Free( lzwData );
+	lzwData = NULL;
+}
+
+/*
+========================
 idLobby::Initialize
 ========================
 */
@@ -331,18 +345,6 @@ void idLobby::Shutdown( bool retainMigrationInfo, bool skipGoodbye )
 	}
 
 	state = STATE_IDLE;
-}
-
-void idLobby::Free()
-{
-    // SRS - cleanup any allocations made for multiplayer networking support
-	if( objMemory )
-	{
-		Mem_Free( objMemory );
-		objMemory = NULL;
-		Mem_Free( lzwData );
-		lzwData = NULL;
-	}
 }
 
 /*

--- a/neo/sys/sys_lobby.cpp
+++ b/neo/sys/sys_lobby.cpp
@@ -330,7 +330,12 @@ void idLobby::Shutdown( bool retainMigrationInfo, bool skipGoodbye )
 		}
 	}
 
-	// SRS - cleanup any allocations made for multiplayer networking support
+	state = STATE_IDLE;
+}
+
+void idLobby::Free()
+{
+    // SRS - cleanup any allocations made for multiplayer networking support
 	if( objMemory )
 	{
 		Mem_Free( objMemory );
@@ -338,8 +343,6 @@ void idLobby::Shutdown( bool retainMigrationInfo, bool skipGoodbye )
 		Mem_Free( lzwData );
 		lzwData = NULL;
 	}
-
-	state = STATE_IDLE;
 }
 
 /*

--- a/neo/sys/sys_lobby.h
+++ b/neo/sys/sys_lobby.h
@@ -41,8 +41,7 @@ class idLobby : public idLobbyBase
 {
 public:
 	idLobby();
-
-	void Free();
+	~idLobby();
 
 	enum lobbyType_t
 	{

--- a/neo/sys/sys_lobby.h
+++ b/neo/sys/sys_lobby.h
@@ -42,6 +42,8 @@ class idLobby : public idLobbyBase
 public:
 	idLobby();
 
+	void Free();
+
 	enum lobbyType_t
 	{
 		TYPE_PARTY				= 0,

--- a/neo/sys/sys_session.h
+++ b/neo/sys/sys_session.h
@@ -346,6 +346,8 @@ idLobbyBase
 class idLobbyBase
 {
 public:
+	virtual ~idLobbyBase() {}
+
 	// General lobby functionality
 	virtual bool						IsHost() const = 0;
 	virtual bool						IsPeer() const = 0;


### PR DESCRIPTION
fixes #846 

Freeing `idLobby` memory inside `idLobby::Shutdown` causes Segfault on sending snapshots to the clients.

I have moved `Mem_Free` calls inside `idLobby::~idLobby` so memory will be properly freed at shutdown.