### PR TITLE
Fix SDL joystick controller mapping

### DIFF
--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -1348,13 +1348,12 @@ sysEvent_t Sys_GetEvent()
 					{K_JOY_DPAD_LEFT, J_DPAD_LEFT},
 					{K_JOY_DPAD_RIGHT, J_DPAD_RIGHT},
 				};
-				joystick_polls.Append( joystick_poll_t( controllerButtonRemap[ev.cbutton.button][1], ev.cbutton.state == SDL_PRESSED ? 1 : 0 ) );
 
 				res.evType = SE_KEY;
 				res.evValue = controllerButtonRemap[ev.cbutton.button][0];
 				res.evValue2 = ev.cbutton.state == SDL_PRESSED ? 1 : 0;
 
-				joystick_polls.Append( joystick_poll_t( res.evValue, res.evValue2 ) );
+				joystick_polls.Append( joystick_poll_t( controllerButtonRemap[ev.cbutton.button][1], res.evValue2 ) );
 				return res;
 #else
 			// WM0110


### PR DESCRIPTION
Fixes #942.  Does the correct controller button -> joystick event mapping for SDL joystick polling.

I did not change the actual mapping table - it seems to be fine as is.  Tested with PS4 controller.