### PR TITLE
A few cmake tweaks for improved NEON support

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -280,6 +280,7 @@ endif()
 
 if (USE_INTRINSICS_NEON)
 	add_definitions(-DUSE_INTRINSICS_NEON)
+	add_definitions(-DSTBI_NEON)
 endif()
 
 if(STANDALONE)

--- a/neo/libs/ispc_texcomp/CMakeLists.txt
+++ b/neo/libs/ispc_texcomp/CMakeLists.txt
@@ -47,7 +47,7 @@ elseif (USE_INTRINSICS_NEON)
         COMMAND ${ISPC_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${ISPC_SOURCE}
                 -o ${ISPC_OBJ}
                 -h ${ISPC_HEADER}
-                --target=neon-i32x8 --arch=aarch64 --pic
+                --target=neon-i32x8 --arch=aarch64 ${ISPC_PIC}
         DEPENDS ${ISPC_SOURCE}
         COMMENT "Compiling ISPC file ${ISPC_SOURCE}"
     )

--- a/neo/renderer/DXT/DXTEncoder.cpp
+++ b/neo/renderer/DXT/DXTEncoder.cpp
@@ -5783,11 +5783,10 @@ void idDxtEncoder::CompressImageR11G11B10_BC6Fast_Generic( const byte* inBuf, by
 
 
 
-#if !defined( DMAP )
+#if ( defined(USE_INTRINSICS_SSE) || defined(USE_INTRINSICS_NEON) ) && !defined( DMAP )
 
 #if 1
 
-#if defined(USE_INTRINSICS_SSE) || defined(USE_INTRINSICS_NEON)
 #include "../../libs/ispc_texcomp/ispc_texcomp.h"
 
 /*
@@ -5868,11 +5867,9 @@ void idDxtEncoder::CompressImageR11G11B10_BC6Fast_SIMD( const byte* inBuf, byte*
 
 	delete[] fp16Buf;
 }
-#endif // #if defined(USE_INTRINSICS_SSE) || defined(USE_INTRINSICS_NEON)
 
 #else
 
-#if defined(USE_INTRINSICS_SSE)
 #include "../../libs/compressonator/include/compressonator.h"
 
 /*
@@ -6000,11 +5997,10 @@ void idDxtEncoder::CompressImageR11G11B10_BC6Fast_SIMD( const byte* inBuf, byte*
 
 	delete[] fp32Buf;
 }
-#endif // #if defined(USE_INTRINSICS_SSE)
 
 #endif
 
-#endif // #if !defined( DMAP )
+#endif // #if ( defined(USE_INTRINSICS_SSE) || defined(USE_INTRINSICS_NEON) ) && !defined( DMAP )
 
 void idDxtEncoder::CompressImageR11G11B10_BC6HQ( const byte* inBuf, byte* outBuf, int width, int height )
 {


### PR DESCRIPTION
1. Now uses `ISPC_PIC` cmake variable for ispc arm64 builds (i.e. not just x86_64).  Compiler choice and architecture are somewhat orthogonal, so I thought I would adopt this variable for consistency.
2. Since the infrastructure is now in place, adds NEON SIMD support for stb library via the `STBI_NEON` define.  This seems to work fine on my MacBook Air M1 (arm64).
3. Readability: Removes extra #ifdef blocks surrounding ispc_texcomp vs. compressonator in DXTEncoder.cpp