### PR TITLE
rbdmap build warning fixes for gcc/posix and MSVC/win32

### DIFF
--- a/neo/tools/compilers/CMakeLists.txt
+++ b/neo/tools/compilers/CMakeLists.txt
@@ -307,6 +307,12 @@ else()
 	SEPARATE_ARGUMENTS(_compiler_FLAGS)
 	
 	if (USE_PRECOMPILED_HEADERS)
+	# SRS - USE_OPTICK not useful for rbdmap, but definition required to avoid mismatch with idlib precompiled header
+	if(OPTICK)
+		LIST(APPEND _compiler_FLAGS -DUSE_OPTICK=1)
+	else()
+		LIST(APPEND _compiler_FLAGS -DUSE_OPTICK=0)
+	endif()
 	add_custom_target(precomp_header_rbdmap ALL
 	                  COMMAND ${CMAKE_CXX_COMPILER} ${_compiler_FLAGS} -x c++-header precompiled.h -o precompiled.h.gch
 	                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -318,6 +324,34 @@ else()
 	add_dependencies(rbdmap idlib)
 	if (USE_PRECOMPILED_HEADERS)
 	add_dependencies(rbdmap precomp_header_rbdmap)
+
+	if(WIN32)
+		set(remove_command "del")
+		set(idlib_dir_slash "${CMAKE_SOURCE_DIR}\\idlib\\")
+	else()
+		set(remove_command "rm")
+		set(idlib_dir_slash "${CMAKE_SOURCE_DIR}/idlib/")
+	endif()
+
+	# SRS - delete precompiled header file after executable is compiled: command line build case
+	if(CMAKE_GENERATOR MATCHES "Makefiles" OR CMAKE_GENERATOR MATCHES "Ninja")
+		add_custom_target(rm_precomp_header_rbdmap ALL
+				COMMAND ${remove_command} "precompiled.h.gch"
+				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+				COMMENT "remove tools/compilers/precompiled.h.gch"
+				)
+		add_dependencies(rm_precomp_header_rbdmap rbdmap)
+
+	# SRS - delete precompiled header files after executable is compiled: IDE build case (e.g. Xcode)
+	else()
+		add_custom_command(TARGET rbdmap POST_BUILD
+				# SRS - added wildcards to remove tmp files from cmake ZERO_CHECK regeneration
+				COMMAND ${remove_command} "${idlib_dir_slash}precompiled.h*.gch*"
+				COMMAND ${remove_command} "precompiled.h*.gch*"
+				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+				COMMENT "remove idlib/precompiled.h.gch and tools/compilers/precompiled.h.gch"
+		)
+	endif()
 	endif()
 	target_link_libraries(rbdmap idlib ${CURSES_NCURSES_LIBRARY} ${ZLIB_LIBRARY})
 	

--- a/neo/tools/compilers/CMakeLists.txt
+++ b/neo/tools/compilers/CMakeLists.txt
@@ -268,6 +268,18 @@ if(MSVC)
 		OBJECT_DEPENDS "precompiled.pch"
 		)
 
+	# SRS - disable certain MSVC warnings for select third-party source libraries, consider updating versions in the future?
+	set_source_files_properties(
+			${MC_IMTUI_SOURCES} ${MC_IMGUI_SOURCES}
+			PROPERTIES
+			COMPILE_FLAGS "/wd4005 /wd4244 /wd4305"	# C4005: macro redefinition, C4244: type conversion with possible loss of data, C4305: trucation from double to float
+			)
+	set_source_files_properties(
+			${PDCURSES_SOURCES} ${WINCON_SOURCES}
+			PROPERTIES
+			COMPILE_FLAGS "/wd4244 /wd4267 /wd4996"	# C4244, C4267: type conversion with possible loss of data, C4996: declared deprecated
+			)
+
     add_executable(rbdmap ${MC_SOURCES_ALL} ${MC_INCLUDES_ALL})
 	add_dependencies(rbdmap idlib)
 	target_link_libraries(rbdmap idlib winmm imtui-pdcurses ${ZLIB_LIBRARY})

--- a/neo/tools/compilers/CMakeLists.txt
+++ b/neo/tools/compilers/CMakeLists.txt
@@ -289,6 +289,14 @@ else()
 	endforeach()
 	endif()
 
