### PR TITLE
Support ISPC SIMD BC6 encoding for Linux/macOS x86_64 and arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,19 +447,19 @@ Recommended in this case is `cmake-vs2022-win64-no-ffmpeg.bat`
 
 	On Debian or Ubuntu:
 
-		> sudo apt install cmake libsdl2-dev libopenal-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libvulkan-dev libncurses-dev
+		> sudo apt install cmake ispc libsdl2-dev libopenal-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libvulkan-dev libncurses-dev
 	
 	On Fedora
 		
-		> sudo dnf install cmake clang SDL2-devel openal-devel compat-ffmpeg4-devel ncurses-devel vulkan-devel
+		> sudo dnf install cmake clang ispc SDL2-devel openal-devel compat-ffmpeg4-devel ncurses-devel vulkan-devel
 	
 	On ArchLinux 
 	
-		> sudo pacman -S sdl2 cmake openal ffmpeg
+		> sudo pacman -S sdl2 cmake ispc openal ffmpeg
 
 	On openSUSE
 	
-		> sudo zypper install cmake libSDL2-devel openal-soft-devel
+		> sudo zypper install cmake ispc libSDL2-devel openal-soft-devel
 
 	You don't need FFmpeg to be installed. You can turn it off by adding -DFFMPEG=OFF and -DBINKDEC=ON to the CMake options. It is enabled by default because the bundled libbinkdec is slow during development if compiled for Debug mode.
 
@@ -495,9 +495,9 @@ Recommended in this case is `cmake-vs2022-win64-no-ffmpeg.bat`
 
 2.	You need the following dependencies in order to compile RBDoom3BFG with all features:
 
-		> brew install cmake sdl2 openal-soft ffmpeg (for single arch libraries only)
+		> brew install cmake ispc sdl2 openal-soft ffmpeg (for single arch libraries only)
 		or
-		> sudo port install cmake libsdl2 +universal openal-soft +universal (for universal arch libraries)
+		> sudo port install cmake ispc libsdl2 +universal openal-soft +universal (for universal arch libraries)
 		
 	You don't need FFmpeg to be installed. You can turn it off by adding -DFFMPEG=OFF and -DBINKDEC=ON to the CMake options. For debug builds FFmpeg is enabled by default because the bundled libbinkdec is slow during development if compiled for Debug mode.  For release, retail and universal builds FFmpeg is disabled and libbinkdec is enabled by default.
 	

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -84,6 +84,13 @@ else()
 	option(USE_INTRINSICS_SSE "Compile using x86 MMX/SSE intrinsics (e.g SSE SIMD instructions)" OFF)
 endif()
 
+# SRS - Turn on NEON intrinsics for arm but not when cross-compiling from Apple arm64 to x86_64
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64)|(ARM64)|(aarch64)|(AArch64)" AND NOT CMAKE_OSX_ARCHITECTURES MATCHES "x86_64")
+	option(USE_INTRINSICS_NEON "Compile using arm NEON intrinsics (e.g NEON SIMD instructions)" ON)
+else()
+	option(USE_INTRINSICS_NEON "Compile using arm NEON intrinsics (e.g NEON SIMD instructions)" OFF)
+endif()
+
 if(FFMPEG AND BINKDEC)
 	message(FATAL_ERROR "Only one of FFMPEG and BINKDEC (or neither) can be enabled at a time")
 endif()
@@ -271,6 +278,10 @@ if (USE_INTRINSICS_SSE)
 	add_definitions(-DUSE_INTRINSICS_SSE)
 endif()
 
+if (USE_INTRINSICS_NEON)
+	add_definitions(-DUSE_INTRINSICS_NEON)
+endif()
+
 if(STANDALONE)
 	add_definitions(-DSTANDALONE)
 
@@ -436,11 +447,13 @@ if(USE_INTRINSICS_SSE)
 	add_subdirectory(libs/moc)
 	set(MASKED_OCCLUSION_LIBRARY MaskedOcclusionCulling)
 
-	add_subdirectory(libs/ispc_texcomp)
-	set(ISPC_TEXCOMP_LIBRARY ispc_texcomp)
-	
 	#set(ISPC_TEXCOMP_LIBRARY Compressonator_MD)
 	#link_directories(${CMAKE_CURRENT_SOURCE_DIR}/libs/compressonator/lib)
+endif()
+
+if(USE_INTRINSICS_SSE OR USE_INTRINSICS_NEON)
+	add_subdirectory(libs/ispc_texcomp)
+	set(ISPC_TEXCOMP_LIBRARY ispc_texcomp)
 endif()
 
 file(GLOB NATVIS_SOURCES .natvis)

