### PR TITLE
Explicit font's position's type is signed char

### DIFF
--- a/doomclassic/doom/d_ticcmd.h
+++ b/doomclassic/doom/d_ticcmd.h
@@ -41,8 +41,8 @@ If you have questions concerning this license or the applicable additional terms
 // plus a checksum for internal state consistency.
 typedef struct
 {
-	char	forwardmove;	// *2048 for move
-	char	sidemove;	// *2048 for move
+	signed char	forwardmove;	// *2048 for move
+	signed char	sidemove;	// *2048 for move
 	short	angleturn;	// <<16 for angle delta
 	short	consistancy;	// checks for net game
 	byte	buttons;

--- a/neo/idlib/sys/sys_defines.h
+++ b/neo/idlib/sys/sys_defines.h
@@ -130,6 +130,8 @@ If you have questions concerning this license or the applicable additional terms
 			#define CPUSTRING						"sparc"
 		#elif defined(__loongarch64)
 			#define CPUSTRING						"loongarch64"
+		#elif defined(__arm__)
+			#define CPUSTRING						"arm"
 		#else
 			#error unknown CPU
 		#endif

--- a/neo/renderer/Font.h
+++ b/neo/renderer/Font.h
@@ -68,8 +68,8 @@ private:
 	{
 		byte	width;	// width of glyph in pixels
 		byte	height;	// height of glyph in pixels
-		char	top;	// distance in pixels from the base line to the top of the glyph
-		char	left;	// distance in pixels from the pen to the left edge of the glyph
+		signed char	top;	// distance in pixels from the base line to the top of the glyph
+		signed char	left;	// distance in pixels from the pen to the left edge of the glyph
 		byte	xSkip;	// x adjustment after rendering this glyph
 		uint16	s;		// x offset in image where glyph starts (in pixels)
 		uint16	t;		// y offset in image where glyph starts (in pixels)


### PR DESCRIPTION
idFont::fontInfo_t::ascii should be not effect it.