### PR TITLE
Add Sys_Microseconds and Sys_CPUCount to rbdmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ neo/neo.kdev4
 neo/.idea/
 neo/cmake-build-*/
 neo/bin/
-tools/
+/tools/

--- a/neo/tools/compilers/main.cpp
+++ b/neo/tools/compilers/main.cpp
@@ -668,6 +668,44 @@ int Sys_Milliseconds()
 	return timeGetTime() - sys_timeBase;
 }
 
+
+/*
+================
+Sys_Microseconds
+================
+*/
+uint64 Sys_Microseconds()
+{
+	static uint64 ticksPerMicrosecondTimes1024 = 0;
+
+	if( ticksPerMicrosecondTimes1024 == 0 )
+	{
+		ticksPerMicrosecondTimes1024 = ( ( uint64 )Sys_ClockTicksPerSecond() << 10 ) / 1000000;
+		assert( ticksPerMicrosecondTimes1024 > 0 );
+	}
+
+	return ( ( uint64 )( ( int64 )Sys_GetClockTicks() << 10 ) ) / ticksPerMicrosecondTimes1024;
+}
+
+/*
+========================
+Sys_CPUCount
+
+TODO: This is a dummy function;
+If required I recommend using SDL_CpuCount();
+
+numLogicalCPUCores      - the number of logical CPU per core
+numPhysicalCPUCores     - the total number of cores per package
+numCPUPackages          - the total number of packages (physical processors)
+========================
+*/
+void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCPUPackages )
+{
+        numPhysicalCPUCores = 1;
+        numLogicalCPUCores = 1;
+        numCPUPackages = 1;
+}
+
 class idSysCmdline : public idSys
 {
 public:

--- a/neo/tools/compilers/main_posix.cpp
+++ b/neo/tools/compilers/main_posix.cpp
@@ -622,6 +622,71 @@ int Sys_Milliseconds()
 	// DG end
 }
 
+/*
+================
+Sys_Microseconds
+================
+*/
+static uint64 sys_microTimeBase = 0;
+
+uint64 Sys_Microseconds()
+{
+#if 0
+	static uint64 ticksPerMicrosecondTimes1024 = 0;
+
+	if( ticksPerMicrosecondTimes1024 == 0 )
+	{
+		ticksPerMicrosecondTimes1024 = ( ( uint64 )Sys_ClockTicksPerSecond() << 10 ) / 1000000;
+		assert( ticksPerMicrosecondTimes1024 > 0 );
+	}
+
+	return ( ( uint64 )( ( int64 )Sys_GetClockTicks() << 10 ) ) / ticksPerMicrosecondTimes1024;
+#elif 0
+	uint64 curtime;
+	struct timespec ts;
+
+	clock_gettime( CLOCK_MONOTONIC, &ts );
+
+	curtime = ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
+
+	return curtime;
+#else
+	uint64 curtime;
+	struct timespec ts;
+
+	clock_gettime( D3_CLOCK_TO_USE, &ts );
+
+	if( !sys_microTimeBase )
+	{
+		sys_microTimeBase = ts.tv_sec;
+		return ts.tv_nsec / 1000;
+	}
+
+	curtime = ( ts.tv_sec - sys_microTimeBase ) * 1000000 + ts.tv_nsec / 1000;
+
+	return curtime;
+#endif
+}
+
+/*
+========================
+Sys_CPUCount
+
+TODO: This is a dummy function;
+If required I recommend using SDL_CpuCount();
+
+numLogicalCPUCores      - the number of logical CPU per core
+numPhysicalCPUCores     - the total number of cores per package
+numCPUPackages          - the total number of packages (physical processors)
+========================
+*/
+void Sys_CPUCount( int& numLogicalCPUCores, int& numPhysicalCPUCores, int& numCPUPackages )
+{
+        numPhysicalCPUCores = 1;
+        numLogicalCPUCores = 1;
+        numCPUPackages = 1;
+}
+
 class idSysCmdline : public idSys
 {
 public:


### PR DESCRIPTION
Since idlib requires the loading executable to have those symbols GCC/Clang with `-Wl,--no-allow-shlib-undefined` throws a linker error.
`shlib-undefined` refers to symbols referenced in a dynamically linked library that can not building executable does not defined or import.

Sys_CPUCount is a implemented as a dummy function.

I also changed the `.gitignore` to only ignore the tools folder in the root director and not the neo/tools folder.

As a heads-up: I also added these to the Windows version of rbdmap but I was not actually able to test this atm.