### PR TITLE
Fix HiZ for macOS+AMD and reenable compute shader push constants on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ Recommended in this case is `cmake-vs2022-win64-no-ffmpeg.bat`
 ---
 # Compiling on macOS <a name="compile_macos"></a>
 
-1.	Download and install Homebrew (https://brew.sh) for single architecture builds or MacPorts (https://www.macports.org/install.php) for universal architecture builds on macOS Big Sur or later.
+1.	Download and install Homebrew (https://brew.sh) for single architecture builds or MacPorts (https://www.macports.org/install.php) for universal architecture builds on macOS Catalina (10.15) or later.
 
 2.	You need the following dependencies in order to compile RBDoom3BFG with all features:
 
@@ -498,7 +498,7 @@ Recommended in this case is `cmake-vs2022-win64-no-ffmpeg.bat`
 		
 	You don't need FFmpeg to be installed. You can turn it off by adding -DFFMPEG=OFF and -DBINKDEC=ON to the CMake options. For debug builds FFmpeg is enabled by default because the bundled libbinkdec is slow during development if compiled for Debug mode.  For release, retail and universal builds FFmpeg is disabled and libbinkdec is enabled by default.
 	
-	The Vulkan SDK 1.3.275.0 or later must be installed and can be obtained from https://vulkan.lunarg.com/sdk/home#mac
+	The Vulkan SDK 1.3.275.0 (minimum) or 1.3.296.0 (min recommended) or later must be installed and can be obtained from https://vulkan.lunarg.com/sdk/home#mac
 	
 3. Clone the source code into a new `DoomCode` directory and checkout the `rpsubsets-and-pc` branch for optimal performance on macOS with MoltenVK:
 

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -2011,7 +2011,7 @@ void idRenderBackend::GL_StartFrame()
 			globalImages->ambientOcclusionImage[0]->GetTextureHandle() );
 	}
 
