### PR TITLE
Fix mismatches between AO & TAA shader variables and their ImageViews

### DIFF
--- a/neo/renderer/Image_intrinsic.cpp
+++ b/neo/renderer/Image_intrinsic.cpp
@@ -285,9 +285,9 @@ static void R_HDR_RGBA16FImage_ResNative( idImage* image, nvrhi::ICommandList* c
 	image->GenerateImage( NULL, renderSystem->GetWidth(), renderSystem->GetHeight(), TF_NEAREST, TR_CLAMP, TD_RGBA16F, nullptr, true );
 }
 
-static void R_HDR_RGBA16FImage_ResNative_UAV( idImage* image, nvrhi::ICommandList* commandList )
+static void R_HDR_RGBA32FImage_ResNative_UAV( idImage* image, nvrhi::ICommandList* commandList )
 {
-	image->GenerateImage( NULL, renderSystem->GetWidth(), renderSystem->GetHeight(), TF_NEAREST, TR_CLAMP, TD_RGBA16F, nullptr, true, true );
+	image->GenerateImage( NULL, renderSystem->GetWidth(), renderSystem->GetHeight(), TF_NEAREST, TR_CLAMP, TD_RGBA32F, nullptr, true, true );
 }
 
 static void R_HDR_RGBA16SImage_ResNative_UAV( idImage* image, nvrhi::ICommandList* commandList )
@@ -347,7 +347,7 @@ static void R_SMAAImage_ResNative( idImage* image, nvrhi::ICommandList* commandL
 
 static void R_AmbientOcclusionImage_ResNative( idImage* image, nvrhi::ICommandList* commandList )
 {
-	image->GenerateImage( NULL, renderSystem->GetWidth(), renderSystem->GetHeight(), TF_LINEAR, TR_CLAMP, TD_R8F, nullptr, true, true );
+	image->GenerateImage( NULL, renderSystem->GetWidth(), renderSystem->GetHeight(), TF_LINEAR, TR_CLAMP, TD_R32F, nullptr, true, true );
 }
 
 static void R_GeometryBufferImage_ResNative( idImage* image, nvrhi::ICommandList* commandList )
@@ -1091,9 +1091,9 @@ void idImageManager::CreateIntrinsicImages()
 	ldrImage = globalImages->ImageFromFunction( "_currentRenderLDR", R_LdrNativeImage );
 
 	taaMotionVectorsImage = ImageFromFunction( "_taaMotionVectors", R_HDR_RG16FImage_ResNative ); // RB: could be shared with _currentNormals.zw
-	taaResolvedImage = ImageFromFunction( "_taaResolved", R_HDR_RGBA16FImage_ResNative_UAV );
-	taaFeedback1Image = ImageFromFunction( "_taaFeedback1", R_HDR_RGBA16SImage_ResNative_UAV );
-	taaFeedback2Image = ImageFromFunction( "_taaFeedback2", R_HDR_RGBA16SImage_ResNative_UAV );
+	taaResolvedImage = ImageFromFunction( "_taaResolved", R_HDR_RGBA32FImage_ResNative_UAV );
+	taaFeedback1Image = ImageFromFunction( "_taaFeedback1", R_HDR_RGBA32FImage_ResNative_UAV );
+	taaFeedback2Image = ImageFromFunction( "_taaFeedback2", R_HDR_RGBA32FImage_ResNative_UAV );
 
 	envprobeHDRImage = globalImages->ImageFromFunction( "_envprobeHDR", R_EnvprobeImage_HDR );
 	envprobeDepthImage = ImageFromFunction( "_envprobeDepth", R_EnvprobeImage_Depth );

--- a/neo/renderer/Passes/SsaoPass.cpp
+++ b/neo/renderer/Passes/SsaoPass.cpp
@@ -91,7 +91,7 @@ SsaoPass::SsaoPass(
 	m_QuantizedGbufferTextureSize = idVec2( float( DeinterleavedTextureDesc.width ), float( DeinterleavedTextureDesc.height ) ) * 4.f;
 
 	DeinterleavedTextureDesc.debugName = "SSAO/DeinterleavedOcclusion";
-	DeinterleavedTextureDesc.format = params.directionalOcclusion ? nvrhi::Format::RGBA16_FLOAT : nvrhi::Format::R8_UNORM;
+	DeinterleavedTextureDesc.format = params.directionalOcclusion ? nvrhi::Format::RGBA32_FLOAT : nvrhi::Format::R32_FLOAT;
 	m_DeinterleavedOcclusion = device->createTexture( DeinterleavedTextureDesc );
 
 	{


### PR DESCRIPTION
This fixes #984.

I believe this is the correct way to fix these format mismatch issues.  Open to feedback if there is a better solution.

Tested on Windows 10, Manjaro Linux, and macOS Ventura with no validation errors.