### PR TITLE
A few small NEON and macOS updates

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -280,6 +280,7 @@ endif()
 
 if (USE_INTRINSICS_NEON)
 	add_definitions(-DUSE_INTRINSICS_NEON)
+	add_definitions(-DSTBI_NEON)
 endif()
 
 if(STANDALONE)

--- a/neo/libs/ispc_texcomp/CMakeLists.txt
+++ b/neo/libs/ispc_texcomp/CMakeLists.txt
@@ -62,7 +62,7 @@ elseif (USE_INTRINSICS_NEON)
         COMMAND ${ISPC_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${ISPC_SOURCE}
                 -o ${ISPC_OBJ}
                 -h ${ISPC_HEADER}
-                --target=neon-i32x8 --arch=aarch64 --pic
+                --target=neon-i32x8 --arch=aarch64 ${ISPC_PIC}
         DEPENDS ${ISPC_SOURCE}
         COMMENT "Compiling ISPC file ${ISPC_SOURCE}"
     )


### PR DESCRIPTION
This replaces #989 since BC6 working branch has now been merged to master.

1. Now uses `ISPC_PIC` cmake variable for ispc arm64 builds (i.e. not just x86_64). Compiler choice and architecture are somewhat orthogonal, so I thought I would adopt this variable for consistency.
2. Since the infrastructure is now in place, adds NEON SIMD support for stb library via the `STBI_NEON` define. This seems to work fine on my MacBook Air M1 (arm64).
3. macOS only: Updates `r_mvk*` cvar types to match modern MoltenVK config variable types.