### PR TITLE
macOS: Support non-system Vulkan SDK installs & enable cmake regen for Xcode release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,8 @@ Recommended in this case is `cmake-vs2022-win64-no-ffmpeg.bat`
 		> # DXC compiler
 		> PATH="~/dxc-artifacts/bin:$PATH"
 
+	As an alternative to modifying your PATH, you can add -DDXC\_CUSTOM_PATH=\<path-to-dxc-binary> to the CMake options.
+
 2. You need the following dependencies in order to compile RBDoom3BFG with all features:
 
 	On Debian or Ubuntu:

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -375,7 +375,7 @@ if(USE_VULKAN)
 		endif()
 
         if(APPLE)
-            # SRS - Enable Beta extensions for VULKAN_SDK portability subset features on OSX
+            # SRS - Enable Beta extensions for Vulkan portability subset features on macOS
             add_definitions(-DVK_ENABLE_BETA_EXTENSIONS)
             # SRS - Optionally link directly to MoltenVK headers/library for runtime config functions on OSX
             if(USE_MoltenVK)
@@ -386,6 +386,19 @@ if(USE_VULKAN)
                 else()
 		            message(FATAL_ERROR "Must define VULKAN_SDK location if USE_MoltenVK option enabled!")
                 endif()
+			else()
+				# If using Xcode and the Vulkan loader's environment variables are defined, make them available within Xcode scheme
+				if(CMAKE_GENERATOR MATCHES "Xcode")
+					if(DEFINED ENV{VK_ADD_LAYER_PATH})
+						set(CMAKE_XCODE_SCHEME_ENVIRONMENT "${CMAKE_XCODE_SCHEME_ENVIRONMENT};VK_ADD_LAYER_PATH=$ENV{VK_ADD_LAYER_PATH}")
+					endif()
+					if(DEFINED ENV{VK_ICD_FILENAMES})
+						set(CMAKE_XCODE_SCHEME_ENVIRONMENT "${CMAKE_XCODE_SCHEME_ENVIRONMENT};VK_ICD_FILENAMES=$ENV{VK_ICD_FILENAMES}")
+					endif()
+					if(DEFINED ENV{VK_DRIVER_FILES})
+						set(CMAKE_XCODE_SCHEME_ENVIRONMENT "${CMAKE_XCODE_SCHEME_ENVIRONMENT};VK_DRIVER_FILES=$ENV{VK_DRIVER_FILES}")
+					endif()
+				endif()
             endif()
 		endif()
 		message(STATUS "Using Vulkan: " ${Vulkan_LIBRARY})

--- a/neo/cmake-xcode-debug.sh
+++ b/neo/cmake-xcode-debug.sh
@@ -13,8 +13,8 @@ if [ -z "$OPENAL_PREFIX" ]; then
   fi
 fi
 
-# note 1: remove or set -DCMAKE_SUPPRESS_REGENERATION=OFF to reenable ZERO_CHECK target which checks for CMakeLists.txt changes and re-runs CMake before builds
-#         however, if ZERO_CHECK is reenabled **must** add VULKAN_SDK location to Xcode Custom Paths (under Prefs/Locations) otherwise build failures may occur
+# note 1: remove or set -DCMAKE_SUPPRESS_REGENERATION=OFF to enable ZERO_CHECK target which checks for CMakeLists.txt changes and re-runs CMake before builds
+#         however, if ZERO_CHECK is enabled **must** add Vulkan's VK_ADD_LAYER_PATH, VK_ICD_FILENAMES, and VK_DRIVER_FILES locations to Xcode Custom Paths (under Settings/Locations) otherwise runtime failures may occur
 # note 2: policy CMAKE_POLICY_DEFAULT_CMP0142=NEW suppresses non-existant per-config suffixes on Xcode library search paths, works for cmake version 3.25 and later
 # note 3: env variable MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE=1 enables MoltenVK's image view swizzle which may be required on older macOS versions or hardware (see vulkaninfo) - only used for VulkanSDK < 1.3.275
 # note 4: env variable MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS=0 disables synchronous queue submits which is optimal for the synchronization method used by the game - only used for VulkanSDK < 1.3.275

--- a/neo/cmake-xcode-release.sh
+++ b/neo/cmake-xcode-release.sh
@@ -13,7 +13,5 @@ if [ -z "$OPENAL_PREFIX" ]; then
   fi
 fi
 
