### PR TITLE
Remove redundant cmake code for finding dxc, now handled by ShaderMake

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -396,8 +396,9 @@ if(USE_VULKAN)
 	else()
 		include_directories(${Vulkan_INCLUDE_DIRS})
 
-		if(Vulkan_dxc_exe_FOUND AND NOT DEFINED DXC_SPIRV_EXECUTABLE)
-			set(DXC_SPIRV_EXECUTABLE ${Vulkan_dxc_EXECUTABLE})
+		# SRS - ShaderMake uses DXC_CUSTOM_PATH as fallback if dxc for SPIRV not found by other means
+		if(Vulkan_dxc_exe_FOUND AND NOT DEFINED DXC_CUSTOM_PATH)
+			set(DXC_CUSTOM_PATH ${Vulkan_dxc_EXECUTABLE})
 		endif()
 
         if(APPLE)
@@ -446,18 +447,21 @@ add_definitions(-DUSE_NVRHI)
 set(SHADERMAKE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/ShaderMake)
 add_subdirectory(${SHADERMAKE_DIR})
 
-if(USE_DX11)
-	find_package(FXC REQUIRED)
-endif()
+# SRS - ShaderMake now finds fxc when required
+#if(USE_DX11)
+#	find_package(FXC REQUIRED)
+#endif()
 
 if(USE_DX12)
-	find_package(DXCdxil REQUIRED)
+	# SRS - ShaderMake now finds dxc for DXIL when required
+	# find_package(DXCdxil REQUIRED)
 	set(USE_DXIL_ON_DX12 TRUE CACHE BOOL "Use DXC to compile DXIL shaders on DX12 - otherwise FXC and DXBC")
 endif()
 
-if(USE_VULKAN)
-	find_package(DXCspirv REQUIRED)
-endif()
+# SRS - ShaderMake now finds dxc for SPIRV when required
+#if(USE_VULKAN)
+#	find_package(DXCspirv REQUIRED)
+#endif()
 
 include_directories(${NVRHI_DIR}/include)
 include_directories(${SHADERMAKE_DIR}/include)

--- a/neo/compileshaders.cmake
+++ b/neo/compileshaders.cmake
@@ -57,8 +57,8 @@ function(compile_shaders)
         SOURCES ${params_SOURCES})
 
     if (params_DXIL AND (USE_DX12 AND USE_DXIL_ON_DX12))
-        if (NOT DXC_DXIL_EXECUTABLE)
-            message(FATAL_ERROR "compile_shaders: DXC not found --- please set DXC_DXIL_EXECUTABLE to the full path to the DXC binary")
+        if (NOT DXC_PATH)
+            message(FATAL_ERROR "compile_shaders: DXC not found --- please set DXC_PATH to the full path to the DXC binary")
         endif()
 
         if (NOT params_CFLAGS)
@@ -76,12 +76,12 @@ function(compile_shaders)
                                    --outputExt=.bin
                                    -I ${SHADER_INCLUDE_DIR}
                                    ${CFLAGS}
-                                   --compiler=${DXC_DXIL_EXECUTABLE})
+                                   --compiler=${DXC_PATH})
     endif()
 
     if (params_DXBC AND (USE_DX11 OR (USE_DX12 AND NOT USE_DXIL_ON_DX12)))
-        if (NOT FXC_EXECUTABLE)
-            message(FATAL_ERROR "compile_shaders: FXC not found --- please set FXC_EXECUTABLE to the full path to the FXC binary")
+        if (NOT FXC_PATH)
+            message(FATAL_ERROR "compile_shaders: FXC not found --- please set FXC_PATH to the full path to the FXC binary")
         endif()
 
         if (NOT params_CFLAGS)
@@ -99,12 +99,12 @@ function(compile_shaders)
                                    --outputExt=.bin
                                    -I ${SHADER_INCLUDE_DIR}
                                    ${CFLAGS}
-                                   --compiler=${FXC_EXECUTABLE})
+                                   --compiler=${FXC_PATH})
     endif()
 
     if (params_SPIRV_DXC AND USE_VULKAN)
-        if (NOT DXC_SPIRV_EXECUTABLE)
-            message(FATAL_ERROR "compile_shaders: DXC for SPIR-V not found --- please set DXC_SPIRV_EXECUTABLE to the full path to the DXC binary")
+        if (NOT DXC_SPIRV_PATH)
+            message(FATAL_ERROR "compile_shaders: DXC for SPIR-V not found --- please set DXC_SPIRV_PATH to the full path to the DXC binary")
         endif()
 
         if (NOT params_CFLAGS)
@@ -123,7 +123,7 @@ function(compile_shaders)
                                    -I ${SHADER_INCLUDE_DIR}
                                    -D SPIRV
                                    ${CFLAGS}
-                                   --compiler=${DXC_SPIRV_EXECUTABLE})
+                                   --compiler=${DXC_SPIRV_PATH})
     endif()
 
     if(params_FOLDER)


### PR DESCRIPTION
I initially missed this when doing the nvrhi rebase:  ShaderMake now finds all shader compiler executable paths by itself for all platforms and makes them available to the application.  In addition it has some good fallback and error reporting.

In this PR I have removed the redundant work in RBDoom3BFG's **CMakeLists** and aligned **compileshaders.cmake** with the new path variables.  The only external difference is the **dxc for SPIRV** override path is now called `DXC_CUSTOM_PATH` instead of `DXC_SPIRV_EXECUTABLE`.  This is not needed on Windows and macOS due to their use of the Vulkan SDK.  However, on linux it is useful if the distro does not have a dxc package, and you need to install your own copy at a non-standard path.

Tested on Windows 10, macOS Ventura, and Manjaro Linux.  Note that Manjaro has a dxc package available and with it installed you don't need to do anything special or even define `DXC_CUSTOM_PATH`. ShaderMake finds dxc and populates the required path variable automatically.