### PR TITLE
Update README and CMakeLists for DXC_CUSTOM_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Recommended in this case is `cmake-vs2022-win64-no-ffmpeg.bat`
 	
 	E.g. Unpack linux_dxc_2024_05_24.x86_64.tar.gz to `~/.local` and make `~/.local/bin/dxc` as executable with chmod +x
 
-	As an alternative you can add `-DDXC_CUSTOM_PATH=<path-to-dxc-binary>` to the CMake options.
+	As an alternative you can add `-DDXC_CUSTOM_PATH=<path-to-dxc-binary>` to the CMake options.  Please make sure to specify only the **directory path** to dxc, and don't include the binary name itself.
 
 2. You need the following dependencies in order to compile RBDoom3BFG with all features:
 

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -372,7 +372,8 @@ if(USE_VULKAN)
 
 		# SRS - ShaderMake uses DXC_CUSTOM_PATH as fallback if dxc for SPIRV not found by other means
 		if(Vulkan_dxc_exe_FOUND AND NOT DEFINED DXC_CUSTOM_PATH)
-			set(DXC_CUSTOM_PATH ${Vulkan_dxc_EXECUTABLE})
+			get_filename_component(Vulkan_dxc_EXECUTABLE_PATH ${Vulkan_dxc_EXECUTABLE} DIRECTORY)
+			set(DXC_CUSTOM_PATH ${Vulkan_dxc_EXECUTABLE_PATH})
 		endif()
 
         if(APPLE)

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -371,7 +371,7 @@ if(USE_VULKAN)
 		include_directories(${Vulkan_INCLUDE_DIRS})
 
 		# SRS - ShaderMake uses DXC_CUSTOM_PATH as fallback if dxc for SPIRV not found by other means
-		if(Vulkan_dxc_exe_FOUND AND NOT DEFINED DXC_CUSTOM_PATH)
+		if(Vulkan_dxc_exe_FOUND AND NOT DXC_CUSTOM_PATH)
 			get_filename_component(DXC_CUSTOM_PATH ${Vulkan_dxc_EXECUTABLE} DIRECTORY)
 		endif()
 

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -372,8 +372,7 @@ if(USE_VULKAN)
 
 		# SRS - ShaderMake uses DXC_CUSTOM_PATH as fallback if dxc for SPIRV not found by other means
 		if(Vulkan_dxc_exe_FOUND AND NOT DEFINED DXC_CUSTOM_PATH)
-			get_filename_component(Vulkan_dxc_EXECUTABLE_PATH ${Vulkan_dxc_EXECUTABLE} DIRECTORY)
-			set(DXC_CUSTOM_PATH ${Vulkan_dxc_EXECUTABLE_PATH})
+			get_filename_component(DXC_CUSTOM_PATH ${Vulkan_dxc_EXECUTABLE} DIRECTORY)
 		endif()
 
         if(APPLE)


### PR DESCRIPTION
This PR updates the README to clarify that `DXC_CUSTOM_PATH` must contain only the **directory path** and not the **dxc** executable name itself.  In addition it fixes the same issue within CMakeLists.txt by stripping the **dxc** binary name before setting a backup default value for `DXC_CUSTOM_PATH` when it is not defined manually on the command line.

This latter change is an edge case that likely was not commonly hit since if **dxc** was found as an optional component by `find(Vulkan)`, then ShaderMake's `find_program(dxc)` would likely work as well even without a `DXC_CUSTOM_PATH` hint.  And if `-DDXC_CUSTOM_PATH=<>` was specified on the command line, this default code would not be executed anyways.

Tested on Windows 11, Linux Manjaro, and macOS Ventura.

Supersedes #1038.