### PR TITLE
Minor fixes related to jpeg/png libs -> stb changes

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -281,12 +281,11 @@ if(APPLE)
 	set(CMAKE_FIND_FRAMEWORK LAST)
 endif()
 
-# SRS - search for system zlib only if we have not already searched via system libpng
 if(USE_SYSTEM_ZLIB)
 	find_package(ZLIB)
 endif()
 
-if (USE_SYSTEM_ZLIB AND ZLIB_FOUND)
+if(ZLIB_FOUND)
 	include_directories(${ZLIB_INCLUDE_DIRS})
 	set(ZLIB_LIBRARY ${ZLIB_LIBRARIES})
 else()

--- a/neo/libs/stb/stb_image_write.h
+++ b/neo/libs/stb/stb_image_write.h
@@ -894,7 +894,7 @@ static int stbi_write_hdr_core( stbi__write_context* s, int x, int y, int comp, 
 #ifdef __STDC_LIB_EXT1__
 		len = sprintf_s( buffer, sizeof( buffer ), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x );
 #else
-		len = sprintf( buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x );
+		len = snprintf( buffer, sizeof( buffer ), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x );
 #endif
 		s->func( s->context, buffer, len );
 

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -847,7 +847,7 @@ bool R_ReadPixelsRGB8( nvrhi::IDevice* device, CommonRenderPasses* pPasses, nvrh
 
 	// SRS - Save screen shots to fs_savepath on macOS (i.e. don't save into an app bundle's basepath)
 #if defined(__APPLE__)
-	R_WritePNG( fullname, static_cast<byte*>( pData ), 4, desc.width, desc.height, true, "fs_savepath" );
+	R_WritePNG( fullname, static_cast<byte*>( pData ), 4, desc.width, desc.height, "fs_savepath" );
 #else
 	R_WritePNG( fullname, static_cast<byte*>( pData ), 4, desc.width, desc.height, "fs_basepath" );
 #endif


### PR DESCRIPTION
A couple of trivial changes related to removing the old jpeg/png libs in favour of stb header:

1. Remove old **CMakeLists.txt** comment and unneeded test in system zlib logic
2. Use `snprintf()` instead of `sprintf()` in **sub_image_write.h** to avoid clang/gcc deprecation warning
3. Remove extra parameter in call to `R_WritePNG()` which caused a compile failure on macOS