-# note 1: remove or set -DCMAKE_SUPPRESS_REGENERATION=OFF to reenable ZERO_CHECK target which checks for CMakeLists.txt changes and re-runs CMake before builds
-#         however, if ZERO_CHECK is reenabled **must** add VULKAN_SDK location to Xcode Custom Paths (under Prefs/Locations) otherwise build failures may occur
-# note 2: policy CMAKE_POLICY_DEFAULT_CMP0142=NEW suppresses non-existant per-config suffixes on Xcode library search paths, works for cmake version 3.25 and later
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DMACOSX_BUNDLE=ON -DFFMPEG=OFF -DBINKDEC=ON -DUSE_MoltenVK=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_XCODE_SCHEME_ENABLE_GPU_API_VALIDATION=OFF -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=$OPENAL_PREFIX/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=$OPENAL_PREFIX/include ../neo -DCMAKE_POLICY_DEFAULT_CMP0142=NEW -Wno-dev
+# note 1: policy CMAKE_POLICY_DEFAULT_CMP0142=NEW suppresses non-existant per-config suffixes on Xcode library search paths, works for cmake version 3.25 and later
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DMACOSX_BUNDLE=ON -DFFMPEG=OFF -DBINKDEC=ON -DUSE_MoltenVK=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_XCODE_SCHEME_ENABLE_GPU_API_VALIDATION=OFF -DOPENAL_LIBRARY=$OPENAL_PREFIX/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=$OPENAL_PREFIX/include ../neo -DCMAKE_POLICY_DEFAULT_CMP0142=NEW -Wno-dev

--- a/neo/cmake-xcode-universal.sh
+++ b/neo/cmake-xcode-universal.sh
@@ -11,8 +11,6 @@ if [[ $OPENAL_VARIANTS != *universal* ]]; then
   exit 1
 fi
 
-# note 1: remove or set -DCMAKE_SUPPRESS_REGENERATION=OFF to reenable ZERO_CHECK target which checks for CMakeLists.txt changes and re-runs CMake before builds
-#         however, if ZERO_CHECK is reenabled **must** add VULKAN_SDK location to Xcode Custom Paths (under Prefs/Locations) otherwise build failures may occur
-# note 2: policy CMAKE_POLICY_DEFAULT_CMP0142=NEW suppresses non-existant per-config suffixes on Xcode library search paths, works for cmake version 3.25 and later
-# note 3: universal openal-soft library and include paths assume MacPorts install locations
-cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DMACOSX_BUNDLE=ON -DFFMPEG=OFF -DBINKDEC=ON -DUSE_MoltenVK=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_XCODE_SCHEME_ENABLE_GPU_API_VALIDATION=OFF -DCMAKE_SUPPRESS_REGENERATION=ON -DOPENAL_LIBRARY=/opt/local/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/opt/local/include ../neo -DCMAKE_POLICY_DEFAULT_CMP0142=NEW -Wno-dev
+# note 1: policy CMAKE_POLICY_DEFAULT_CMP0142=NEW suppresses non-existant per-config suffixes on Xcode library search paths, works for cmake version 3.25 and later
+# note 2: universal openal-soft library and include paths assume MacPorts install locations
+cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_CONFIGURATION_TYPES="Release;MinSizeRel;RelWithDebInfo" -DMACOSX_BUNDLE=ON -DFFMPEG=OFF -DBINKDEC=ON -DUSE_MoltenVK=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_XCODE_SCHEME_ENABLE_GPU_API_VALIDATION=OFF -DOPENAL_LIBRARY=/opt/local/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/opt/local/include ../neo -DCMAKE_POLICY_DEFAULT_CMP0142=NEW -Wno-dev


### PR DESCRIPTION
This is a small cmake pull request that adds:

1. Ability to use non-system level Vulkan SDK installs for Xcode debug builds.  This change makes sure the Vulkan loader's `VK_ADD_LAYER_PATH`, `VK_ICD_FILENAMES`, and `VK_DRIVER_FILES` environment variables (if defined) are added to the Xcode build scheme.  This prevents runtime failures when the Vulkan loader cannot find the Vulkan layers and the MoltenVK library when installed without the _Global System Installation_ option.
2. Enables cmake regeneration for Xcode release and universal builds by enabling the ZERO_CHECK target.
3. Update README re `DXC_CUSTOM_PATH` option for specifying location of dxc (typically on linux - see #881)