### PR TITLE
Add LFH based system paths to search path stack

### DIFF
--- a/neo/framework/FileSystem.cpp
+++ b/neo/framework/FileSystem.cpp
@@ -3262,6 +3262,11 @@ idFileSystemLocal::SetupGameDirectories
 */
 void idFileSystemLocal::SetupGameDirectories( const char* gameName )
 {
+#if __linux__
+	// setup LFH based system file locations at the bottom of the path stack
+	AddGameDirectory( "/usr/share/rbdoom3bfg", gameName );
+	AddGameDirectory( "/usr/local/share/rbdoom3bfg", gameName );
+#endif
 	// setup basepath
 	if( fs_basepath.GetString()[0] )
 	{


### PR DESCRIPTION
This might be a controversial change since it might be at the wrong location and maybe unwanted. This pushes the standard system paths for the Linux to the bottom of the game file search paths.

This allows the files added with the build process to be added to a safe location with a package manager (`/usr/share/rbdoom3bfg`) and also makes easier to replace the files when building manually (`/usr/local/share/rbdoom3bfg`)

Since these paths aren't POSIX iirc but are defined by the LFH (Linux Filesystem Hierarchy) they will only be added if `__linux__` is defined which GCC and Clang set.

This might require changes if the frankly just straightforward implementation violates some code structure.
It is in `neo/FrameWork/Filesystem.cpp` instead of for example a new function in `neo/sys/posix/posix_main.cpp` that just calls the same functions but at another place. Which seemed needlessly convoluted to me but I can see that hard-coded paths might not be wanted at this location.

Further I also understand if this is just in general not wanted but I use this patch in my system and I thought I might as well submit it even if it does get rejected.

To my use case this makes issues like #969 less likely to occur when using a package manager as no files have to be copied to the users private files after updating and the package manager can control all files.