### PR TITLE
Multiplayer fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ base/video/
 base/wads/
 base/renderprogs2/
 base/generated/
+base/env/
 
 GPATH
 GRTAGS

--- a/neo/d3xp/Game_network.cpp
+++ b/neo/d3xp/Game_network.cpp
@@ -983,8 +983,8 @@ void idGameLocal::ClientReadSnapshot( const idSnapShot& ss )
 
 			ent->FlagNewSnapshot();
 
-			// read the class specific data from the snapshot
-			if( msg.GetRemainingReadBits() > 0 )
+			// read the class specific data from the snapshot; SRS - only if network-synced
+			if( msg.GetRemainingReadBits() > 0 && ent->fl.networkSync )
 			{
 				ent->ReadFromSnapshot_Ex( msg );
 				ent->snapshotBits = msg.GetSize();

--- a/neo/d3xp/physics/Physics_Player.h
+++ b/neo/d3xp/physics/Physics_Player.h
@@ -196,7 +196,7 @@ private:
 	waterLevel_t			waterLevel;
 	int						waterType;
 
-	bool					clientPusherLocked;
+	bool					clientPusherLocked = false;			// SRS - initialize to unlocked at start
 
 private:
 	float					CmdScale( const usercmd_t& cmd ) const;

--- a/neo/renderer/ModelDecal.cpp
+++ b/neo/renderer/ModelDecal.cpp
@@ -60,6 +60,8 @@ idRenderModelDecal::idRenderModelDecal() :
 	demoSerialWrite( 0 ),
 	demoSerialCurrent( 0 )
 {
+	// SRS - initialize decals so members are defined for logical tests in CreateDecalFromWinding()
+	memset( decals, 0, sizeof( decals ) );
 }
 
 /*

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -168,7 +168,7 @@ idCVar r_testGammaBias( "r_testGammaBias", "0", CVAR_RENDERER | CVAR_FLOAT, "if 
 idCVar r_lightScale( "r_lightScale", "3", CVAR_ARCHIVE | CVAR_RENDERER | CVAR_FLOAT, "all light intensities are multiplied by this", 0, 100 );
 idCVar r_flareSize( "r_flareSize", "1", CVAR_RENDERER | CVAR_FLOAT, "scale the flare deforms from the material def" );
 
-idCVar r_useScissor( "r_useScissor", "1", CVAR_RENDERER | CVAR_BOOL, "scissor clip as portals and lights are processed" );
+idCVar r_useScissor( "r_useScissor", "1", CVAR_RENDERER | CVAR_BOOL | CVAR_NOCHEAT, "scissor clip as portals and lights are processed" );
 idCVar r_useLightDepthBounds( "r_useLightDepthBounds", "1", CVAR_RENDERER | CVAR_BOOL, "use depth bounds test on lights to reduce both shadow and interaction fill" );
 idCVar r_useShadowDepthBounds( "r_useShadowDepthBounds", "1", CVAR_RENDERER | CVAR_BOOL, "use depth bounds test on individual shadow volumes to reduce shadow fill" );
 // RB begin

--- a/neo/renderer/RenderWorld_envprobes.cpp
+++ b/neo/renderer/RenderWorld_envprobes.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
 Doom 3 BFG Edition GPL Source Code
@@ -1148,7 +1148,7 @@ CONSOLE_COMMAND( bakeEnvironmentProbes, "Bake environment probes", NULL )
 
 	idLib::Printf( "----------------------------------\n" );
 	idLib::Printf( "Processed %i light probes\n", totalProcessedProbes );
-	common->Printf( "Baked SH irradiance and GGX mip maps in %5.1f seconds\n\n", ( totalEnd - totalStart ) / ( 1000.0f ) );
+	common->Printf( "Baked SH irradiance and GGX mip maps in %5.1f minutes\n\n", ( totalEnd - totalStart ) / ( 1000.0f * 60 ) );
 }
 
 CONSOLE_COMMAND( makeBrdfLUT, "make a GGX BRDF lookup table", NULL )

--- a/neo/renderer/tr_frontend_addlights.cpp
+++ b/neo/renderer/tr_frontend_addlights.cpp
@@ -38,7 +38,7 @@ extern idCVar r_forceShadowCaps;
 extern idCVar r_useShadowPreciseInsideTest;
 
 idCVar r_useAreasConnectedForShadowCulling( "r_useAreasConnectedForShadowCulling", "2", CVAR_RENDERER | CVAR_INTEGER, "cull entities cut off by doors" );
-idCVar r_useParallelAddLights( "r_useParallelAddLights", "1", CVAR_RENDERER | CVAR_BOOL, "aadd all lights in parallel with jobs" );
+idCVar r_useParallelAddLights( "r_useParallelAddLights", "1", CVAR_RENDERER | CVAR_BOOL | CVAR_NOCHEAT, "aadd all lights in parallel with jobs" );
 
 /*
 ============================

--- a/neo/renderer/tr_frontend_addmodels.cpp
+++ b/neo/renderer/tr_frontend_addmodels.cpp
@@ -35,8 +35,8 @@ If you have questions concerning this license or the applicable additional terms
 
 idCVar r_skipStaticShadows( "r_skipStaticShadows", "0", CVAR_RENDERER | CVAR_BOOL, "skip static shadows" );
 idCVar r_skipDynamicShadows( "r_skipDynamicShadows", "0", CVAR_RENDERER | CVAR_BOOL, "skip dynamic shadows" );
-idCVar r_useParallelAddModels( "r_useParallelAddModels", "1", CVAR_RENDERER | CVAR_BOOL, "add all models in parallel with jobs" );
-idCVar r_useParallelAddShadows( "r_useParallelAddShadows", "1", CVAR_RENDERER | CVAR_INTEGER, "0 = off, 1 = threaded", 0, 1 );
+idCVar r_useParallelAddModels( "r_useParallelAddModels", "1", CVAR_RENDERER | CVAR_BOOL | CVAR_NOCHEAT, "add all models in parallel with jobs" );
+idCVar r_useParallelAddShadows( "r_useParallelAddShadows", "1", CVAR_RENDERER | CVAR_INTEGER | CVAR_NOCHEAT, "0 = off, 1 = threaded", 0, 1 );
 idCVar r_forceShadowCaps( "r_forceShadowCaps", "0", CVAR_RENDERER | CVAR_BOOL, "0 = skip rendering shadow caps if view is outside shadow volume, 1 = always render shadow caps" );
 // RB begin
 idCVar r_forceShadowMapsOnAlphaTestedSurfaces( "r_forceShadowMapsOnAlphaTestedSurfaces", "1", CVAR_RENDERER | CVAR_BOOL, "0 = same shadowing as with stencil shadows, 1 = ignore noshadows for alpha tested materials" );

--- a/neo/sys/sys_lobby.cpp
+++ b/neo/sys/sys_lobby.cpp
@@ -120,6 +120,20 @@ idLobby::idLobby()
 
 /*
 ========================
+idLobby::~idLobby
+========================
+*/
+idLobby::~idLobby()
+{
+	// SRS - cleanup any allocations made for multiplayer networking support
+	Mem_Free( objMemory );
+	objMemory = NULL;
+	Mem_Free( lzwData );
+	lzwData = NULL;
+}
+
+/*
+========================
 idLobby::Initialize
 ========================
 */
@@ -328,15 +342,6 @@ void idLobby::Shutdown( bool retainMigrationInfo, bool skipGoodbye )
 			sessionCB->DestroyLobbyBackend( lobbyBackend );
 			lobbyBackend = NULL;
 		}