--- a/neo/libs/ispc_texcomp/CMakeLists.txt
+++ b/neo/libs/ispc_texcomp/CMakeLists.txt
@@ -35,7 +35,7 @@ if (USE_INTRINSICS_SSE)
         COMMAND ${ISPC_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${ISPC_SOURCE}
                 -o ${ISPC_OBJ}
                 -h ${ISPC_HEADER}
-                --target=avx2-i32x8 --arch=x86-64
+                --target=avx2-i32x8 --arch=x86-64 --pic
         DEPENDS ${ISPC_SOURCE}
         COMMENT "Compiling ISPC file ${ISPC_SOURCE}"
     )
@@ -46,7 +46,7 @@ elseif (USE_INTRINSICS_NEON)
         COMMAND ${ISPC_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${ISPC_SOURCE}
                 -o ${ISPC_OBJ}
                 -h ${ISPC_HEADER}
-                --target=neon-i32x8 --arch=aarch64
+                --target=neon-i32x8 --arch=aarch64 --pic
         DEPENDS ${ISPC_SOURCE}
         COMMENT "Compiling ISPC file ${ISPC_SOURCE}"
     )

--- a/neo/libs/ispc_texcomp/CMakeLists.txt
+++ b/neo/libs/ispc_texcomp/CMakeLists.txt
@@ -19,14 +19,17 @@ set(SOURCES
 
 # ISPC file
 set(ISPC_SOURCE kernel.ispc)
-set(ISPC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/kernel_ispc.h)
-
-# ISPC compilation command
-# Target for x86_64 (can be adjusted for other architectures)
+set(ISPC_HEADER ${CMAKE_CURRENT_BINARY_DIR}/kernel_ispc.h)
 
 if (MSVC)
-    set(ISPC_OBJ ${CMAKE_CURRENT_SOURCE_DIR}/kernel.obj)
+    set(ISPC_OBJ ${CMAKE_CURRENT_BINARY_DIR}/kernel.obj)
+else()
+    set(ISPC_OBJ ${CMAKE_CURRENT_BINARY_DIR}/kernel.o)
+endif()
 
+# ISPC compilation command
+# Target for x86_64
+if (USE_INTRINSICS_SSE)
     add_custom_command(
         OUTPUT ${ISPC_OBJ} ${ISPC_HEADER}
         COMMAND ${ISPC_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${ISPC_SOURCE}
@@ -36,9 +39,19 @@ if (MSVC)
         DEPENDS ${ISPC_SOURCE}
         COMMENT "Compiling ISPC file ${ISPC_SOURCE}"
     )
+# Target for arm64
+elseif (USE_INTRINSICS_NEON)
+    add_custom_command(
+        OUTPUT ${ISPC_OBJ} ${ISPC_HEADER}
+        COMMAND ${ISPC_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${ISPC_SOURCE}
+                -o ${ISPC_OBJ}
+                -h ${ISPC_HEADER}
+                --target=neon-i32x8 --arch=aarch64
+        DEPENDS ${ISPC_SOURCE}
+        COMMENT "Compiling ISPC file ${ISPC_SOURCE}"
+    )
 else()
-    # TODO: Add support for other platforms (e.g., ARM, AArch64)
-    message(FATAL_ERROR "ISPC compilation for non-MSVC platforms is not yet implemented.")
+    message(FATAL_ERROR "ISPC compilation not implemented for non-x86_64 and non-arm64 platforms.")
 endif()
 
 # Create a static library

--- a/neo/libs/ispc_texcomp/kernel.ispc
+++ b/neo/libs/ispc_texcomp/kernel.ispc
@@ -338,7 +338,7 @@ inline void pick_endpoints(float c0[3], float c1[3], float block[48], float axis
 		max_dot = max(max_dot, dot);
 	}
 
-	if (max_dot-min_dot < 1f)
+	if (max_dot-min_dot < 1.0f)
 	{
 		min_dot -= 0.5f;
 		max_dot += 0.5f;
@@ -435,12 +435,12 @@ inline void compute_covar_dc_ugly(float covar[6], float dc[3], float block[48])
 		dc[p] = acc/16;
 	}
 	
-	float covar0 = 0f;
-	float covar1 = 0f;
-	float covar2 = 0f;
-	float covar3 = 0f;
-	float covar4 = 0f;
-	float covar5 = 0f;
+	float covar0 = 0.0f;
+	float covar1 = 0.0f;
+	float covar2 = 0.0f;
+	float covar3 = 0.0f;
+	float covar4 = 0.0f;
+	float covar5 = 0.0f;
 
 	for (uniform int k=0; k<16; k++)
 	{
@@ -514,7 +514,7 @@ inline void bc1_refine(int pe[2], float block[48], unsigned int32 bits, float dc
 	    float Cxx = 16*sq(3)-2*3*sum_q+sum_qq;
 	    float Cyy = sum_qq;
 		float Cxy = 3*sum_q-sum_qq;
-		float scale = 3f * RCP(Cxx*Cyy - Cxy*Cxy);
+		float scale = 3.0f * RCP(Cxx*Cyy - Cxy*Cxy);
 
         for (uniform int p=0; p<3; p++)
         {
@@ -596,7 +596,7 @@ inline void CompressBlockBC3_alpha(float block[16], uint32 data[2])
     if (ep[0] == ep[1]) ep[1] = ep[0]+0.1f;
 	    
     uint32 qblock[2] = { 0, 0 };
-    float scale = 7f/(ep[1]-ep[0]);
+    float scale = 7.0f/(ep[1]-ep[0]);
 
     for (uniform int k=0; k<16; k++)
     {
@@ -974,7 +974,7 @@ void block_segment_core(float ep[], float block[64], int mask, uniform int chann
 	}
 
 	// create some distance if the endpoints collapse
-	if (ext[1]-ext[0] < 1f)
+	if (ext[1]-ext[0] < 1.0f)
 	{
 		ext[0] -= 0.5f;
 		ext[1] += 0.5f;
@@ -1020,7 +1020,7 @@ float get_pca_bound(float covar[10], uniform int channels)
     if (channels == 3) ssymv3(vec, covar, axis);
     if (channels == 4) ssymv4(vec, covar, axis);
 
-	float sq_sum = 0f;
+	float sq_sum = 0.0f;
 	for (uniform int p=0; p<channels; p++) sq_sum += sq(vec[p]);
 	float lambda = sqrt(sq_sum);
 
@@ -1057,7 +1057,7 @@ float block_pca_bound_split(float block[64], int mask, float full_stats[15], uni
 	float covar2[10];
 	covar_from_stats(covar2, stats, channels);
 
-	float bound = 0f;
+	float bound = 0.0f;
 	bound += get_pca_bound(covar1, channels);
 	bound += get_pca_bound(covar2, channels);
 
@@ -1090,7 +1090,7 @@ void ep_quant0367(int qep[], float ep[], uniform int mode, uniform int channels)
 		for (uniform int b=0; b<2; b++)
 		for (uniform int p=0; p<4; p++)
 		{
-			int v = (int)((ep[i*4+p]/255f*levels2-b)/2+0.5)*2+b;
+			int v = (int)((ep[i*4+p]/255.0f*levels2-b)/2+0.5)*2+b;
 			qep_b[b*4+p] = clamp(v, b, levels2-1+b);
 		}
 
@@ -1102,8 +1102,8 @@ void ep_quant0367(int qep[], float ep[], uniform int mode, uniform int channels)
 		for (uniform int j=0; j<8; j++)
 			ep_b[j] = unpack_to_byte(qep_b[j], 5);
     
-        float err0 = 0f;
-        float err1 = 0f;
+        float err0 = 0.0f;
+        float err1 = 0.0f;
         for (uniform int p=0; p<channels; p++)
         {
             err0 += sq(ep[i*4+p]-ep_b[0+p]);
@@ -1122,7 +1122,7 @@ void ep_quant1(int qep[], float ep[], uniform int mode)
     for (uniform int b=0; b<2; b++)
 	for (uniform int i=0; i<8; i++)
     {
-        int v = ((int)((ep[i]/255f*127f-b)/2+0.5))*2+b;
+        int v = ((int)((ep[i]/255.0f*127.0f-b)/2+0.5))*2+b;
 		qep_b[b*8+i] = clamp(v, b, 126+b);
     }
     
@@ -1131,8 +1131,8 @@ void ep_quant1(int qep[], float ep[], uniform int mode)
 	for (uniform int k=0; k<16; k++)
         ep_b[k] = unpack_to_byte(qep_b[k], 7);
 
-	float err0 = 0f;
-    float err1 = 0f;
+	float err0 = 0.0f;
+    float err1 = 0.0f;
     for (uniform int j = 0; j < 2; j++)
     for (uniform int p = 0; p < 3; p++)
     {
@@ -1153,7 +1153,7 @@ void ep_quant245(int qep[], float ep[], uniform int mode)
         
 	for (uniform int i=0; i<8; i++)
 	{
-		int v = ((int)(ep[i]/255f*(levels-1)+0.5));
+		int v = ((int)(ep[i]/255.0f*(levels-1)+0.5));
 		qep[i] = clamp(v, 0, levels-1);
 	}
 }
@@ -1361,7 +1361,7 @@ void opt_endpoints(float ep[], float block[64], uniform int bits, uint32 qblock[
 float compute_opaque_err(float block[64], uniform int channels)
 {
     if (channels == 3) return 0;
-    float err = 0f;
+    float err = 0.0f;
     for (uniform int k=0; k<16; k++)
     {
         err += sq(block[48+k]-255);
@@ -1534,7 +1534,7 @@ void channel_quant_dequant(int qep[2], float ep[2], uniform int epbits)
 
 	for (uniform int i=0; i<2; i++)
 	{
-		int v = ((int)(ep[i]/255f*(elevels-1)+0.5));
+		int v = ((int)(ep[i]/255.0f*(elevels-1)+0.5));
 		qep[i] = clamp(v, 0, elevels-1);
 		ep[i] = unpack_to_byte(qep[i], epbits);
 	}
@@ -2236,7 +2236,7 @@ void ep_quant_bc6h(int qep[], float ep[], int bits, uniform int pairs)
 
     for (uniform int i = 0; i < 8 * pairs; i++)
     {
-        int v = ((int)(ep[i] / (256 * 256f - 1) * (levels - 1) + 0.5));
+        int v = ((int)(ep[i] / (256 * 256.0f - 1) * (levels - 1) + 0.5));
         qep[i] = clamp(v, 0, levels - 1);
     }
 }
@@ -2622,7 +2622,7 @@ void bc6h_pack(uint32 packed[], int qep[], int mode)
         for (uniform int i = 1; i < 4; i++)
         for (uniform int p = 0; p < 3; p++)
         {
-            int bits = 4;
+            uniform int bits = 4;
             if (p == mode - 2) bits = 5;
             assert(                qep[i * 4 + p] - qep[p] <= (1<<bits)/2 - 1);
             assert(-(1<<bits)/2 <= qep[i * 4 + p] - qep[p]);
@@ -2805,7 +2805,7 @@ void bc6h_pack(uint32 packed[], int qep[], int mode)
         for (uniform int i = 1; i < 4; i++)
         for (uniform int p = 0; p < 3; p++)
         {
-            int bits = 5;
+            uniform int bits = 5;
             if (p == mode - 6) bits = 6;
             assert(                qep[i * 4 + p] - qep[p] <= (1<<bits)/2 - 1);
             assert(-(1<<bits)/2 <= qep[i * 4 + p] - qep[p]);

--- a/neo/renderer/DXT/DXTCodec.h
+++ b/neo/renderer/DXT/DXTCodec.h
@@ -105,7 +105,9 @@ public:
 	// fast DXT5 compression for real-time use at the cost of a little quality
 	void	CompressImageR11G11B10_BC6Fast( const byte* inBuf, byte* outBuf, int width, int height );
 	void	CompressImageR11G11B10_BC6Fast_Generic( const byte* inBuf, byte* outBuf, int width, int height );
-	void	CompressImageR11G11B10_BC6Fast_SSE2( const byte* inBuf, byte* outBuf, int width, int height );
+#if ( defined(USE_INTRINSICS_SSE) || defined(USE_INTRINSICS_NEON) ) && !defined( DMAP )
+	void	CompressImageR11G11B10_BC6Fast_SIMD( const byte* inBuf, byte* outBuf, int width, int height );
+#endif
 	// RB end
 
 	// high quality CTX1 compression, uses exhaustive search to find a line through 2D space and is very slow
@@ -374,8 +376,8 @@ idDxtEncoder::CompressImageDXT5Fast
 */
 ID_INLINE void idDxtEncoder::CompressImageR11G11B10_BC6Fast( const byte* inBuf, byte* outBuf, int width, int height )
 {
-#if defined(USE_INTRINSICS_SSE) && !defined( DMAP )
-	CompressImageR11G11B10_BC6Fast_SSE2( inBuf, outBuf, width, height );
+#if ( defined(USE_INTRINSICS_SSE) || defined(USE_INTRINSICS_NEON) ) && !defined( DMAP )
+	CompressImageR11G11B10_BC6Fast_SIMD( inBuf, outBuf, width, height );
 #else
 	CompressImageR11G11B10_BC6Fast_Generic( inBuf, outBuf, width, height );
 #endif

--- a/neo/renderer/DXT/DXTEncoder.cpp
+++ b/neo/renderer/DXT/DXTEncoder.cpp
@@ -5927,8 +5927,15 @@ void idDxtEncoder::CompressImageR11G11B10_BC6Fast_Generic( const byte* inBuf, by
 
 #if 1
 
+#if defined(USE_INTRINSICS_SSE) || defined(USE_INTRINSICS_NEON)
 #include "../../libs/ispc_texcomp/ispc_texcomp.h"
 
+/*
+========================
+ConvertR11G11B10ImageToFP16
+Converts the entire image from R11G11B10 to FP16
+========================
+*/
 static void ConvertR11G11B10ImageToFP16( const byte* inBuf, int width, int height, halfFloat_t* outBuf )
 {
 	for( int y = 0; y < height; ++y )
@@ -5959,12 +5966,11 @@ static void ConvertR11G11B10ImageToFP16( const byte* inBuf, int width, int heigh
 
 /*
 ========================
-idDxtEncoder::ConvertR11G11B10_BC6
-
+idDxtEncoder::CompressImageR11G11B10_BC6Fast_SIMD
 ISPC-Variant with ISPCTextureCompressor for BC6H
 ========================
 */
-void idDxtEncoder::CompressImageR11G11B10_BC6Fast_SSE2( const byte* inBuf, byte* outBuf, int width, int height )
+void idDxtEncoder::CompressImageR11G11B10_BC6Fast_SIMD( const byte* inBuf, byte* outBuf, int width, int height )
 {
 	if( width < 4 || height < 4 || ( width & 3 ) != 0 || ( height & 3 ) != 0 )
 	{
@@ -6002,16 +6008,11 @@ void idDxtEncoder::CompressImageR11G11B10_BC6Fast_SSE2( const byte* inBuf, byte*
 
 	delete[] fp16Buf;
 }
+#endif // #if defined(USE_INTRINSICS_SSE) || defined(USE_INTRINSICS_NEON)
 
 #else
 
-/*
-========================
-idDxtEncoder::CompressImageR11G11B10_BC6Fast_SSE2
-Compressonator-based variant for BC6H compression
-========================
-*/
-
+#if defined(USE_INTRINSICS_SSE)
 #include "../../libs/compressonator/include/compressonator.h"
 
 /*
@@ -6051,11 +6052,11 @@ static void ConvertR11G11B10ToFP32( const byte* inBuf, int width, int height, fl
 
 /*
 ========================
-idDxtEncoder::CompressImageR11G11B10_BC6Fast_SSE2
+idDxtEncoder::CompressImageR11G11B10_BC6Fast_SIMD
 Compressonator-based variant for BC6H compression with CMP_FORMAT_RGBA_32F, single call, multi-threaded
 ========================
 */
-void idDxtEncoder::CompressImageR11G11B10_BC6Fast_SSE2( const byte* inBuf, byte* outBuf, int width, int height )
+void idDxtEncoder::CompressImageR11G11B10_BC6Fast_SIMD( const byte* inBuf, byte* outBuf, int width, int height )
 {
 	// Validation
 	if( width < 4 || height < 4 || ( width & 3 ) != 0 || ( height & 3 ) != 0 )
@@ -6138,7 +6139,7 @@ void idDxtEncoder::CompressImageR11G11B10_BC6Fast_SSE2( const byte* inBuf, byte*
 
 	delete[] fp32Buf;
 }
-
+#endif // #if defined(USE_INTRINSICS_SSE)
 
 #endif
 


### PR DESCRIPTION
This PR adds Linux and macOS support for ISPC SIMD-accelerated BC6 encoding.

1. Adds support for Linux and macOS.
2. Adds support for both `x86_64` **SSE** and `arm64` **NEON** SIMD instructions for BC6 encoding.
3. Renames `CompressImageR11G11B10_BC6Fast_SSE2()` to `CompressImageR11G11B10_BC6Fast_SIMD()` to account for multi-architecture support of **SSE** and **NEON**.
4. Moves ISPC-generated **kernel.o** and **kernel_ispc.h** files from source directory into build directory (i.e. outside of git)
5. Fixes ISPC radix and integer type mismatch warnings in the **kernel.ispc** file.
6. Adds `--pic` flag for position independent code which is required on Linux (flag is ignored on Windows).
7. Updates build instructions for Linux and macOS.  Windows docs tbd based on how you want to handle this.
8. Retains `CompressImageR11G11B10_BC6Fast_Generic()` option for cross-compilation situations (e.g. compiling macOS Universal binaries where host-native SIMD instructions must be disabled).

Note there is something wrong with BC6 compressed files generated by `CompressImageR11G11B10_BC6Fast_Generic()`.  SSR blood effects do not work with images compressed with this non-SIMD routine.

Tested on Windows 11 (x86_64), Manjaro Linux (x86_64 gcc + clang), and macOS Ventura (x86_64 and arm64).