### PR TITLE
Respect basePath parameter vs hardcoded path in R_WritePNG()

### DIFF
--- a/neo/renderer/Image_files.cpp
+++ b/neo/renderer/Image_files.cpp
@@ -522,7 +522,7 @@ void R_WritePNG( const char* filename, const byte* data, int bytesPerPixel, int 
 		common->Error( "R_WritePNG( %s ): bytesPerPixel = %i not supported", filename, bytesPerPixel );
 	}
 
-	idFileLocal file( fileSystem->OpenFileWrite( filename, "fs_basepath" ) );
+	idFileLocal file( fileSystem->OpenFileWrite( filename, basePath ) );
 	if( file == NULL )
 	{
 		common->Printf( "R_WritePNG: Failed to open %s\n", filename );


### PR DESCRIPTION
Don't hardcode `fs_basepath` in `R_WritePNG()`, but instead use the passed-in function parameter `basePath`.

**All** non-macOS calls to `R_WritePNG()` already include `fs_basepath` in the function parameter list, so there is no need to override with a hardcoded value inside the function.

The one exception is for macOS which calls `R_WritePNG()` with `fs_savepath` for F12 screenshots.  This is intentional since it is pretty weird on macOS to write into an App bundle for something like screenshots.  No one would think to look there for a user accessible item.