### PR TITLE
Generate absolute mouse coords when imgui tools are active

### DIFF
--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -1216,7 +1216,7 @@ sysEvent_t Sys_GetEvent()
 			case SDL_MOUSEMOTION:
 				// DG: return event with absolute mouse-coordinates when in menu
 				// to fix cursor problems in windowed mode
-				if( game && game->Shell_IsActive() )
+				if( game && ( game->Shell_IsActive() || ImGuiTools::ReleaseMouseForTools() ) )
 				{
 					res.evType = SE_MOUSE_ABSOLUTE;
 					res.evValue = ev.motion.x;


### PR DESCRIPTION
fixes #850