-	}
-
-	// SRS - cleanup any allocations made for multiplayer networking support
-	if( objMemory )
-	{
-		Mem_Free( objMemory );
-		objMemory = NULL;
-		Mem_Free( lzwData );
-		lzwData = NULL;
 	}
 
 	state = STATE_IDLE;

--- a/neo/sys/sys_lobby.h
+++ b/neo/sys/sys_lobby.h
@@ -41,6 +41,7 @@ class idLobby : public idLobbyBase
 {
 public:
 	idLobby();
+	~idLobby();
 
 	enum lobbyType_t
 	{

--- a/neo/sys/sys_voicechat.cpp
+++ b/neo/sys/sys_voicechat.cpp
@@ -48,7 +48,11 @@ void idVoiceChatMgr::Shutdown()
 
 	// We shouldn't have voice users if everything shutdown correctly
 	assert( talkers.Num() == 0 );
-	assert( remoteMachines.Num() == 0 );
+	for( int i = remoteMachines.Num() - 1; i >= 0; i-- )
+	{
+		assert( remoteMachines[i].refCount == 0 );
+		remoteMachines.RemoveIndex( i );
+	}
 }
 
 /*


### PR DESCRIPTION
This fixes a number of multiplayer issues.  **Create Private Match** with clients now works reliably at least on a local network.  Not tested across internet but should work for known IP addresses.  Did not look into online game browser or leaderboards.

The fixes are:

1. Fixes regression #846 caused by an earlier, but broken memory leak fix on my part.  The fix is almost identical to PR #847.  I didn't want to duplicate but unfortnuately I had already added a commit at the start of this branch and didn't want to reset and start again.  @RobertBeckebans should review and merge as appropriate.
2. Fixes a critical issue with mis-reading network snapshot data on the client side, which caused no end of problems with mis-rendering, slowdowns, unstable connections, etc.  The client was ignoring the entity network-synced flag which tells it whether it should read entity class-specific data.  It was trying to read it all the time and sometimes coming up with null data which caused tons of problems with rendering and physics calculations (e.g. operations on NaN numbers).  Simple fix was to respect the entity's network-synced flag on the client side but it makes all the difference.
3. Fixes an incorrect assert on multiplayer VoiceChat shutdown.
4. Allows r_useScissor cvar to be changed in multiplayer mode for use in bake* operations on multiplayer maps.
5. Allows r_useParallelAdd* cvars to to be changed in multiplayer mode for use in bake* operations on multiplayer maps.  This one is interesting, as I cannot duplicate the crash noted in the code if these cvars are not set to false.  i.e. you can do the bake operations with them left on with no crashes.  However, the interesting thing is that the bake operations are about 5-10% _faster_ with them set to false.  Unexpected but I can duplicate this across multiple platforms (Win, Linux, macOS).  So in the end I left the logic in place but allowed the cvars to be changed in multiplayer mode.
6. Fixed a couple of uninitialized variables that showed up in valgrind when in multiplayer mode.
7. Added `base/env/` to **.gitignore** since multiplayer bake operations write to this location in the install tree.

Tested on Win 10, Manjaro Linux, macOS Ventura with various cross-platform client-to-server connections.