### PR TITLE
Backported CB versions fix in MipMapGenPass from rpsubsets-and-pc branch

### DIFF
--- a/neo/renderer/Passes/MipMapGenPass.cpp
+++ b/neo/renderer/Passes/MipMapGenPass.cpp
@@ -127,7 +127,7 @@ MipMapGenPass::MipMapGenPass(
 	constantBufferDesc.isConstantBuffer = true;
 	constantBufferDesc.isVolatile = true;
 	constantBufferDesc.debugName = "MipMapGenPass/Constants";
-	constantBufferDesc.maxVersions = c_MaxRenderPassConstantBufferVersions;
+	constantBufferDesc.maxVersions = numConstantBufferVersions;
 	m_ConstantBuffer = m_Device->createBuffer( constantBufferDesc );
 
 	// BindingLayout

--- a/neo/renderer/Passes/MipMapGenPass.h
+++ b/neo/renderer/Passes/MipMapGenPass.h
@@ -69,6 +69,8 @@ private:
 	std::shared_ptr<NullTextures> m_NullTextures;
 
 	BindingCache m_BindingCache;
+
+	const uint32_t numConstantBufferVersions = 32;
 };
 
 #endif


### PR DESCRIPTION
Fixes #1000 for the master branch.  Bumps constant buffer versions to 32 for MipMapGenPass.

With all our completion work on the rpsubsets-and-pc branch, I somehow missed this for master.

The only issue here is this will create a future merge conflict with the rpsubsets-and-pc branch.  Not sure how to address that other than resolving it during the next merge sync.