### PR TITLE
Fix SWF Objs variable by name not checking bounds

### DIFF
--- a/neo/swf/SWF_ScriptObject.cpp
+++ b/neo/swf/SWF_ScriptObject.cpp
@@ -525,7 +525,7 @@ idSWFScriptObject::swfNamedVar_t* idSWFScriptObject::GetVariable( const char* na
 	int hash = idStr::Hash( name ) & ( VARIABLE_HASH_BUCKETS - 1 );
 	for( int i = variablesHash[hash]; i >= 0; i = variables[i].hashNext )
 	{
-		if( variables[i].name == name )
+		if((i < variables.Num()) && (variables[i].name == name))
 		{
 			return &variables[i];
 		}


### PR DESCRIPTION
Unlike the index name version which does a check if i < variables.Num(); the name version did not check.
Not being defined is probably a bug in itself but not checking at all leads to the engine crashing.
(This happened to me in the System Options Menu while using Mouse and Keyboard to change Environment Light Strength)