### PR TITLE
Fix va() for multi-threading, and state change logic for volatile constant buffers

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -184,8 +184,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 	if(CMAKE_C_COMPILER_ID MATCHES "Clang")
 		# add clang-specific settings for warnings (the second one make sure clang doesn't complain
 		# about unknown -W flags, like -Wno-unused-but-set-variable)
-		# SRS - Add -Wno-expansion-to-defined, Wno-nullability-completeness and -Wno-shorten-64-to-32 to list of warning settings
-		add_compile_options(-Wno-local-type-template-args -Wno-unknown-warning-option -Wno-inline-new-delete -Wno-switch-enum -Wno-expansion-to-defined -Wno-nullability-completeness -Wno-shorten-64-to-32)
+		# SRS - Add -Wno-expansion-to-defined, Wno-nullability-completeness, -Wno-shorten-64-to-32 and -Wno-nontrivial-memcall to list of warning settings
+		add_compile_options(-Wno-local-type-template-args -Wno-unknown-warning-option -Wno-inline-new-delete -Wno-switch-enum -Wno-expansion-to-defined -Wno-nullability-completeness -Wno-shorten-64-to-32 -Wno-nontrivial-memcall)
 	endif()
 	
 	if(NOT CMAKE_CROSSCOMPILING AND ONATIVE)

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -541,6 +541,7 @@ endif()
 
 file(GLOB MINIZIP_INCLUDES libs/zlib/minizip/*.h)
 file(GLOB MINIZIP_SOURCES libs/zlib/minizip/*.c libs/zlib/minizip/*.cpp)
+file(GLOB MINIZIP_C_SOURCES libs/zlib/minizip/*.c)
 
 set(SOUND_INCLUDES
 	sound/snd_local.h
@@ -1359,9 +1360,9 @@ else()
 	# SRS - disable certain gcc/clang warnings for select third-party source libraries, consider updating versions in the future?
 	set_source_files_properties(
 			${ZLIB_SOURCES}
-			${MINIZIP_SOURCES}
+			${MINIZIP_C_SOURCES}
 			PROPERTIES
-			COMPILE_FLAGS "-Wno-stringop-overread -Wno-deprecated-non-prototype"
+			COMPILE_FLAGS "-Wno-stringop-overread -Wno-deprecated-non-prototype -Wno-old-style-definition"
 			)
 		
 	# SRS - if using gcc compiler enable gnu extensions for ##__VA_ARGS__ support within optick profiler (i.e. __STRICT_ANSI__ not set)

--- a/neo/d3xp/Actor.cpp
+++ b/neo/d3xp/Actor.cpp
@@ -2314,7 +2314,7 @@ idActor::GetAnim
 int idActor::GetAnim( int channel, const char* animname )
 {
 	int			anim;
-	const char* temp;
+	idStr		temp;
 	idAnimator* animatorPtr;
 
 	if( channel == ANIMCHANNEL_HEAD )

--- a/neo/d3xp/Entity.cpp
+++ b/neo/d3xp/Entity.cpp
@@ -232,7 +232,7 @@ which should be used by dmap and the editor
 void idGameEdit::ParseSpawnArgsToRenderEntity( const idDict* args, renderEntity_t* renderEntity, const idDeclEntityDef* def )
 {
 	int			i;
-	const char*	temp;
+	idStr		temp;
 	idVec3		color;
 	float		angle;
 	const idDeclModelDef* modelDef;
@@ -242,7 +242,7 @@ void idGameEdit::ParseSpawnArgsToRenderEntity( const idDict* args, renderEntity_
 	temp = args->GetString( "model" );
 
 	modelDef = NULL;
-	if( temp[0] != '\0' )
+	if( temp.Length() > 0 )
 	{
 		modelDef = static_cast<const idDeclModelDef*>( declManager->FindType( DECL_MODELDEF, temp, false ) );
 		if( modelDef )
@@ -265,7 +265,7 @@ void idGameEdit::ParseSpawnArgsToRenderEntity( const idDict* args, renderEntity_
 		{
 			// grab the model key from the definition instead
 			temp = def->dict.GetString( "model" );
-			if( temp[0] != '\0' )
+			if( temp.Length() > 0 )
 			{
 				modelDef = static_cast<const idDeclModelDef*>( declManager->FindType( DECL_MODELDEF, temp, false ) );
 				if( modelDef )
@@ -299,7 +299,7 @@ void idGameEdit::ParseSpawnArgsToRenderEntity( const idDict* args, renderEntity_
 	}
 
 	temp = args->GetString( "skin" );
-	if( temp[0] != '\0' )
+	if( temp.Length() > 0 )
 	{
 		renderEntity->customSkin = declManager->FindSkin( temp );
 	}
@@ -309,7 +309,7 @@ void idGameEdit::ParseSpawnArgsToRenderEntity( const idDict* args, renderEntity_
 	}
 
 	temp = args->GetString( "shader" );
-	if( temp[0] != '\0' )
+	if( temp.Length() > 0 )
 	{
 		renderEntity->customShader = declManager->FindMaterial( temp );
 	}
@@ -400,7 +400,7 @@ void idGameEdit::ParseSpawnArgsToRenderEntity( const idDict* args, renderEntity_
 	for( i = 0; i < MAX_RENDERENTITY_GUI; i++ )
 	{
 		temp = args->GetString( i == 0 ? "gui" : va( "gui%d", i + 1 ) );
-		if( temp[ 0 ] != '\0' )
+		if( temp.Length() > 0 )
 		{
 			AddRenderGui( temp, &renderEntity->gui[ i ], args );
 		}
@@ -586,7 +586,7 @@ idEntity::Spawn
 void idEntity::Spawn()
 {
 	int					i;
-	const char*			temp;
+	idStr				temp;
 	idVec3				origin;
 	idMat3				axis;
 	const idKeyValue*	networkSync;
@@ -635,7 +635,7 @@ void idEntity::Spawn()
 
 	cameraTarget = NULL;
 	temp = spawnArgs.GetString( "cameraTarget" );
-	if( temp != NULL && temp[0] != '\0' )
+	if( temp.Length() > 0 )
 	{
 		// update the camera taget
 		PostEventMS( &EV_UpdateCameraTarget, 0 );
@@ -699,7 +699,7 @@ void idEntity::Spawn()
 	SetAxis( axis );
 
 	temp = spawnArgs.GetString( "model" );
-	if( temp != NULL && *temp != '\0' )
+	if( temp.Length() > 0 )
 	{
 		SetModel( temp );
 
@@ -717,7 +717,7 @@ void idEntity::Spawn()
 		{
 			// grab the model key from the definition instead
 			temp = def->dict.GetString( "model" );
-			if( temp != NULL && *temp != '\0' )
+			if( temp.Length() > 0 )
 			{
 				SetModel( temp );
 
@@ -730,7 +730,7 @@ void idEntity::Spawn()
 	}
 	// RB end
 
-	if( spawnArgs.GetString( "bind", "", &temp ) )
+	if( spawnArgs.GetString( "bind", "", temp ) )
 	{
 		PostEventMS( &EV_SpawnBind, 0 );
 	}
@@ -3878,7 +3878,8 @@ idEntity::AddDamageEffect
 */
 void idEntity::AddDamageEffect( const trace_t& collision, const idVec3& velocity, const char* damageDefName )
 {
-	const char* sound, *decal, *key;
+	const char* sound, *decal;
+	idStr key;
 
 	const idDeclEntityDef* def = gameLocal.FindEntityDef( damageDefName, false );
 	if( def == NULL )
@@ -6577,7 +6578,8 @@ idAnimatedEntity::AddLocalDamageEffect
 */
 void idAnimatedEntity::AddLocalDamageEffect( jointHandle_t jointNum, const idVec3& localOrigin, const idVec3& localNormal, const idVec3& localDir, const idDeclEntityDef* def, const idMaterial* collisionMaterial )
 {
-	const char* sound, *splat, *decal, *bleed, *key;
+	const char* sound, *splat, *decal, *bleed;
+	idStr key;
 	damageEffect_t*	de;
 	idVec3 origin, dir;
 	idMat3 axis;

--- a/neo/d3xp/Game_local.cpp
+++ b/neo/d3xp/Game_local.cpp
@@ -1989,7 +1989,7 @@ void idGameLocal::CacheDictionaryMedia( const idDict* dict )
 	if( kv != NULL && kv->GetValue().Length() )
 	{
 		int teleportType = atoi( kv->GetValue() );
-		const char* p = ( teleportType ) ? va( "fx/teleporter%i.fx", teleportType ) : "fx/teleporter.fx";
+		idStr p = ( teleportType ) ? va( "fx/teleporter%i.fx", teleportType ) : "fx/teleporter.fx";
 		declManager->FindType( DECL_FX, p );
 	}
 

--- a/neo/d3xp/Player.cpp
+++ b/neo/d3xp/Player.cpp
@@ -1663,6 +1663,8 @@ idPlayer::idPlayer():
 	playedTimeSecs			= 0;
 	playedTimeResidual		= 0;
 
+	flashlightReset			= false;
+
 	ResetControllerShake();
 
 	memset( pdaHasBeenRead, 0, sizeof( pdaHasBeenRead ) );

--- a/neo/d3xp/anim/Anim.h
+++ b/neo/d3xp/anim/Anim.h
@@ -293,7 +293,7 @@ public:
 	bool						GetOrigin( idVec3& offset, int animNum, int time, int cyclecount ) const;
 	bool						GetOriginRotation( idQuat& rotation, int animNum, int currentTime, int cyclecount ) const;
 	bool						GetBounds( idBounds& bounds, int animNum, int time, int cyclecount ) const;
-	const char*					AddFrameCommand( const class idDeclModelDef* modelDef, int framenum, idLexer& src, const idDict* def );
+	idStr						AddFrameCommand( const class idDeclModelDef* modelDef, int framenum, idLexer& src, const idDict* def );
 	void						CallFrameCommands( idEntity* ent, int from, int to ) const;
 	bool						HasFrameCommands() const;
 

--- a/neo/d3xp/anim/Anim_Blend.cpp
+++ b/neo/d3xp/anim/Anim_Blend.cpp
@@ -315,7 +315,7 @@ idAnim::AddFrameCommand
 Returns NULL if no error.
 =====================
 */
-const char* idAnim::AddFrameCommand( const idDeclModelDef* modelDef, int framenum, idLexer& src, const idDict* def )
+idStr idAnim::AddFrameCommand( const idDeclModelDef* modelDef, int framenum, idLexer& src, const idDict* def )
 {
 	int					i;
 	int					index;
@@ -3297,8 +3297,8 @@ bool idDeclModelDef::ParseAnim( idLexer& src, int numDefaultAnims, const idStr& 
 			else if( token == "frame" )
 			{
 				// create a frame command
-				int			framenum;
-				const char*	err;
+				int		framenum;
+				idStr	err;
 
 				// make sure we don't have any line breaks while reading the frame command so the error line # will be correct
 				if( !src.ReadTokenOnLine( &token ) )
@@ -3323,9 +3323,9 @@ bool idDeclModelDef::ParseAnim( idLexer& src, int numDefaultAnims, const idStr& 
 
 				// put the command on the specified frame of the animation
 				err = anim->AddFrameCommand( this, framenum, src, NULL );
-				if( err )
+				if( err.Length() > 0 )
 				{
-					src.Warning( "%s", err );
+					src.Warning( "%s", err.c_str() );
 					MakeDefault();
 					return false;
 				}

--- a/neo/d3xp/gamesys/SysCmds.cpp
+++ b/neo/d3xp/gamesys/SysCmds.cpp
@@ -1039,7 +1039,8 @@ void Cmd_TestLight_f( const idCmdArgs& args )
 {
 	int			i;
 	idStr		filename;
-	const char* key = NULL, *value = NULL, *name = NULL;
+	const char* key = NULL, *value = NULL;
+	idStr		name;
 	idPlayer* 	player = NULL;
 	idDict		dict;
 
@@ -1102,7 +1103,8 @@ Cmd_TestPointLight_f
 */
 void Cmd_TestPointLight_f( const idCmdArgs& args )
 {
-	const char* key = NULL, *value = NULL, *name = NULL;
+	const char* key = NULL, *value = NULL;
+	idStr		name;
 	int			i;
 	idPlayer*	player = NULL;
 	idDict		dict;
@@ -1806,7 +1808,7 @@ static void Cmd_SaveSelected_f( const idCmdArgs& args )
 	idMapFile* mapFile = gameLocal.GetLevelMap();
 	idDict dict;
 	idStr mapName;
-	const char* name = NULL;
+	idStr name;
 
 	player = gameLocal.GetLocalPlayer();
 	if( !player || !gameLocal.CheatsOk() )
@@ -1902,7 +1904,7 @@ static void Cmd_SaveMoveables_f( const idCmdArgs& args )
 	idMapEntity* mapEnt = NULL;
 	idMapFile* mapFile = gameLocal.GetLevelMap();
 	idStr mapName;
-	const char* name = NULL;
+	idStr name;
 
 	if( !gameLocal.CheatsOk() )
 	{
@@ -2000,7 +2002,7 @@ static void Cmd_SaveRagdolls_f( const idCmdArgs& args )
 	idMapFile* mapFile = gameLocal.GetLevelMap();
 	idDict dict;
 	idStr mapName;
-	const char* name = NULL;
+	idStr name;
 
 	if( !gameLocal.CheatsOk() )
 	{
@@ -2136,7 +2138,7 @@ static void Cmd_SaveLights_f( const idCmdArgs& args )
 	idMapFile* mapFile = gameLocal.GetLevelMap();
 	idDict dict;
 	idStr mapName;
-	const char* name = NULL;
+	idStr name;
 
 	if( !gameLocal.CheatsOk() )
 	{

--- a/neo/d3xp/menus/MenuHandler_PDA.cpp
+++ b/neo/d3xp/menus/MenuHandler_PDA.cpp
@@ -315,7 +315,7 @@ void idMenuHandler_PDA::Initialize( const char* swfFile, idSoundWorld* sw )
 
 		for( int j = 0; j < MAX_WEAPONS; j++ )
 		{
-			const char* weaponDefName = va( "def_weapon%d", j );
+			idStr weaponDefName = va( "def_weapon%d", j );
 			const char* weap = player->spawnArgs.GetString( weaponDefName );
 			if( weap != NULL && *weap != '\0' )
 			{

--- a/neo/d3xp/menus/MenuScreen_HUD.cpp
+++ b/neo/d3xp/menus/MenuScreen_HUD.cpp
@@ -543,7 +543,7 @@ void idMenuScreen_HUD::GiveWeapon( idPlayer* player, int weaponIndex )
 		return;
 	}
 
-	const char* weapnum = va( "def_weapon%d", weaponIndex );
+	idStr weapnum = va( "def_weapon%d", weaponIndex );
 	const char* weap = player->spawnArgs.GetString( weapnum );
 	if( weap != NULL && *weap != '\0' )
 	{
@@ -1199,7 +1199,7 @@ void idMenuScreen_HUD::UpdateWeaponStates( idPlayer* player, bool weaponChanged 
 
 		for( int i = 0; i < MAX_WEAPONS; i++ )
 		{
-			const char* weapnum = va( "def_weapon%d", i );
+			idStr weapnum = va( "def_weapon%d", i );
 			int weapstate = 0;
 			if( player->inventory.weapons & ( 1 << i ) )
 			{

--- a/neo/d3xp/menus/MenuScreen_PDA_Inventory.cpp
+++ b/neo/d3xp/menus/MenuScreen_PDA_Inventory.cpp
@@ -174,7 +174,7 @@ const char* idMenuScreen_PDA_Inventory::GetWeaponName( int index )
 		return NULL;
 	}
 
-	const char* weaponDefName = va( "def_weapon%d", index );
+	idStr weaponDefName = va( "def_weapon%d", index );
 	if( player->GetInventory().weapons & ( 1 << index ) )
 	{
 		return player->spawnArgs.GetString( weaponDefName );

--- a/neo/d3xp/menus/MenuWidget_Button.cpp
+++ b/neo/d3xp/menus/MenuWidget_Button.cpp
@@ -316,7 +316,7 @@ void idMenuWidget_Button::AnimateToState( const animState_t targetAnimState, con
 		{
 			for( int i = 0; i < trans.prefixes.Num(); ++i )
 			{
-				const char* const frameLabel = va( "%s%s", trans.prefixes[ i ], trans.animationName );
+				idStr const frameLabel = va( "%s%s", trans.prefixes[ i ], trans.animationName );
 				if( GetSprite()->FrameExists( frameLabel ) )
 				{
 					GetSprite()->PlayFrame( frameLabel );

--- a/neo/d3xp/script/Script_Compiler.cpp
+++ b/neo/d3xp/script/Script_Compiler.cpp
@@ -1360,7 +1360,7 @@ idVarDef* idCompiler::ParseFunctionCall( idVarDef* funcDef )
 
 	if( funcDef->initialized == idVarDef::uninitialized )
 	{
-		Error( "Function '%s' has not been defined yet", funcDef->GlobalName() );
+		Error( "Function '%s' has not been defined yet", funcDef->GlobalName().c_str() );
 	}
 
 	assert( funcDef->value.functionPtr );
@@ -1653,7 +1653,7 @@ idVarDef* idCompiler::ParseValue()
 			{
 				if( namespaceDef != NULL )
 				{
-					Error( "Unknown value \"%s::%s\"", namespaceDef->GlobalName(), name.c_str() );
+					Error( "Unknown value \"%s::%s\"", namespaceDef->GlobalName().c_str(), name.c_str() );
 				}
 				else
 				{
@@ -2495,7 +2495,7 @@ void idCompiler::ParseObjectDef( const char* objname )
 	idTypeDef*	parentType;
 	idTypeDef*	fieldtype;
 	idStr		name;
-	const char*  fieldname;
+	idStr		fieldname;
 	idTypeDef	newtype( ev_field, NULL, "", 0, NULL );
 	idVarDef*	oldscope;
 	int			num;
@@ -2654,7 +2654,7 @@ void idCompiler::ParseFunctionDef( idTypeDef* returnType, const char* name )
 		assert( func );
 		if( func->firstStatement )
 		{
-			Error( "%s redeclared", def->GlobalName() );
+			Error( "%s redeclared", def->GlobalName().c_str() );
 		}
 	}
 

--- a/neo/d3xp/script/Script_Program.cpp
+++ b/neo/d3xp/script/Script_Program.cpp
@@ -708,11 +708,11 @@ const char* idVarDef::Name() const
 idVarDef::GlobalName
 ============
 */
-const char* idVarDef::GlobalName() const
+idStr idVarDef::GlobalName() const
 {
 	if( scope != &def_namespace )
 	{
-		return va( "%s::%s", scope->GlobalName(), name->Name() );
+		return va( "%s::%s", scope->GlobalName().c_str(), name->Name() );
 	}
 	else
 	{
@@ -894,11 +894,11 @@ void idVarDef::PrintInfo( idFile* file, int instructionPointer ) const
 		case ev_function :
 			if( value.functionPtr->eventdef )
 			{
-				file->Printf( "event %s", GlobalName() );
+				file->Printf( "event %s", GlobalName().c_str() );
 			}
 			else
 			{
-				file->Printf( "function %s", GlobalName() );
+				file->Printf( "function %s", GlobalName().c_str() );
 			}
 			break;
 
@@ -2155,9 +2155,9 @@ bool idProgram::CompileText( const char* source, const char* text, bool console 
 				if( !def->value.functionPtr->eventdef && !def->value.functionPtr->firstStatement )
 				{
 #if defined(USE_EXCEPTIONS)
-					throw idCompileError( va( "function %s was not defined\n", def->GlobalName() ) );
+					throw idCompileError( va( "function %s was not defined\n", def->GlobalName().c_str() ) );
 #else
-					gameLocal.Error( "function %s was not defined\n", def->GlobalName() );
+					gameLocal.Error( "function %s was not defined\n", def->GlobalName().c_str() );
 #endif
 				}
 			}

--- a/neo/d3xp/script/Script_Program.h
+++ b/neo/d3xp/script/Script_Program.h
@@ -350,7 +350,7 @@ public:
 	~idVarDef();
 
 	const char* 			Name() const;
-	const char* 			GlobalName() const;
+	idStr		 			GlobalName() const;
 
 	void					SetTypeDef( idTypeDef* _type )
 	{

--- a/neo/framework/Console.cpp
+++ b/neo/framework/Console.cpp
@@ -270,7 +270,7 @@ float idConsoleLocal::DrawFPS( float y )
 		cpuUsage /= FPS_FRAMES;
 		gpuUsage /= FPS_FRAMES;
 
-		const char* s = va( "%ifps", fps );
+		idStr s = va( "%ifps", fps );
 		int w = strlen( s ) * BIGCHAR_WIDTH;
 
 		if( com_showFPS.GetInteger() == 1 )
@@ -528,7 +528,7 @@ float idConsoleLocal::DrawFPS( float y )
 
 		if( com_showFPS.GetInteger() > 2 )
 		{
-			const char* overlay = va( "Average FPS %-4i", fps );
+			idStr overlay = va( "Average FPS %-4i", fps );
 
 			ImGui::PlotLines( "Relative\nFrametime ms", previousTimesNormalized, FPS_FRAMES_HISTORY, valuesOffset, overlay, -10.0f, 10.0f, ImVec2( 0, 50 ) );
 		}

--- a/neo/framework/common_frame.cpp
+++ b/neo/framework/common_frame.cpp
@@ -299,7 +299,7 @@ void idCommonLocal::Draw()
 			}
 
 			// prepare our strings
-			const char* text;
+			idStr text;
 			if( loadPacifierBinarizeTimeLeft >= 99.5f )
 			{
 				text = va( "Binarizing %3.0f%% ETA %2.0f minutes", loadPacifierBinarizeProgress * 100.0f, loadPacifierBinarizeTimeLeft / 60.0f );

--- a/neo/idlib/Str.cpp
+++ b/neo/idlib/Str.cpp
@@ -501,8 +501,8 @@ idStr::FloatArrayToString
 */
 const char* idStr::FloatArrayToString( const float* array, const int length, const int precision )
 {
-	static int index = 0;
-	static char str[4][16384];	// in case called by nested functions
+	thread_local int index = 0;
+	thread_local char str[4][MAX_PRINT_MSG];	// in case called by nested functions
 	int i, n;
 	char format[16], *s;
 
@@ -549,8 +549,8 @@ idStr::CStyleQuote
 */
 const char* idStr::CStyleQuote( const char* str )
 {
-	static int index = 0;
-	static char buffers[4][16384];	// in case called by nested functions
+	thread_local int index = 0;
+	thread_local char buffers[4][MAX_PRINT_MSG];	// in case called by nested functions
 	unsigned int i;
 	char* buf;
 
@@ -633,8 +633,8 @@ const char* idStr::CStyleUnQuote( const char* str )
 		return str;
 	}
 
-	static int index = 0;
-	static char buffers[4][16384];	// in case called by nested functions
+	thread_local int index = 0;
+	thread_local char buffers[4][MAX_PRINT_MSG];	// in case called by nested functions
 	unsigned int i;
 	char* buf;
 
@@ -740,7 +740,7 @@ void idStr::Format( const char* fmt, ... )
 
 	if( len < 0 )
 	{
-		idLib::common->FatalError( "Tried to set a large buffer using %s", fmt );
+		idLib::common->FatalError( "idStr::Format() tried to set a large buffer using %s", fmt );
 	}
 	*this = text;
 }

--- a/neo/idlib/Str.h
+++ b/neo/idlib/Str.h
@@ -400,7 +400,13 @@ public:
 	static const int	INVALID_POSITION = -1;
 };
 
-char* 					va( VERIFY_FORMAT_STRING const char* fmt, ... ) ID_STATIC_ATTRIBUTE_PRINTF( 1, 2 );
+// SRS - Converted previous va() definition to va_ptr() unique_ptr combined with va() macro to guarantee thread safety
+std::unique_ptr< const char[] > va_ptr( VERIFY_FORMAT_STRING const char* fmt, ... ) ID_STATIC_ATTRIBUTE_PRINTF( 1, 2 );
+
+// Note: va() returns a const char* stack address that must be copied into a new memory location (e.g. idStr) to be persistent.
+//		 This means that va() should not be assigned to a char* variable or used as a return value for a char* type function.
+//		 Once the va() expression is complete, the returned memory location will be recovered and the contents will be lost.
+#define va( format, ... ) va_ptr( format, ##__VA_ARGS__ ).get()
 
 /*
 ================================================================================================

--- a/neo/idlib/Str.h
+++ b/neo/idlib/Str.h
@@ -400,13 +400,13 @@ public:
 	static const int	INVALID_POSITION = -1;
 };
 
-// SRS - Converted previous va() definition to va_ptr() unique_ptr combined with va() macro to guarantee thread safety
-std::unique_ptr< const char[] > va_ptr( VERIFY_FORMAT_STRING const char* fmt, ... ) ID_STATIC_ATTRIBUTE_PRINTF( 1, 2 );
+// SRS - Converted previous va() definition to idStr return type va_str() combined with va() macro to guarantee thread safety
+idStr va_str( VERIFY_FORMAT_STRING const char* fmt, ... ) ID_STATIC_ATTRIBUTE_PRINTF( 1, 2 );
 
 // Note: va() returns a const char* stack address that must be copied into a new memory location (e.g. idStr) to be persistent.
 //		 This means that va() should not be assigned to a char* variable or used as a return value for a char* type function.
 //		 Once the va() expression is complete, the returned memory location will be recovered and the contents will be lost.
-#define va( format, ... ) va_ptr( format, ##__VA_ARGS__ ).get()
+#define va( format, ... ) va_str( format, ##__VA_ARGS__ ).c_str()
 
 /*
 ================================================================================================

--- a/neo/idlib/math/Lcp.cpp
+++ b/neo/idlib/math/Lcp.cpp
@@ -2294,7 +2294,12 @@ bool idLCP_Square::Solve( const idMatX& o_m, idVecX& o_x, const idVecX& o_b, con
 	}
 
 	// tells if a variable is at the low boundary, high boundary or inbetween
-	side = ( int* ) _alloca16( m.GetNumRows() * sizeof( int ) );
+	// SRS - side is used by SIMD code so alloc in multiples of four and initialize
+	side = ( int* ) _alloca16( ( ( m.GetNumRows() + 3 ) & ~3 ) * sizeof( int ) );
+	for( int i = 0; i < ( ( m.GetNumRows() + 3 ) & ~3 ); i++ )
+	{
+		side[i] = 0;
+	}
 
 	// index to keep track of the permutation
 	permuted = ( int* ) _alloca16( m.GetNumRows() * sizeof( int ) );
@@ -3074,7 +3079,12 @@ bool idLCP_Symmetric::Solve( const idMatX& o_m, idVecX& o_x, const idVecX& o_b, 
 	}
 
 	// tells if a variable is at the low boundary, high boundary or inbetween
-	side = ( int* ) _alloca16( m.GetNumRows() * sizeof( int ) );
+	// SRS - side is used by SIMD code so alloc in multiples of four and initialize
+	side = ( int* ) _alloca16( ( ( m.GetNumRows() + 3 ) & ~3 ) * sizeof( int ) );
+	for( int i = 0; i < ( ( m.GetNumRows() + 3 ) & ~3 ); i++ )
+	{
+		side[i] = 0;
+	}
 
 	// index to keep track of the permutation
 	permuted = ( int* ) _alloca16( m.GetNumRows() * sizeof( int ) );

--- a/neo/renderer/Font.cpp
+++ b/neo/renderer/Font.cpp
@@ -271,7 +271,7 @@ bool idFont::LoadFont()
 	for( int i = 0; i < 3; i++ )
 	{
 		oldGlyphInfo_t oldGlyphInfo[GLYPHS_PER_FONT];
-		const char* oldFileName = va( "newfonts/%s/old_%d.dat", GetName(), pointSizes[i] );
+		idStr oldFileName = va( "newfonts/%s/old_%d.dat", GetName(), pointSizes[i] );
 		if( LoadOldGlyphData( oldFileName, oldGlyphInfo ) )
 		{
 			int mh = 0;

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -486,7 +486,7 @@ void idRenderBackend::DrawElementsWithCounters( const drawSurf_t* surf, bool sha
 		{
 			// Reset the graphics state if the uniforms or binding layout type
 			// have changed for Vulkan - either push constants are enabled or
-			// the constant buffer is written to and the render pass is
+			// the binding layout type has changed and the render pass is
 			// ended for vulkan. setGraphicsState will reinstate the
 			// render pass or set up for push constants.
 			changeState = true;

--- a/neo/renderer/NVRHI/RenderProgs_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderProgs_NVRHI.cpp
@@ -555,7 +555,10 @@ bool idRenderProgManager::CommitConstantBuffer( nvrhi::ICommandList* commandList
 
 		uniformsChanged[bindingLayoutType] = false;
 
-		return true;
+		// SRS - Writing to a volatile constant buffer no longer ends the renderpass, so indicate state change only if binding layout type has changed
+		//     - for nvrhi Vulkan see related commit https://github.com/NVIDIA-RTX/NVRHI/commit/dafbd407f6fb8b91078da72ca1712dbbd6ac2496
+		//     - for nvrhi DX12 a state change has never been required or activated when writing uniforms to volatile constant buffers
+		return bindingLayoutTypeChanged;
 	}
 
 	return false;

--- a/neo/swf/SWF_ScriptObject.cpp
+++ b/neo/swf/SWF_ScriptObject.cpp
@@ -687,7 +687,7 @@ void idSWFScriptObject::PrintToConsole() const
 
 		maxVarLength += 2;	// a little extra padding
 
-		const char* const fmt = va( "%%-%ds %%-10s %%-s\n", maxVarLength );
+		idStr const fmt = va( "%%-%ds %%-10s %%-s\n", maxVarLength );
 		idLib::Printf( fmt, "Name", "Type", "Value" );
 		idLib::Printf( "------------------------------------------------------------\n" );
 		for( int i = 0; i < variables.Num(); ++i )

--- a/neo/sys/DeviceManager_VK.cpp
+++ b/neo/sys/DeviceManager_VK.cpp
@@ -1345,7 +1345,7 @@ bool DeviceManager_VK::CreateDeviceAndSwapChain()
 	auto vecLayers = stringSetToVector( enabledExtensions.layers );
 	auto vecDeviceExt = stringSetToVector( enabledExtensions.device );
 
-	nvrhi::vulkan::DeviceDesc deviceDesc;
+	nvrhi::vulkan::DeviceDesc deviceDesc {};
 	deviceDesc.errorCB = &DefaultMessageCallback::GetInstance();
 	deviceDesc.instance = m_VulkanInstance;
 	deviceDesc.physicalDevice = m_VulkanPhysicalDevice;

--- a/neo/sys/common/savegame.cpp
+++ b/neo/sys/common/savegame.cpp
@@ -844,7 +844,7 @@ void Sys_SaveGameCheck( bool& exists, bool& autosaveExists )
 
 		for( int i = 0; i < fileList.Num(); i++ )
 		{
-			const char* directory = va( "%s/%s", saveFolder, fileList[i].c_str() );
+			idStr directory = va( "%s/%s", saveFolder, fileList[i].c_str() );
 
 			if( fileSystem->IsFolder( directory, "fs_savePath" ) == FOLDER_YES )
 			{

--- a/neo/sys/common/socket_net.cpp
+++ b/neo/sys/common/socket_net.cpp
@@ -1166,8 +1166,9 @@ const char* Sys_NetAdrToString( const netadr_t a )
 	// DG: FIXME: those static buffers look fishy - I would feel better if they were
 	//            at least thread-local - so /maybe/ use ID_TLS here?
 	//            or maybe return an idStr and change calling code accordingly
-	static int index = 0;
-	static char buf[ 4 ][ 64 ];	// flip/flop
+	// SRS -      changed index and buffer array to use C++11 thread_local attribute
+	thread_local int index = 0;
+	thread_local char buf[ 4 ][ 64 ];	// flip/flop
 	char* s;
 
 	s = buf[index];

--- a/neo/sys/sdl/sdl_events.cpp
+++ b/neo/sys/sdl/sdl_events.cpp
@@ -184,7 +184,7 @@ static void PushConsoleEvent( const char* s )
 	b = ( char* )Mem_Alloc( len, TAG_EVENTS );
 	strcpy( b, s );
 
-	SDL_Event event;
+	SDL_Event event {};
 
 	event.type = SDL_USEREVENT;
 	event.user.code = SE_CONSOLE;

--- a/neo/tools/compilers/CMakeLists.txt
+++ b/neo/tools/compilers/CMakeLists.txt
@@ -136,6 +136,7 @@ endif()
 
 file(GLOB MC_MINIZIP_INCLUDES ../../libs/zlib/minizip/*.h)
 file(GLOB MC_MINIZIP_SOURCES ../../libs/zlib/minizip/*.c ../../libs/zlib/minizip/*.cpp)
+file(GLOB MC_MINIZIP_C_SOURCES ../../libs/zlib/minizip/*.c)
 
 if(MSVC)
 	file(GLOB CURSES_INCLUDES ../../libs/imtui/pdcurses/*.h)
@@ -340,9 +341,9 @@ else()
 	# SRS - disable certain gcc/clang warnings for select third-party source libraries, consider updating versions in the future?
 	set_source_files_properties(
 			${MC_ZLIB_SOURCES}
-			${MC_MINIZIP_SOURCES}
+			${MC_MINIZIP_C_SOURCES}
 			PROPERTIES
-			COMPILE_FLAGS "-Wno-stringop-overread -Wno-deprecated-non-prototype"
+			COMPILE_FLAGS "-Wno-stringop-overread -Wno-deprecated-non-prototype -Wno-old-style-definition"
 			)
 
 	add_executable(rbdmap ${MC_SOURCES_ALL} ${MC_INCLUDES_ALL})

--- a/neo/ui/Winvar.h
+++ b/neo/ui/Winvar.h
@@ -84,7 +84,7 @@ public:
 	virtual void Init( const char* _name, idWindow* win ) = 0;
 	virtual void Set( const char* val ) = 0;
 	virtual void Update() = 0;
-	virtual const char* c_str() const = 0;
+	virtual const char* c_str() = 0;
 	virtual size_t Size()
 	{
 		size_t sz = ( name ) ? strlen( name ) : 0;
@@ -167,9 +167,10 @@ public:
 		}
 	}
 
-	virtual const char* c_str() const
+	virtual const char* c_str()
 	{
-		return va( "%i", data );
+		data_str = va( "%i", data );
+		return data_str.c_str();
 	}
 
 	// SaveGames
@@ -191,6 +192,7 @@ public:
 
 protected:
 	bool data;
+	idStr data_str;
 };
 
 class idWinStr : public idWinVar
@@ -269,7 +271,7 @@ public:
 		}
 		data.RemoveColors();
 	}
-	virtual const char* c_str() const
+	virtual const char* c_str()
 	{
 		return data.c_str();
 	}
@@ -382,9 +384,10 @@ public:
 			data = guiDict->GetInt( s );
 		}
 	}
-	virtual const char* c_str() const
+	virtual const char* c_str()
 	{
-		return va( "%i", data );
+		data_str = va( "%i", data );
+		return data_str.c_str();
 	}
 
 	// SaveGames
@@ -408,6 +411,7 @@ public:
 
 protected:
 	int data;
+	idStr data_str;
 };
 
 class idWinFloat : public idWinVar
@@ -458,9 +462,10 @@ public:
 			data = guiDict->GetFloat( s );
 		}
 	}
-	virtual const char* c_str() const
+	virtual const char* c_str()
 	{
-		return va( "%f", data );
+		data_str = va( "%f", data );
+		return data_str.c_str();
 	}
 
 	virtual void WriteToSaveGame( idFile* savefile )
@@ -480,6 +485,7 @@ public:
 	};
 protected:
 	float data;
+	idStr data_str;
 };
 
 class idWinRectangle : public idWinVar
@@ -596,7 +602,7 @@ public:
 		}
 	}
 
-	virtual const char* c_str() const
+	virtual const char* c_str()
 	{
 		return data.ToVec4().ToString();
 	}
@@ -684,7 +690,7 @@ public:
 			data = guiDict->GetVec2( s );
 		}
 	}
-	virtual const char* c_str() const
+	virtual const char* c_str()
 	{
 		return data.ToString();
 	}
@@ -787,7 +793,7 @@ public:
 			data = guiDict->GetVec4( s );
 		}
 	}
-	virtual const char* c_str() const
+	virtual const char* c_str()
 	{
 		return data.ToString();
 	}
@@ -889,7 +895,7 @@ public:
 			data = guiDict->GetVector( s );
 		}
 	}
-	virtual const char* c_str() const
+	virtual const char* c_str()
 	{
 		return data.ToString();
 	}
@@ -996,7 +1002,7 @@ public:
 		}
 		return data.Length();
 	}
-	virtual const char* c_str() const
+	virtual const char* c_str()
 	{
 		return data.c_str();
 	}


### PR DESCRIPTION
Fixes #1066 and #1067.

1. Enhances the `va()` implementation so that multi-threading does not cause problems.  The approach is to dynamically allocate a `std::unique_ptr< const char[] >` of the correct size, and pass that back in a new function called `va_ptr()`.  Memory management is automatic and the allocation will live until the calling expression is complete.  For backwards compatibility, a new `va()` macro is defined that converts the unique_ptr return value to a `const char*` via the standard `.get()` method.  The remaining issue is the usage pattern: it is not okay to assign the return value of `va()` to a `char*` variable since the referenced memory is not persistent and will be released once the expression containing `va()` is complete.  This means that the return value of `va()` must be either: a) used immediately within the expression, or b) assigned to an idStr or similar for persistent storage, including changing `char*` functions to `idStr` functions when `va()` is the return value.  Fortunately, modern clang versions point out these issues and can help find them.
2. As part of testing for 1, I ran the game through leak testing on macOS (using Instruments), and on Linux (using valgrind).  No leaks were found, but valgrind found a few uninitialized variables which I have fixed here.
3. Also while testing on Linux, the newest clang now checks for typed structures when calling `memset()`.  This is a bit inconvenient in RBDoom3BFG since untyped memsets are used throughout the code.  Rather than go through and change them all, I simply added `-Wno-nontrivial-memcall` to the warning suppression for clang.
4. Another change fixes a small but important issue with Vulkan renderpasses.  A recent nvrhi change does not end the  Vulkan renderpass when volatile constant buffers are written to.  A corresponding change in RBDoom3BFG is needed to not force a Vulkan graphics state change when updating the uniforms via volatile constant buffers.  Push constants are handled the same as before, i.e. no change.  Without this update you can occasionally get a binding layout mismatch.  A simple but important fix.
5. **UPDATED:** The final item is adding the `-Wno-old-style-definition` gcc compiler flag to Zlib and Minizip C source files to suppress warnings for this specific library.  The bundled version of Zlib/Minizip uses an older implicit declaration style, and the warnings generated by newer gcc compilers is noise to the end-user.  If a linux user is not happy using the (older) bundled version, they can always use the `-DUSE_SYSTEM_ZLIB=ON` cmake option.

Tested on Windows 11 Vulkan and DX12, Linux Manjaro, and macOS Ventura.