### PR TITLE
Binding set [0] to pipeline layout [0] mismatch fix

### DIFF
--- a/neo/renderer/ImmediateMode.cpp
+++ b/neo/renderer/ImmediateMode.cpp
@@ -138,16 +138,19 @@ void fhImmediateMode::End()
 	vertexBuffer.Update( drawVerts, drawVertsUsed * sizeof( idDrawVert ), 0, false, commandList );
 	indexBuffer.Update( lineIndices, drawVertsUsed * sizeof( triIndex_t ), 0, false, commandList );
 
-	renderProgManager.CommitConstantBuffer( commandList, true );
-
 	int bindingLayoutType = renderProgManager.BindingLayoutType();
 
 	idStaticList<nvrhi::BindingLayoutHandle, nvrhi::c_MaxBindingLayouts>* layouts
 		= renderProgManager.GetBindingLayout( bindingLayoutType );
 
+	backEnd.GetCurrentBindingLayout( bindingLayoutType );
+
+	bool uniformsLayoutChanged = backEnd.prevBindingLayoutType >= 0 ? ( *layouts )[0] != ( *renderProgManager.GetBindingLayout( backEnd.prevBindingLayoutType ) )[0] : true;
+
 	for( int i = 0; i < layouts->Num(); i++ )
 	{
-		if( !backEnd.currentBindingSets[i] || *backEnd.currentBindingSets[i]->getDesc() != backEnd.pendingBindingSetDescs[bindingLayoutType][i] || bindingLayoutType != backEnd.prevBindingLayoutType )
+		// SRS - Update currentBindingSets[0] if uniforms binding layout has changed, can happen with push constants even if binding set descriptions match
+		if( !backEnd.currentBindingSets[i] || *backEnd.currentBindingSets[i]->getDesc() != backEnd.pendingBindingSetDescs[bindingLayoutType][i] || ( uniformsLayoutChanged && i == 0 ) )
 		{
 			backEnd.currentBindingSets[i] = backEnd.bindingCache.GetOrCreateBindingSet( backEnd.pendingBindingSetDescs[bindingLayoutType][i], ( *layouts )[i] );
 		}
@@ -158,6 +161,8 @@ void fhImmediateMode::End()
 	int program = renderProgManager.CurrentProgram();
 	PipelineKey key{ stateBits, program, static_cast<int>( backEnd.depthBias ), backEnd.slopeScaleBias, backEnd.currentFrameBuffer };
 	auto pipeline = backEnd.pipelineCache.GetOrCreatePipeline( key );
+
+	renderProgManager.CommitConstantBuffer( commandList, bindingLayoutType != backEnd.prevBindingLayoutType );
 
 	{
 		nvrhi::GraphicsState state;

--- a/neo/renderer/ImmediateMode.cpp
+++ b/neo/renderer/ImmediateMode.cpp
@@ -189,6 +189,10 @@ void fhImmediateMode::End()
 		commandList->setGraphicsState( state );
 
 		renderProgManager.CommitPushConstants( commandList, bindingLayoutType );
+
+		// SRS - Save context so state change detection works properly in DrawElementsWithCounters()
+		backEnd.prevBindingLayoutType = bindingLayoutType;
+		backEnd.currentPipeline = pipeline;
 	}
 
 	nvrhi::DrawArguments args;

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -446,9 +446,12 @@ void idRenderBackend::DrawElementsWithCounters( const drawSurf_t* surf, bool sha
 	{
 		GetCurrentBindingLayout( bindingLayoutType );
 
+		bool uniformsLayoutChanged = prevBindingLayoutType >= 0 ? ( *layouts )[0] != ( *renderProgManager.GetBindingLayout( prevBindingLayoutType ) )[0] : true;
+
 		for( int i = 0; i < layouts->Num(); i++ )
 		{
-			if( !currentBindingSets[i] || *currentBindingSets[i]->getDesc() != pendingBindingSetDescs[bindingLayoutType][i] || bindingLayoutType != prevBindingLayoutType )
+			// SRS - Update currentBindingSets[0] if uniforms binding layout has changed, can happen with push constants even if binding set descriptions match
+			if( !currentBindingSets[i] || *currentBindingSets[i]->getDesc() != pendingBindingSetDescs[bindingLayoutType][i] || ( uniformsLayoutChanged && i == 0 ) )
 			{
 				currentBindingSets[i] = bindingCache.GetOrCreateBindingSet( pendingBindingSetDescs[bindingLayoutType][i], ( *layouts )[i] );
 				changeState = true;

--- a/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
+++ b/neo/renderer/NVRHI/RenderBackend_NVRHI.cpp
@@ -540,6 +540,11 @@ void idRenderBackend::DrawElementsWithCounters( const drawSurf_t* surf, bool sha
 		commandList->setGraphicsState( state );
 
 		renderProgManager.CommitPushConstants( commandList, bindingLayoutType );
+
+		// keep track of last context to avoid setting up the binding layout and binding set again.
+		// SRS - Save context only if state actually changed - to keep currentBindingSets in sync
+		prevContext = context;
+		prevBindingLayoutType = bindingLayoutType;
 	}
 
 	//
@@ -550,10 +555,6 @@ void idRenderBackend::DrawElementsWithCounters( const drawSurf_t* surf, bool sha
 	args.startIndexLocation = currentIndexOffset / sizeof( triIndex_t );
 	args.vertexCount = surf->numIndexes;
 	commandList->drawIndexed( args );
-
-	// keep track of last context to avoid setting up the binding layout and binding set again.
-	prevContext = context;
-	prevBindingLayoutType = bindingLayoutType;
 
 	if( shadowCounter )
 	{

--- a/neo/renderer/RenderProgs.cpp
+++ b/neo/renderer/RenderProgs.cpp
@@ -405,11 +405,10 @@ void idRenderProgManager::Init( nvrhi::IDevice* device )
 	{
 		// SRS - FIXME: Workaround - Disable push constants for select shaders to reduce GPU Timeout Errors (seen on Linux+AMD and macOS+AMD)
 		//     - Possibly due to exceeding push constant resource limits or perhaps a driver sync problem with AMD GPUs
-		//     - Note this may not be required on Windows Vulkan+AMD, but being conservative with no negative impact
+		//     - Note this may not be required on Windows Vulkan+AMD, but being conservative with minimal impact
 		layoutTypeAttributes[BINDING_LAYOUT_GBUFFER].pcEnabled = false;
-		layoutTypeAttributes[BINDING_LAYOUT_GBUFFER_SKINNED].pcEnabled = false;
 		layoutTypeAttributes[BINDING_LAYOUT_TEXTURE].pcEnabled = false;
-		layoutTypeAttributes[BINDING_LAYOUT_TEXTURE_SKINNED].pcEnabled = false;
+		layoutTypeAttributes[BINDING_LAYOUT_CONSTANT_BUFFER_ONLY].pcEnabled = false;
 	}
 
 	auto defaultLayoutDesc = nvrhi::BindingLayoutDesc()


### PR DESCRIPTION
Provisionally fixes #1083.

This PR does three things:
1. Force updates `currentBindingSets[0]` if the uniforms layout has changed, even if the binding set descriptions match.  This can happen with push constants enabled since the descriptors only specify size, which is not unqiue between sets.  The new method is a more precise way of identifying uniforms layout changes vs. the simpler `bindingLayoutType` comparison which was used previously.  Note this approach may not result in any operational or perf change, but I believe is more correct.
2. Only saves the graphics state context for future change detection if a state change has actually occurred.  This _**may**_ be the cause of the layout mismatch error in #1083, but this still needs to be proven.  TBD with further testing needed from reporting users - @klaussilveira.
3. Updates the AMD GPU-specific  push contant workarounds to remove some low impact (`*_SKINNING`) cases and adds the `BINDING_LAYOUT_CONSTANT_BUFFER_ONLY` case.

These changes have been verified as working (no regressions seen) via stability testing on Windows 11 x86_64 + AMD, Manjaro Linux x86_64 + AMD, and macOS Sequoia x86_64 + AMD / Apple Silicon (arm64).  Additional testing on nVidia GPUs would be greatly appreciated!