### PR TITLE
Fix ppc64le Clang build: guard intrinsics already defined as builtins

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -185,7 +185,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 		# add clang-specific settings for warnings (the second one make sure clang doesn't complain
 		# about unknown -W flags, like -Wno-unused-but-set-variable)
 		# SRS - Add -Wno-expansion-to-defined, Wno-nullability-completeness and -Wno-shorten-64-to-32 to list of warning settings
-		add_compile_options(-Wno-local-type-template-args -Wno-unknown-warning-option -Wno-inline-new-delete -Wno-switch-enum -Wno-expansion-to-defined -Wno-nullability-completeness -Wno-shorten-64-to-32)
+		add_compile_options(-Wno-local-type-template-args -Wno-unknown-warning-option -Wno-inline-new-delete -Wno-switch-enum -Wno-expansion-to-defined -Wno-nullability-completeness -Wno-shorten-64-to-32 -Wno-nontrivial-memcall)
 	endif()
 	
 	if(NOT CMAKE_CROSSCOMPILING AND ONATIVE)

--- a/neo/idlib/sys/sys_intrinsics.h
+++ b/neo/idlib/sys/sys_intrinsics.h
@@ -44,18 +44,26 @@ ID_INLINE_EXTERN float __fmuls( float a, float b )
 {
 	return ( a * b );
 }
+// On ppc64le, Clang defines __fmadds, __fnmsubs, and __fsels as macros
+// mapping to compiler builtins. Skip our definitions when they already exist.
+#ifndef __fmadds
 ID_INLINE_EXTERN float __fmadds( float a, float b, float c )
 {
 	return ( a * b + c );
 }
+#endif
+#ifndef __fnmsubs
 ID_INLINE_EXTERN float __fnmsubs( float a, float b, float c )
 {
 	return ( c - a * b );
 }
+#endif
+#ifndef __fsels
 ID_INLINE_EXTERN float __fsels( float a, float b, float c )
 {
 	return ( a >= 0.0f ) ? b : c;
 }
+#endif
 ID_INLINE_EXTERN float __frcps( float x )
 {
 	return ( 1.0f / x );


### PR DESCRIPTION
On ppc64le, Clang pre-defines `__fmadds`, `__fnmsubs`, and `__fsels` as macros mapping to compiler builtins. Wrap our custom definitions with `#ifndef` guards so they are skipped when the compiler already provides them.

Fixes #1042