### PR TITLE
Do not ignore "insane" mouse delta

### DIFF
--- a/neo/framework/UsercmdGen.cpp
+++ b/neo/framework/UsercmdGen.cpp
@@ -501,13 +501,19 @@ void idUsercmdGenLocal::MouseMove()
 	my /= smooth;
 
 	historyCounter++;
+/*
+-- Originally found by Caedes
+Unclear what this was supposed to achieve, in practice it ends up clamping fast mouse movement to zero, 
+which makes for extremely unresponsive and jittery feel either for high-DPI mice or fast flicks. Thus, commented out.
+--
 
 	if( idMath::Fabs( mx ) > 1000 || idMath::Fabs( my ) > 1000 )
 	{
 		Sys_DebugPrintf( "idUsercmdGenLocal::MouseMove: Ignoring ridiculous mouse delta.\n" );
 		mx = my = 0;
 	}
-
+*/
+	
 	mx *= sensitivity.GetFloat();
 	my *= sensitivity.GetFloat();
 


### PR DESCRIPTION
Do not clamp mouse movement to zero if delta is high.

Video demonstration of the issue: https://www.youtube.com/watch?v=GZ7_QXV--MI

The issue persists in practically all Doom 3 versions, whether it be classic or BFG.
Dhewm 3 fixed some time ago: https://github.com/dhewm/dhewm3/issues/616