-	if( globalImages->hierarchicalZbufferImage->GetTextureID() != textureId || !hiZGenPass )
+	if( ( globalImages->hierarchicalZbufferImage->GetTextureID() != textureId || !hiZGenPass ) && R_UseHiZ() )
 	{
 		if( hiZGenPass )
 		{

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -364,10 +364,17 @@ bool R_UseTemporalAA()
 bool R_UseHiZ()
 {
 	// TODO check for driver problems here
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
 	if( glConfig.vendor == VENDOR_INTEL && glConfig.gpuType == GPU_TYPE_OTHER )
 	{
-		// SRS - Disable HiZ to work-around Linux driver issues on Intel iGPUs
+		// SRS - Disable HiZ to work-around Linux/macOS driver issues on Intel iGPUs
+		return false;
+	}
+#endif
+#if defined(__APPLE__)
+	if( glConfig.vendor == VENDOR_AMD && glConfig.gpuType == GPU_TYPE_DISCRETE )
+	{
+		// SRS - Disable HiZ to work-around macOS/MoltenVK driver issues on AMD GPUs
 		return false;
 	}
 #endif

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -364,17 +364,10 @@ bool R_UseTemporalAA()
 bool R_UseHiZ()
 {
 	// TODO check for driver problems here
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__)
 	if( glConfig.vendor == VENDOR_INTEL && glConfig.gpuType == GPU_TYPE_OTHER )
 	{
-		// SRS - Disable HiZ to work-around Linux/macOS driver issues on Intel iGPUs
-		return false;
-	}
-#endif
-#if defined(__APPLE__)
-	if( glConfig.vendor == VENDOR_AMD && glConfig.gpuType == GPU_TYPE_DISCRETE )
-	{
-		// SRS - Disable HiZ to work-around macOS/MoltenVK driver issues on AMD GPUs
+		// SRS - Disable HiZ to work-around Linux driver issues on Intel iGPUs
 		return false;
 	}
 #endif

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -364,10 +364,10 @@ bool R_UseTemporalAA()
 bool R_UseHiZ()
 {
 	// TODO check for driver problems here
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
 	if( glConfig.vendor == VENDOR_INTEL && glConfig.gpuType == GPU_TYPE_OTHER )
 	{
-		// SRS - Disable HiZ to work-around Linux driver issues on Intel iGPUs
+		// SRS - Disable HiZ to work-around Linux/macOS driver issues on Intel iGPUs
 		return false;
 	}
 #endif

--- a/neo/shaders/builtin/mipmapgen.cs.hlsl
+++ b/neo/shaders/builtin/mipmapgen.cs.hlsl
@@ -89,11 +89,7 @@ cbuffer c_MipMapgen : register( b0 )
 };
 #endif
 
-#ifdef __spirv__	// use unbounded array size for proper SPIR-V descriptor binding
-RWTexture2D<VALUE_TYPE> u_output[] : register( u0 );
-#else				// use bounded array for DXIL -flegacy-resource-reservation flag
 RWTexture2D<VALUE_TYPE> u_output[NUM_LODS] : register( u0 );
-#endif
 Texture2D<VALUE_TYPE> t_input : register( t0 );
 // *INDENT-ON*
 

--- a/neo/shaders/builtin/post/exposure.cs.hlsl
+++ b/neo/shaders/builtin/post/exposure.cs.hlsl
@@ -23,30 +23,7 @@
 #pragma pack_matrix(row_major)
 
 #include "vulkan.hlsli"
-
-struct ToneMappingConstants
-{
-	uint2 viewOrigin;
-	uint2 viewSize;
-
-	float logLuminanceScale;
-	float logLuminanceBias;
-	float histogramLowPercentile;
-	float histogramHighPercentile;
-
-	float eyeAdaptationSpeedUp;
-	float eyeAdaptationSpeedDown;
-	float minAdaptedLuminance;
-	float maxAdaptedLuminance;
-
-	float frameTime;
-	float exposureScale;
-	float whitePointInvSquared;
-	uint sourceSlice;
-
-	float2 colorLUTTextureSize;
-	float2 colorLUTTextureSizeInv;
-};
+#include "tonemapping_cb.h"
 
 // *INDENT-OFF*
 Buffer<uint> t_Histogram : register(t0);

--- a/neo/shaders/builtin/post/histogram.cs.hlsl
+++ b/neo/shaders/builtin/post/histogram.cs.hlsl
@@ -23,30 +23,7 @@
 #pragma pack_matrix(row_major)
 
 #include "vulkan.hlsli"
-
-struct ToneMappingConstants
-{
-	uint2 viewOrigin;
-	uint2 viewSize;
-
-	float logLuminanceScale;
-	float logLuminanceBias;
-	float histogramLowPercentile;
-	float histogramHighPercentile;
-
-	float eyeAdaptationSpeedUp;
-	float eyeAdaptationSpeedDown;
-	float minAdaptedLuminance;
-	float maxAdaptedLuminance;
-
-	float frameTime;
-	float exposureScale;
-	float whitePointInvSquared;
-	uint sourceSlice;
-
-	float2 colorLUTTextureSize;
-	float2 colorLUTTextureSizeInv;
-};
+#include "tonemapping_cb.h"
 
 // *INDENT-OFF*
 #if SOURCE_ARRAY

--- a/neo/shaders/builtin/post/tonemapping.ps.hlsl
+++ b/neo/shaders/builtin/post/tonemapping.ps.hlsl
@@ -23,30 +23,7 @@
 #pragma pack_matrix(row_major)
 
 #include "vulkan.hlsli"
-
-struct ToneMappingConstants
-{
-	uint2 viewOrigin;
-	uint2 viewSize;
-
-	float logLuminanceScale;
-	float logLuminanceBias;
-	float histogramLowPercentile;
-	float histogramHighPercentile;
-
-	float eyeAdaptationSpeedUp;
-	float eyeAdaptationSpeedDown;
-	float minAdaptedLuminance;
-	float maxAdaptedLuminance;
-
-	float frameTime;
-	float exposureScale;
-	float whitePointInvSquared;
-	uint sourceSlice;
-
-	float2 colorLUTTextureSize;
-	float2 colorLUTTextureSizeInv;
-};
+#include "tonemapping_cb.h"
 
 // *INDENT-OFF*
 #if SOURCE_ARRAY

--- a/neo/sys/DeviceManager_VK.cpp
+++ b/neo/sys/DeviceManager_VK.cpp
@@ -1270,10 +1270,14 @@ bool DeviceManager_VK::CreateDeviceAndSwapChain()
 		// 0x609a13b: vertex shader writes to output location X.0 which is not consumed by fragment shader...
 		// 0x609a13b: Vertex attribute at location X not consumed by vertex shader.
 		// 0x609a13b: fragment shader writes to output location X with no matching attachment.
+
+		// SRS - Suppress false-positive descriptor count warning for MipMapGen pass which is by design:
+		// 0x3af3126a: vkCreateComputePipelines(): pCreateInfos[0].stage uses ... with a descriptorCount of X, but requires at least Y in the SPIR-V.
+
 #ifdef _WIN32
-		SetEnvironmentVariable( "VK_LAYER_MESSAGE_ID_FILTER", "0xc81ad50e;0x9805298c;0x609a13b" );
+		SetEnvironmentVariable( "VK_LAYER_MESSAGE_ID_FILTER", "0xc81ad50e;0x9805298c;0x609a13b;0x3af3126a" );
 #else
-		setenv( "VK_LAYER_MESSAGE_ID_FILTER", "0xc81ad50e:0x9805298c:0x609a13b", 1 );
+		setenv( "VK_LAYER_MESSAGE_ID_FILTER", "0xc81ad50e:0x9805298c:0x609a13b:0x3af3126a", 1 );
 #endif
 	}
 


### PR DESCRIPTION
I have been working to figure out the underlying reason for the macOS+AMD push constant workaround 2 which disables push constants for your updated compute shaders in this branch.  I finally tracked it down to the HiZ shader on macOS+AMD - it's broken on that combination and causes a bunch of trouble with incorrect rendering.  Once I disabled HiZ for macOS+AMD, the other compute shaders work properly with push constants enabled and high load rendering problems disappear.  This PR contains 3 commits:

1. _This branch only_: Fix for the above issue, disabling HiZ for macOS+Intel and macOS+AMD and restoring pcs for the other compute shaders on macOS+AMD.  For some reason HiZ seems to work properly on Apple Silicon when MoltenVK's Metal Argument Buffers option is disabled (how it is configured for RBDoom3BFG), so it remains enabled for that case.
2. _This branch only_: Includes **tonemapping_cb.h** in the 3 tonemapping shaders vs. repeating the constants struct in each shader.  The file already existed in the project, but was never included before.
3. _Generic_: Updates the minimum host OS and Vulkan SDK version requirements for macOS in the README.

I will make an additional PR #1028 that brings the last commit (macOS README change) to master.

@RobertBeckebans here is the latest Binding to Shader mapping spreadsheet updated to include your compute shader changes: [Binding to Shader Mapping v9.xlsx](https://github.com/user-attachments/files/20822975/Binding.to.Shader.Mapping.v9.xlsx)