### PR TITLE
Fix zlib build failure on macOS starting with Xcode 16.3 / Apple clang 17

### DIFF
--- a/neo/libs/zlib/zutil.h
+++ b/neo/libs/zlib/zutil.h
@@ -118,7 +118,8 @@ extern const char* const z_errmsg[10];  /* indexed by 2-zlib_error */
 	#endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+// SRS - Apple clang 17 defines target conditionals by default which incorrectly enables ancient code here
+#if defined(MACOS) //|| defined(TARGET_OS_MAC)
 	#define OS_CODE  0x07
 	#ifndef Z_SOLO
 		#if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os


### PR DESCRIPTION
Fixes #1005.

It turns out that Apple recently (March 2025) released clang 17 (Xcode >= 16.3) which enables the Target Conditionals definitions by default.  Previously these had to be included via TargetConditionals.h.

The game's bundled zlib version strangely enables a bunch of ancient code when it sees `TARGET_OS_MAC`, but interestingly doesn't include TargetConditionals.h so it was never enabled before.  This ancient code no longer compiles with modern macOS versions.

This PR provides a simple fix for the existing bundled zlib version by disabling `TARGET_OS_MAC`.  Another solution is to update zlib to 1.3.1 which cleans out the ancient code, but perhaps this can happen later or be replaced with miniz.

Thanks to @bigianb for finding and reporting the build error.  I have been using an earlier Xcode version and missed it.

@RobertBeckebans this should go into master and also rpsubsets-and-pc.