### PR TITLE
Save changes to Render Mode and CRT Filter settings across launches

### DIFF
--- a/neo/d3xp/menus/MenuScreen.h
+++ b/neo/d3xp/menus/MenuScreen.h
@@ -1407,9 +1407,11 @@ public:
 		float originalVolume;
 		// RB begin
 		//int originalShadowMapping; // TODO use for quality of shadowmaps?
+		int originalRenderMode;
+		float originalAmbientBrightness;
 		int originalSSAO;
 		int originalPostProcessing;
-		float originalAmbientBrightness;
+		int originalCRTPostFX;
 		// RB end
 
 		idList<vidMode_t>			modeList;

--- a/neo/d3xp/menus/MenuScreen_Shell_SystemOptions.cpp
+++ b/neo/d3xp/menus/MenuScreen_Shell_SystemOptions.cpp
@@ -435,9 +435,11 @@ void idMenuScreen_Shell_SystemOptions::idMenuDataSource_SystemSettings::LoadData
 	originalVolume = s_volume_dB.GetFloat();
 	// RB begin
 	//originalShadowMapping = r_useShadowMapping.GetInteger();
-	originalSSAO = r_useSSAO.GetInteger();
+	originalRenderMode = r_renderMode.GetInteger();
 	originalAmbientBrightness = r_forceAmbient.GetFloat();
+	originalSSAO = r_useSSAO.GetInteger();
 	originalPostProcessing = r_useFilmicPostFX.GetInteger();
+	originalCRTPostFX = r_useCRTPostFX.GetInteger();
 	// RB end
 
 	const int fullscreen = r_fullscreen.GetInteger();
@@ -890,6 +892,16 @@ bool idMenuScreen_Shell_SystemOptions::idMenuDataSource_SystemSettings::IsDataCh
 	//	return true;
 	//}
 
+	if( originalRenderMode != r_renderMode.GetInteger() )
+	{
+		return true;
+	}
+
+	if( originalAmbientBrightness != r_forceAmbient.GetFloat() )
+	{
+		return true;
+	}
+
 	if( originalSSAO != r_useSSAO.GetInteger() )
 	{
 		return true;
@@ -900,7 +912,7 @@ bool idMenuScreen_Shell_SystemOptions::idMenuDataSource_SystemSettings::IsDataCh
 		return true;
 	}
 
-	if( originalAmbientBrightness != r_forceAmbient.GetFloat() )
+	if( originalCRTPostFX != r_useCRTPostFX.GetInteger() )
 	{
 		return true;
 	}

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -2209,14 +2209,8 @@ void idRenderSystemLocal::Shutdown()
 
 	UnbindBufferObjects();
 
-	// SRS - wait for fence to hit before freeing any resources the GPU may be using, otherwise get Vulkan validation layer errors on shutdown
-	// SRS - skip this step if we are in a Doom Classic game
-#if defined(USE_DOOMCLASSIC)
-	if( common->GetCurrentGame() == DOOM3_BFG )
-	{
-		backend.GL_BlockingSwapBuffers();
-	}
-#endif
+	// SRS - wait for device idle before freeing any resources the GPU may be using, otherwise get errors on shutdown
+	deviceManager->GetDevice()->waitForIdle();
 
 	// free the vertex cache, which should have nothing allocated now
 	vertexCache.Shutdown();


### PR DESCRIPTION
Fixes #858

Also properly fixes issue where game is not waiting long enough on exit before shutting down Vertex Cache.  Current code using `GL_BlockingSwapBuffers()` is not correct for the nvrhi implementation, especially when using triple buffering.  The correct solution is to wait on device idle.  This also eliminates the need for an `#ifdef` based on build config options.  This same fix is also included in #849, but I am not sure if that PR will be merged, so I am duplicating the fix here to make sure.