+	# SRS - disable certain gcc/clang warnings for select third-party source libraries, consider updating versions in the future?
+	set_source_files_properties(
+			${MC_ZLIB_SOURCES}
+			${MC_MINIZIP_SOURCES}
+			PROPERTIES
+			COMPILE_FLAGS "-Wno-stringop-overread -Wno-deprecated-non-prototype"
+			)
+
 	include_directories(.)
 	
 	if (USE_PRECOMPILED_HEADERS)

--- a/neo/tools/compilers/main_posix.cpp
+++ b/neo/tools/compilers/main_posix.cpp
@@ -38,6 +38,7 @@ If you have questions concerning this license or the applicable additional terms
 #include <stdio.h>
 #include <dirent.h>
 #include <fnmatch.h>
+#include <unistd.h>
 
 #include "imtui/imtui.h"
 #include "imtui/imtui-impl-ncurses.h"
@@ -315,23 +316,25 @@ int Sys_ListFiles( const char* directory, const char* extension, idStrList& list
 
 	// DG: use readdir_r instead of readdir for thread safety
 	// the following lines are from the readdir_r manpage.. fscking ugly.
-	int nameMax = pathconf( directory, _PC_NAME_MAX );
-	if( nameMax == -1 )
-	{
-		nameMax = 255;
-	}
-	int direntLen = offsetof( struct dirent, d_name ) + nameMax + 1;
+	//int nameMax = pathconf( directory, _PC_NAME_MAX );
+	//if( nameMax == -1 )
+	//{
+	//	nameMax = 255;
+	//}
+	//int direntLen = offsetof( struct dirent, d_name ) + nameMax + 1;
 
-	struct dirent* entry = ( struct dirent* )Mem_Alloc( direntLen, TAG_CRAP );
+	//struct dirent* entry = ( struct dirent* )Mem_Alloc( direntLen, TAG_CRAP );
 
-	if( entry == NULL )
-	{
-		common->Warning( "Sys_ListFiles: Mem_Alloc for entry failed!" );
-		closedir( fdir );
-		return 0;
-	}
+	//if( entry == NULL )
+	//{
+	//	common->Warning( "Sys_ListFiles: Mem_Alloc for entry failed!" );
+	//	closedir( fdir );
+	//	return 0;
+	//}
 
-	while( readdir_r( fdir, entry, &d ) == 0 && d != NULL )
+	//while( readdir_r( fdir, entry, &d ) == 0 && d != NULL )
+	// SRS - readdir_r() is deprecated on linux, readdir() is thread safe with different dir streams
+	while( ( d = readdir( fdir ) ) != NULL )
 	{
 		// DG end
 		idStr::snPrintf( search, sizeof( search ), "%s/%s", directory, d->d_name );
@@ -361,7 +364,7 @@ int Sys_ListFiles( const char* directory, const char* extension, idStrList& list
 	}
 
 	closedir( fdir );
-	Mem_Free( entry );
+	//Mem_Free( entry );
 
 	if( debug )
 	{


### PR DESCRIPTION
This cleans up compiler warnings when building **rbdmap** on linux and win32:

1. Fixes rbdmap / idlib gcc PCH conflcts caused by a missing `USE_OPTICK` define.  Solution is to add the `USE_OPTICK` define to rbdmap PCH flags for non-MSVC builds.  Optick functionality is not needed, but the definition is required for gcc PCH consistency.  Tested on Manjaro linux.
2. Add specific gcc warning suppression for zlib and minizip third-party source libs.  Note this was already present for RBDoom3BFG, but was missing here.  Tested on Manjaro linux.
3. Replace deprecated `posix reader_r()` with `readdir()`, since it is no longer a thread safety issue. Note this was already done for RBDoom3BFG, again was missing here.  Tested on Manjaro linux.
4. Added specific MSVC warning suppression for imtui, imgui, pdcurses, and wincon third-party source libs.  Tested on Windows 10.

Note with these changes (plus adding a missing include) you can build and run rbdmap on macOS.  Not really needed at this time, and not enabled by default (I left your disable code alone), but it is there in case anyone needs it in the future.