### PR TITLE
Compatibility fixes for new KosmicKrisp Vulkan driver on macOS

### DIFF
--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -2470,7 +2470,6 @@ idRenderBackend::idRenderBackend()
 	memset( &glConfig, 0, sizeof( glConfig ) );
 
 	glConfig.uniformBufferOffsetAlignment = 256;
-	glConfig.timerQueryAvailable = true;
 }
 
 /*

--- a/neo/sys/DeviceManager_DX12.cpp
+++ b/neo/sys/DeviceManager_DX12.cpp
@@ -276,6 +276,9 @@ bool DeviceManager_DX12::CreateDeviceAndSwapChain()
 		glConfig.vendor = getGPUVendor( aDesc.VendorId );
 		// SRS - Intel iGPUs typically allocate 128 MB for Dedicated UMA, set threshold at 512 MB to potentially handle other iGPUs (e.g. AMD APUs)
 		glConfig.gpuType = aDesc.DedicatedVideoMemory > 0x20000000 ? GPU_TYPE_DISCRETE : GPU_TYPE_OTHER;
+
+		// SRS - Set timestamp queries as always available on the DX12 device
+		glConfig.timerQueryAvailable = true;
 	}
 	/*
 		// SRS - Don't center window here for DX12 only, instead use portable initialization in CreateWindowDeviceAndSwapChain() within win_glimp.cpp

--- a/neo/sys/DeviceManager_VK.cpp
+++ b/neo/sys/DeviceManager_VK.cpp
@@ -1003,12 +1003,10 @@ bool DeviceManager_VK::createDevice()
 						  .setShaderImageGatherExtended( true )
 						  .setShaderStorageImageReadWithoutFormat( actualDeviceFeatures2.features.shaderStorageImageReadWithoutFormat )
 						  .setSamplerAnisotropy( true )
-						  .setTessellationShader( true )
+						  .setTessellationShader( actualDeviceFeatures2.features.tessellationShader )
 						  .setTextureCompressionBC( true )
-#if !defined(__APPLE__)
-						  .setGeometryShader( true )
-#endif
-						  .setFillModeNonSolid( true )
+						  .setGeometryShader( actualDeviceFeatures2.features.geometryShader )
+						  .setFillModeNonSolid( actualDeviceFeatures2.features.fillModeNonSolid )
 						  .setImageCubeArray( true )
 						  .setDualSrcBlend( true );
 
@@ -1078,6 +1076,11 @@ bool DeviceManager_VK::createDevice()
 	auto prop = m_VulkanPhysicalDevice.getProperties();
 	m_RendererString = std::string( prop.deviceName.data() );
 	m_DeviceApiVersion = prop.apiVersion;
+
+	// SRS - Check if timestamp queries are available on the Vulkan device and graphics queue
+	auto queueProp = m_VulkanPhysicalDevice.getQueueFamilyProperties();
+	glConfig.timerQueryAvailable = ( prop.limits.timestampPeriod > 0.0 ) &&
+								   ( prop.limits.timestampComputeAndGraphics || queueProp[ m_GraphicsQueueFamily ].timestampValidBits > 0 );
 
 #if defined( USE_AMD_ALLOCATOR )
 	// SRS - initialize the vma allocator


### PR DESCRIPTION
This PR adds support for the new KosmicKrisp Vulkan driver on macOS (arm64).

It contains a minimal set of changes making the Vulkan portability subset and layer settings extensions optional at runtime, making the code adapatable to both MoltenVK and KosmicKrisp without need for recompilation.  Commit https://github.com/RobertBeckebans/RBDOOM-3-BFG/pull/1062/commits/aad63bbe2127df8a015f5887559fa175ff82748f changes are guarded for Apple only.  Commit https://github.com/RobertBeckebans/RBDOOM-3-BFG/pull/1062/commits/8b08b592e45ff46b0b65d8f799d42a1ede99a946 is generic and should be backwards compatible across platforms and drivers.

The PR is currently marked WIP to allow me to test against the coming SDK over the next several weeks, and later report back with any issues as well as comparitive performance data.