### PR TITLE
Fix CMake stale linux build dir

### DIFF
--- a/neo/cmake-linux-debug.sh
+++ b/neo/cmake-linux-debug.sh
@@ -1,7 +1,7 @@
 rm -f idlib/precompiled.h.gch
 rm -f tools/compilers/precompiled.h.gch
 cd ..
-rm -rf build
-mkdir build
+mkdir -p build
 cd build
+rm -rf *
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DFFMPEG=ON -DBINKDEC=OFF -DCMAKE_CXX_COMPILER=g++ -DUSE_PRECOMPILED_HEADERS=OFF ../neo

--- a/neo/cmake-linux-release.sh
+++ b/neo/cmake-linux-release.sh
@@ -1,7 +1,7 @@
 rm -f idlib/precompiled.h.gch
 rm -f tools/compilers/precompiled.h.gch
 cd ..
-rm -rf build
-mkdir build
+mkdir -p build
 cd build
+rm -rf *
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DONATIVE=ON -DFFMPEG=OFF -DBINKDEC=ON ../neo

--- a/neo/cmake-linux-retail.sh
+++ b/neo/cmake-linux-retail.sh
@@ -1,7 +1,7 @@
 rm -f idlib/precompiled.h.gch
 rm -f tools/compilers/precompiled.h.gch
 cd ..
-rm -rf build
-mkdir build
+mkdir -p build
 cd build
+rm -rf *
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DONATIVE=ON -DFFMPEG=OFF -DBINKDEC=ON -DRETAIL=ON ../neo

--- a/neo/cmake-macos-release.sh
+++ b/neo/cmake-macos-release.sh
@@ -1,7 +1,7 @@
 cd ..
-rm -rf build
-mkdir build
+mkdir -p build
 cd build
+rm -rf *
 
 # Define the minimum OSX deployment target for machine architecture
 if [ "$(uname -m)" = "arm64" ]; then

--- a/neo/cmake-macos-retail.sh
+++ b/neo/cmake-macos-retail.sh
@@ -1,7 +1,7 @@
 cd ..
-rm -rf build
-mkdir build
+mkdir -p build
 cd build
+rm -rf *
 
 # Define the minimum OSX deployment target for machine architecture
 if [ "$(uname -m)" = "arm64" ]; then


### PR DESCRIPTION
## Problem:

```
mkdir build
cd build
../neo/cmake-<somthing>.sh
make -j32
make: getcwd: No such file or directory
make: *** No targets specified and no makefile found.  Stop
```

Why?  `rm -rf build` and `mkdir build` in those scripts are culprits. Since you're already sitting inside the build directory when you run the script, the directory gets deleted and recreated underneath you. Your shell still holds a file descriptor to the old (now deleted) inode, so make fails with `getcwd: No such file or directory`.

Solution: instead of `rm -rf build && mkdir build`, just clean the contents of the directory