### PR TITLE
Fix crash regression in Bink Decoder when file cannot be opened

### DIFF
--- a/neo/libs/libbinkdec/src/BinkDecoder.cpp
+++ b/neo/libs/libbinkdec/src/BinkDecoder.cpp
@@ -165,6 +165,10 @@ BinkDecoder::BinkDecoder()
 {
 	nFrames = 0;
 	currentFrame = 0;
+	for (int i = 0; i < BINK_NB_SRC; i++)
+	{
+		bundle[i].data = NULL;
+	}
 }
 
 BinkDecoder::~BinkDecoder()

--- a/neo/libs/libbinkdec/src/BinkVideo.cpp
+++ b/neo/libs/libbinkdec/src/BinkVideo.cpp
@@ -105,7 +105,11 @@ void BinkDecoder::InitBundles()
 void BinkDecoder::FreeBundles()
 {
 	for (int i = 0; i < BINK_NB_SRC; i++)
-		delete[] bundle[i].data;
+		if (bundle[i].data)
+		{
+			delete[] bundle[i].data;
+			bundle[i].data = NULL;
+		}
 }
 
 uint8_t BinkDecoder::GetHuffSymbol(BinkCommon::BitReader &bits, Tree &tree)

--- a/neo/renderer/NVRHI/RenderDebug_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderDebug_NVRHI.cpp
@@ -2318,6 +2318,7 @@ void idRenderBackend::DBG_TestImage()
 
 	// Set State
 	GL_State( GLS_SRCBLEND_ONE | GLS_DSTBLEND_ZERO | GLS_DEPTHMASK | GLS_DEPTHFUNC_ALWAYS | GLS_CULL_TWOSIDED );
+	renderProgManager.SetRenderParm( RENDERPARM_ALPHA_TEST, vec4_zero.ToFloatPtr() );
 
 	// Set Parms
 	float texS[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
@@ -2327,6 +2328,7 @@ void idRenderBackend::DBG_TestImage()
 
 	float texGenEnabled[4] = { 0, 0, 0, 0 };
 	renderProgManager.SetRenderParm( RENDERPARM_TEXGEN_0_ENABLED, texGenEnabled );
+	RB_SetVertexColorParms( SVC_IGNORE );
 
 #if 1
 	// not really necessary but just for clarity
@@ -2378,16 +2380,31 @@ void idRenderBackend::DBG_TestImage()
 
 		GL_SelectTexture( 2 );
 		imageCb->Bind();
-		// SRS - Use Bink shader without sRGB to linear conversion, otherwise cinematic colours may be wrong
-		// BindShader_BinkGUI() does not seem to work here - perhaps due to vertex shader input dependencies?
-		renderProgManager.BindShader_Bink_sRGB();
+
+		// SRS - When console is active (i.e. 2D) skip sRGB to linear conversion
+		if( console->Active() )
+		{
+			renderProgManager.BindShader_Bink_sRGB();
+		}
+		else
+		{
+			renderProgManager.BindShader_Bink();
+		}
 	}
 	else
 	{
 		GL_SelectTexture( 0 );
 		image->Bind();
 
-		renderProgManager.BindShader_Texture();
+		// SRS - When console is active (i.e. 2D) skip sRGB to linear conversion
+		if( console->Active() )
+		{
+			renderProgManager.BindShader_TextureVertexColor_sRGB();
+		}
+		else
+		{
+			renderProgManager.BindShader_TextureVertexColor();
+		}
 	}
 
 	// Draw!

--- a/neo/renderer/NVRHI/RenderDebug_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderDebug_NVRHI.cpp
@@ -2381,14 +2381,14 @@ void idRenderBackend::DBG_TestImage()
 		GL_SelectTexture( 2 );
 		imageCb->Bind();
 
-		// SRS - When console is active (i.e. 2D) skip sRGB to linear conversion
-		if( console->Active() )
+		// SRS - When rendering in 2D skip sRGB to linear conversion
+		if( viewDef->viewEntitys )
 		{
-			renderProgManager.BindShader_Bink_sRGB();
+			renderProgManager.BindShader_Bink();
 		}
 		else
 		{
-			renderProgManager.BindShader_Bink();
+			renderProgManager.BindShader_Bink_sRGB();
 		}
 	}
 	else
@@ -2396,14 +2396,14 @@ void idRenderBackend::DBG_TestImage()
 		GL_SelectTexture( 0 );
 		image->Bind();
 
-		// SRS - When console is active (i.e. 2D) skip sRGB to linear conversion
-		if( console->Active() )
+		// SRS - When rendering in 2D skip sRGB to linear conversion
+		if( viewDef->viewEntitys )
 		{
-			renderProgManager.BindShader_TextureVertexColor_sRGB();
+			renderProgManager.BindShader_TextureVertexColor();
 		}
 		else
 		{
-			renderProgManager.BindShader_TextureVertexColor();
+			renderProgManager.BindShader_TextureVertexColor_sRGB();
 		}
 	}
 


### PR DESCRIPTION
Fixes a crash regression in Bink Decoder when the path is missing or not a bink file.  This can be observed when using the testVideo console command and mistyping a file name.  The regression comes my previous memory leak fixes that freed Bink bundles when closing playback.  Unfortunately I did not properly check for unallocated bundles with NULL pointers caused by failed open requests.  This PR fixes that oversight.

In addition, this adds a small change to testVideo playback that checks if ~~the console is open or closed~~ the view is 2D or 3D, and only skips sRGB to linear conversion if the ~~console is open (i.e. a 2D surface)~~ view is 2D.  If the console is closed and a 3D game is running, then normal shaders are used for testVideo to get as close as possible to proper colors.  However, this is not perfect since other 3D processing occurs afterwards - i.e. TAA, Tonemapping, etc.  A minor improvement but I thought I would add it here.