### PR TITLE
Fix GCC 14 -Wstringop-overflow warnings on ppc64le

### DIFF
--- a/neo/d3xp/gamesys/SysCmds.cpp
+++ b/neo/d3xp/gamesys/SysCmds.cpp
@@ -1439,7 +1439,8 @@ static void PrintFloat( float f )
 	char buf[128];
 	int i;
 
-	for( i = idStr::snPrintf( buf, sizeof( buf ), "%3.2f", f ); i < 7; i++ )
+	// snPrintf() returns >= 0 here, cast to uint to avoid false positive -Wstringop-overflow
+	for( i = ( unsigned int )idStr::snPrintf( buf, sizeof( buf ), "%3.2f", f ); i < 7; i++ )
 	{
 		buf[i] = ' ';
 	}

--- a/neo/idlib/Swap.h
+++ b/neo/idlib/Swap.h
@@ -82,21 +82,21 @@ public:
 		// byte swapping pointers is pointless because we should never store pointers on disk
 		assert( !IsPointer( c ) );
 
-		if( sizeof( type ) == 1 )
+		if constexpr( sizeof( type ) == 1 )
 		{
 		}
-		else if( sizeof( type ) == 2 )
+		else if constexpr( sizeof( type ) == 2 )
 		{
 			byte* b = ( byte* )&c;
 			SwapBytes( b[0], b[1] );
 		}
-		else if( sizeof( type ) == 4 )
+		else if constexpr( sizeof( type ) == 4 )
 		{
 			byte* b = ( byte* )&c;
 			SwapBytes( b[0], b[3] );
 			SwapBytes( b[1], b[2] );
 		}
-		else if( sizeof( type ) == 8 )
+		else if constexpr( sizeof( type ) == 8 )
 		{
 			byte* b = ( byte* )&c;
 			SwapBytes( b[0], b[7] );
@@ -106,7 +106,7 @@ public:
 		}
 		else
 		{
-			assert( false );
+			static_assert( sizeof( type ) == 0, "unsupported type size for byte swapping" );
 		}
 	}
 


### PR DESCRIPTION
## Summary


- **`neo/idlib/Swap.h`**: Use C++17 `if constexpr` in `idSwap::Big()` so the compiler discards dead branches at compile time, preventing false positive `-Wstringop-overflow` warnings when GCC inlines and analyzes out-of-bounds accesses in branches that can never execute (e.g. the `sizeof(type) == 8` branch for a 4-byte `float`). Also replaced the runtime `assert(false)` fallback with `static_assert` for a compile-time error on unsupported type sizes.
- **`neo/d3xp/gamesys/SysCmds.cpp`**: Cast `idStr::snPrintf()` return value to `unsigned int` in `PrintFloat()` to tell the compiler the value cannot be negative (buf is 128 bytes, format string is fixed), preventing a false positive `-Wstringop-overflow` warning when GCC inlines `PrintFloat` into `Cmd_ListDebugLines_f` and considers a negative index path.