### PR TITLE
Map SDL joystick movement to key presses for menu and PDA navigation

### DIFF
--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -694,11 +694,13 @@ sysEvent_t Sys_GetEvent()
 
 			// GameController
 			case SDL_JOYAXISMOTION:
+			case SDL_JOYBALLMOTION:
 			case SDL_JOYHATMOTION:
 			case SDL_JOYBUTTONDOWN:
 			case SDL_JOYBUTTONUP:
 			case SDL_JOYDEVICEADDED:
 			case SDL_JOYDEVICEREMOVED:
+			case SDL_JOYBATTERYUPDATED:
 				// Avoid 'unknown event' spam
 				continue;
 
@@ -772,6 +774,18 @@ sysEvent_t Sys_GetEvent()
 
 				joystick_polls.Append( joystick_poll_t( controllerButtonRemap[ev.cbutton.button][1], res.evValue2 ) );
 				return res;
+
+			case SDL_CONTROLLERDEVICEADDED:
+			case SDL_CONTROLLERDEVICEREMOVED:
+			case SDL_CONTROLLERDEVICEREMAPPED:
+			case SDL_CONTROLLERTOUCHPADDOWN:
+			case SDL_CONTROLLERTOUCHPADMOTION:
+			case SDL_CONTROLLERTOUCHPADUP:
+			case SDL_CONTROLLERSENSORUPDATE:
+			case SDL_CONTROLLERUPDATECOMPLETE_RESERVED_FOR_SDL3:
+			case SDL_CONTROLLERSTEAMHANDLEUPDATED:
+				// Avoid more 'unknown event' spam
+				continue;
 
 			case SDL_QUIT:
 				PushConsoleEvent( "quit" );

--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -737,7 +737,7 @@ sysEvent_t Sys_GetEvent()
 						res.evValue = controllerAxisRemap[axisIndex][0];
 						res.evValue2 = stickNeg ? 1 : 0;
 					}
-					if( buttonStates[controllerAxisRemap[axisIndex][1]] != stickPos )
+					else if( buttonStates[controllerAxisRemap[axisIndex][1]] != stickPos )
 					{
 						buttonStates[controllerAxisRemap[axisIndex][1]] = stickPos;
 						res.evType = SE_KEY;


### PR DESCRIPTION
Fixes missing SDL navigation in Flash menus (e.g. PDA) as highlighted within comments for issue #942.

This PR solves the problem by adding `K_JOY_STICK*_LEFT/RIGHT/UP/DOWN` key injection for SDL when left and right joysticks are moved outside of their dead zones.  While the implementation is SDL-specific, it matches the approach taken in Windows and should result in the same behaviour when using a game controller.

Note this results in additional synthetic key presses being generated when using controller joysticks to move around in-game, but this does not seems to cause problems on levels I have tested.

Also suppressed a few more SDL "unknown events" for Joysticks and Controllers.

This PR has been tested on macOS and Linux.