### PR TITLE
Print out Vulkan / DX12 driver name+version to console on startup

### DIFF
--- a/neo/sys/DeviceManager_DX12.cpp
+++ b/neo/sys/DeviceManager_DX12.cpp
@@ -363,6 +363,26 @@ bool DeviceManager_DX12::CreateDeviceAndSwapChain()
 			 IID_PPV_ARGS( &m_Device12 ) );
 	HR_RETURN( hr );
 
+	// SRS - calculate and print out the DXGI device name and driver version string
+	idStr version_string;
+
+	// SRS - check the adaptor interface which returns the User Mode Driver version
+	LARGE_INTEGER UMDVersion;
+	if(	SUCCEEDED( targetAdapter->CheckInterfaceSupport( __uuidof( IDXGIDevice ), &UMDVersion ) ) )
+	{
+		version_string.Format( "UMD driver %u.%u.%u.%u",
+								UMDVersion.QuadPart >> 48,
+							  ( UMDVersion.QuadPart >> 32 ) & 0xFFFF,
+							  ( UMDVersion.QuadPart >> 16 ) & 0xFFFF,
+								UMDVersion.QuadPart & 0xFFFF );
+	}
+	else
+	{
+		version_string.Format( "UMD driver ?.?.?.?" );
+	}
+
+	common->Printf( "Created DX12 device: %s (%s)\n", m_RendererString.c_str(), version_string.c_str() );
+
 	if( m_DeviceParams.enableDebugRuntime )
 	{
 		RefCountPtr<ID3D12InfoQueue> pInfoQueue;

--- a/neo/sys/DeviceManager_VK.cpp
+++ b/neo/sys/DeviceManager_VK.cpp
@@ -1096,7 +1096,75 @@ bool DeviceManager_VK::createDevice()
 	vmaCreateAllocator( &allocatorCreateInfo, &m_VmaAllocator );
 #endif
 
-	common->Printf( "Created Vulkan device: %s\n", m_RendererString.c_str() );
+	// SRS - get the physical device driver properties which contains the driver name
+	vk::PhysicalDeviceDriverProperties driverProperties;
+	vk::PhysicalDeviceProperties2 prop2;
+	prop2.pNext = &driverProperties;
+	m_VulkanPhysicalDevice.getProperties2( &prop2 );
+
+	// SRS - calculate and print out the Vulkan device name and driver version string
+	idStr version_string;
+
+#if defined(__APPLE__)
+	// MoltenVK
+	if( IsVulkanDeviceExtensionEnabled( VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME ) )
+	{
+		// Use custom version conventions for MoltenVK
+		const int ver_major = ( prop.driverVersion ) / 10000;
+		const int ver_minor = ( prop.driverVersion - ver_major * 10000 ) / 100;
+		const int ver_patch = ( prop.driverVersion - ver_major * 10000 - ver_minor * 100 );
+		version_string.Format( "%s %d.%d.%d",
+								&driverProperties.driverName,
+							    ver_major,
+							    ver_minor,
+							    ver_patch );
+	}
+	// KosmicKrisp
+	else
+	{
+		// Use Vulkan version conventions for KosmicKrisp
+		version_string.Format( "%s %d.%d.%d",
+								&driverProperties.driverName,
+							  ( prop.driverVersion >> 22 ) & 0x3ff,
+							  ( prop.driverVersion >> 12 ) & 0x3ff,
+							  ( prop.driverVersion ) & 0xfff );
+	}
+#else
+	// This section is adapted from php code at vulkan.gpuinfo.org/functions.php by Sascha Willems. See the following link:
+	// https://github.com/SaschaWillems/vulkan.gpuinfo.org/blob/1e6ca6e3c0763daabd6a101b860ab4354a07f5d3/functions.php#L294
+	// NVIDIA
+	if( glConfig.vendor == VENDOR_NVIDIA )
+	{
+		version_string.Format( "%s %d.%d.%d.%d",
+								&driverProperties.driverName,
+							  ( prop.driverVersion >> 22 ) & 0x3ff,
+							  ( prop.driverVersion >> 14 ) & 0x0ff,
+							  ( prop.driverVersion >> 6 ) & 0x0ff,
+							  ( prop.driverVersion ) & 0x003f );
+	}
+#if defined(_WIN32)
+	// INTEL on Windows
+	else if( glConfig.vendor == VENDOR_INTEL )
+	{
+		version_string.Format( "%s %d.%d",
+								&driverProperties.driverName,
+							  ( prop.driverVersion >> 14 ) & 0x3ffff,
+							  ( prop.driverVersion ) & 0x3fff );
+	}
+#endif
+	// AMD + OTHER
+	else
+	{
+		// Use Vulkan version conventions if vendor mapping is not available
+		version_string.Format( "%s %d.%d.%d",
+								&driverProperties.driverName,
+							  ( prop.driverVersion >> 22 ) & 0x3ff,
+							  ( prop.driverVersion >> 12 ) & 0x3ff,
+							  ( prop.driverVersion ) & 0xfff );
+	}
+#endif
+
+	common->Printf( "Created Vulkan device: %s (%s)\n", m_RendererString.c_str(), version_string.c_str() );
 
 	return true;
 }


### PR DESCRIPTION
This is a purely cosmetic improvement, but when testing the game against mutiple driver types/versions it would be convenient to see driver name/version information in the console log.  This would confirm the test results against the expected driver.  This change adds this capability for both Vulkan (driver name/version) and DX12 (UMD driver version).

Tested with AMD and Intel iGPUs on Windows 11 Vulkan and DX12, Linux Manjaro (Vulkan), and macOS Sequoia (MoltenVK and KosmicKrisp drivers for Vulkan-on-Metal).

Part of the new Vulkan code is adapted from vulkan.gpuinfo.org/functions.php by Sascha Willems.  Credit is given in the comments added by this PR.

Some examples below (new addition in _italics_):

**1. macOS on M1 MacBook Air and Intel x86_64 Mac + AMD RX6600XT:**

Created Vulkan device: Apple M1 _(MoltenVK 1.4.1)_
Created Vulkan device: Apple M1 _(KosmicKrisp 26.0.99)_
Created Vulkan device: AMD Radeon HD GFX10 Family Unknown Prototype _(MoltenVK 1.4.1)_

**2. Linux x64_64 on AMD RX6600XT and Intel iGPU:**

Created Vulkan device: AMD Radeon RX 6600 XT (RADV NAVI23) _(radv 25.3.3)_
Created Vulkan device: Intel(R) UHD Graphics 630 (CFL GT2) _(Intel open-source Mesa driver 25.3.3)_

**3. Windows x64_64 DX12 & Vulkan on AMD RX6600XT and Intel iGPU:**

Created DX12 device: AMD Radeon RX 6600 XT _(UMD driver 32.0.21037.1004)_
Created Vulkan device: AMD Radeon RX 6600 XT _(AMD proprietary driver 2.0.353)_
Created DX12 device: Intel(R) UHD Graphics 630 _(UMD driver 31.0.101.2111)_
Created Vulkan device: Intel(R) UHD Graphics 630 _(Intel Corporation 101.2111)_