### PR TITLE
Fix GCC -Wstringop-overflow warnings in Swap.h and SysCmds.cpp

### DIFF
--- a/neo/d3xp/gamesys/SysCmds.cpp
+++ b/neo/d3xp/gamesys/SysCmds.cpp
@@ -1437,7 +1437,12 @@ static void PrintFloat( float f )
 	char buf[128];
 	int i;
 
-	for( i = idStr::snPrintf( buf, sizeof( buf ), "%3.2f", f ); i < 7; i++ )
+	i = idStr::snPrintf( buf, sizeof( buf ), "%3.2f", f );
+	if( i < 0 )
+	{
+		i = 0;
+	}
+	for( ; i < 7; i++ )
 	{
 		buf[i] = ' ';
 	}

--- a/neo/idlib/Swap.h
+++ b/neo/idlib/Swap.h
@@ -82,21 +82,21 @@ public:
 		// byte swapping pointers is pointless because we should never store pointers on disk
 		assert( !IsPointer( c ) );
 
-		if( sizeof( type ) == 1 )
+		if constexpr( sizeof( type ) == 1 )
 		{
 		}
-		else if( sizeof( type ) == 2 )
+		else if constexpr( sizeof( type ) == 2 )
 		{
 			byte* b = ( byte* )&c;
 			SwapBytes( b[0], b[1] );
 		}
-		else if( sizeof( type ) == 4 )
+		else if constexpr( sizeof( type ) == 4 )
 		{
 			byte* b = ( byte* )&c;
 			SwapBytes( b[0], b[3] );
 			SwapBytes( b[1], b[2] );
 		}
-		else if( sizeof( type ) == 8 )
+		else if constexpr( sizeof( type ) == 8 )
 		{
 			byte* b = ( byte* )&c;
 			SwapBytes( b[0], b[7] );
@@ -106,7 +106,7 @@ public:
 		}
 		else
 		{
-			assert( false );
+			static_assert( sizeof( type ) == 0, "Unsupported type size for byte swapping" );
 		}
 	}
 


### PR DESCRIPTION
Use if `constexpr in idSwap::Big()` so the compiler discards dead branches for mismatched `sizeof(type)`, preventing false-positive out-of-bounds access warnings when inlined.

Guard `PrintFloat` against negative `snPrintf` return value to prevent GCC from warning about out-of-bounds `buf[]` writes when inlined.

Fixes https://github.com/RobertBeckebans/RBDOOM-3-BFG/issues/1043