### PR TITLE
Update DataQueue.h to fix a build failure in Append method

### DIFF
--- a/neo/idlib/DataQueue.h
+++ b/neo/idlib/DataQueue.h
@@ -109,8 +109,11 @@ bool idDataQueue< maxItems, maxBuffer >::Append( int sequence, const byte* b1, i
 	item.dataOffset = dataLength;
 	memcpy( data + dataLength, b1, b1Len );
 	dataLength += b1Len;
-	memcpy( data + dataLength, b2, b2Len );
-	dataLength += b2Len;
+	if( b2 != NULL )
+	{
+		memcpy( data + dataLength, b2, b2Len );
+		dataLength += b2Len;
+	}
 	return true;
 }
 

--- a/neo/idlib/DataQueue.h
+++ b/neo/idlib/DataQueue.h
@@ -107,8 +107,11 @@ bool idDataQueue< maxItems, maxBuffer >::Append( int sequence, const byte* b1, i
 	item.length = b1Len + b2Len;
 	item.sequence = sequence;
 	item.dataOffset = dataLength;
-	memcpy( data + dataLength, b1, b1Len );
-	dataLength += b1Len;
+	if( b1 != NULL)
+	{
+		memcpy( data + dataLength, b1, b1Len );
+		dataLength += b1Len;
+	}
 	if( b2 != NULL )
 	{
 		memcpy( data + dataLength, b2, b2Len );


### PR DESCRIPTION
This is a quick and dirty fix for this gcc-13 build failure on ppc64el with -O3 optimization level:


/usr/bin/g++-13 -DCPUSTRING=\"ppc64el\" -DUSE_DOOMCLASSIC -DUSE_EXCEPTIONS -DUSE_FFMPEG -DUSE_NEWER_JPEG -DUSE_OPENAL -D__DOOM__ -I/usr/include/imgui -I/usr/include/stb -I/<<PKGBUILDDIR>>/neo/. -I/<<PKGBUILDDIR>>/neo/idlib -isystem /usr/include/SDL2 -g -O3 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -fno-stack-clash-protection -fdebug-prefix-map=/<<PKGBUILDDIR>>=/usr/src/rbdoom3bfg-1.4.0+dfsg-3ubuntu2 -Wdate-time -D_FORTIFY_SOURCE=3  -std=c++11   -pipe -Werror=format-security -Werror=format -Wno-pragmas -Wno-unused-variable -Wno-switch -Wno-unused-value -Winvalid-pch -Wno-multichar -fno-strict-aliasing -MD -MT CMakeFiles/rbdoom3bfg.dir/sys/Snapshot_Jobs.cpp.o -MF CMakeFiles/rbdoom3bfg.dir/sys/Snapshot_Jobs.cpp.o.d -o CMakeFiles/rbdoom3bfg.dir/sys/Snapshot_Jobs.cpp.o -c /<<PKGBUILDDIR>>/neo/sys/Snapshot_Jobs.cpp
In file included from /usr/include/string.h:548,
                 from /<<PKGBUILDDIR>>/neo/idlib/sys/sys_includes.h:141,
                 from /<<PKGBUILDDIR>>/neo/idlib/precompiled.h:34,
                 from /<<PKGBUILDDIR>>/neo/sys/PacketProcessor.cpp:29:
In function â€˜memcpyâ€™,
    inlined from â€˜idDataQueue<64, 8000>::Append(int, unsigned char const*, int, unsigned char const*, int)â€™ at /<<PKGBUILDDIR>>/neo/idlib/../idlib/DataQueue.h:112:8,
    inlined from â€˜idPacketProcessor::VerifyEmptyReliableQueue(unsigned char, unsigned char)â€™ at /<<PKGBUILDDIR>>/neo/sys/PacketProcessor.cpp:660:16:
/usr/include/powerpc64le-linux-gnu/bits/string_fortified.h:29:33: error: argument 2 null where non-null expected [-Werror=nonnull]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/powerpc64le-linux-gnu/bits/string_fortified.h:29:33: note: in a call to built-in function â€˜__memcpy_chkâ€™
cc1plus: some warnings being treated as errors