### PR TITLE
Fix ffmpeg8 compile error and update SDL2 code for sdl2-compat

### DIFF
--- a/neo/renderer/Cinematic.cpp
+++ b/neo/renderer/Cinematic.cpp
@@ -861,9 +861,12 @@ void idCinematicLocal::FFMPEGReset()
 	// SRS - Special handling for RoQ files: only byte seek works and ffmpeg RoQ decoder needs reset
 	else if( dec_ctx->codec_id == AV_CODEC_ID_ROQ && av_seek_frame( fmt_ctx, video_stream_index, 0, AVSEEK_FLAG_BYTE ) >= 0 )
 	{
+#if LIBAVCODEC_VERSION_MAJOR <= 61
 		// Close and reopen the ffmpeg RoQ codec without clearing the context - this seems to reset the decoder properly
+		// Note avcodec_close( dec_ctx ) is deprecated and removed as of ffmpeg version 8 or LIBAVCODEC_VERSION_MAJOR 62
 		avcodec_close( dec_ctx );
 		avcodec_open2( dec_ctx, dec, NULL );
+#endif
 
 		status = FMV_LOOPED;
 	}

--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -807,13 +807,19 @@ sysEvent_t Sys_GetEvent()
 				continue; // just handle next event
 
 			// Avoid 'unknown event' spam
+			case SDL_DISPLAYEVENT:
 			case SDL_TEXTEDITING:
 			case SDL_KEYMAPCHANGED:
 			case SDL_CLIPBOARDUPDATE:
 				continue; // just handle next event
 
 			default:
-				common->Warning( "unknown event %u = %#x", ev.type, ev.type );
+				// SRS - Suppress warnings for redundant SDL3 display / window events leaking in from sdl2-compat
+				//     - This is likely a defect in sdl2-compat but suppress since unknown event spam is annoying
+				if( !( ev.type > SDL_DISPLAYEVENT && ev.type < SDL_WINDOWEVENT ) && !( ev.type > SDL_SYSWMEVENT && ev.type < SDL_KEYDOWN ) )
+				{
+					common->Warning( "unknown event %u = %#x", ev.type, ev.type );
+				}
 				continue; // just handle next event
 		}
 	}

--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -511,12 +511,11 @@ sysEvent_t Sys_GetEvent()
 						SDL_Window* window = SDL_GetWindowFromID( ev.window.windowID );
 						if( !renderSystem->IsFullScreen() && !( SDL_GetWindowFlags( window ) & SDL_WINDOW_MAXIMIZED ) )
 						{
-							// SRS - take window border into account when when saving window position cvars
-							int topBorder, leftBorder, bottomBorder, rightBorder;
-							SDL_Window* window = SDL_GetWindowFromID( ev.window.windowID );
-							SDL_GetWindowBordersSize( window, &topBorder, &leftBorder, &bottomBorder, &rightBorder );
-							r_windowX.SetInteger( x - leftBorder );
-							r_windowY.SetInteger( y - topBorder );
+							// SRS - don't take window border into account when when saving window position cvars
+							//     - border policies are different across window managers and sdl2 vs. sdl2-compat
+							//     - window position may creep on restore, but too many differences so just *KISS*
+							r_windowX.SetInteger( x );
+							r_windowY.SetInteger( y );
 						}
 						break;
 					}


### PR DESCRIPTION
This PR fixes a few issues caused by recent linux package updates and additions:

1. Fix an **ffmpeg8** compile error due to the removed `avcodec_close()` function.  This was used only as a workaround to force a reset the avcodec when playing back legacy RoQ files.  This reset is not absolutely necessary and can be handled by conditional compilation based on the avcodec version.
2. Update the **SDL2** code for linux and macOS to be compatible with both **sdl2-compat+SDL3** and **native SDL2**.  Noteably this fixes the content area resize problem with **sdl2-compat** when restoring from borderless fullscreen.  It also removes any attempt at border adjustment since **sdl2-compat+SDL3** handles this now, and trying to understand and code around differences between window managers, distros, and platforms would be very error prone and buggy.  The effect of this no-border adjustment change means that window position may creep on successive borderless fullscreen and restore operations (alt-enter), but the impact is small and should not be too noticeable or negative.
3. Suppress warnings for **SDL3** events leaking through to the **SDL2** event stream when using **sdl2-compat+SDL3**.  This is an **sdl2-compat** defect, but suppress unknown event spam anyways.  See **https://github.com/libsdl-org/sdl2-compat/issues/508.**

Fixes #1050 and #1051.