### PR TITLE
set idlib include directory

### DIFF
--- a/neo/idlib/CMakeLists.txt
+++ b/neo/idlib/CMakeLists.txt
@@ -151,6 +151,8 @@ else()
 	endif()
 	
 endif()
+
+target_include_directories(idlib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 	
 if(OPTICK)
 	target_compile_definitions(idlib PUBLIC USE_OPTICK=1)


### PR DESCRIPTION
this commit will make include to idlib easier instead of 
```c++
#include "../idlib/math/math.h'
```
you can do
```c++
#include "math/math.h'
```