### PR TITLE
Vulkan: fix runtime fullscreen-toggle deadlock on Wayland KDE/KWin + NVIDIA (recreate swap chain on VK_ERROR_OUT_OF_DATE_KHR)

### DIFF
--- a/neo/sys/DeviceManager_VK.cpp
+++ b/neo/sys/DeviceManager_VK.cpp
@@ -1555,11 +1555,30 @@ void DeviceManager_VK::BeginFrame()
 	}
 	commonLocal.SetRendererGpuMemoryMB( gpuMemoryAllocated / 1024 / 1024 );
 
-	const vk::Result res = m_VulkanDevice.acquireNextImageKHR( m_SwapChain,
-						   std::numeric_limits<uint64_t>::max(), // timeout
-						   m_PresentSemaphore,
-						   vk::Fence(),
-						   &m_SwapChainIndex );
+	vk::Result res = vk::Result::eSuccess;
+	for( int attempt = 0; attempt < 2; attempt++ )
+	{
+		res = m_VulkanDevice.acquireNextImageKHR( m_SwapChain,
+				std::numeric_limits<uint64_t>::max(), // timeout
+				m_PresentSemaphore,
+				vk::Fence(),
+				&m_SwapChainIndex );
+
+		if( res != vk::Result::eErrorOutOfDateKHR )
+		{
+			break;
+		}
+
+		// The swap chain no longer matches the surface, e.g. after a fullscreen
+		// transition on Wayland where the compositor invalidates it without a
+		// size change. A failed acquire leaves m_PresentSemaphore unsignaled, so
+		// rendering this frame would deadlock the graphics queue on the semaphore
+		// wait below. Recreate the swap chain and acquire again.
+		common->Printf( "vkAcquireNextImageKHR returned VK_ERROR_OUT_OF_DATE_KHR, recreating swap chain\n" );
+		BackBufferResizing();
+		ResizeSwapChain();
+		BackBufferResized();
+	}
 
 	assert( res == vk::Result::eSuccess || res == vk::Result::eSuboptimalKHR );
 


### PR DESCRIPTION
## Summary

Toggling `r_fullscreen` at runtime (e.g. from the video settings menu) permanently deadlocks the game on Wayland with **KDE/KWin + the NVIDIA proprietary driver**. Both exclusive (`r_fullscreen 1`) and borderless (`r_fullscreen -2`) transitions are affected. Starting the game already in fullscreen works; only the live toggle hangs.

Scope (from testing across compositors, see PR comments for the full matrix): the trigger is observed only on KWin driving a real display with NVIDIA — the same KWin nested, plus Weston, Sway, Mutter, and Hyprland, complete the identical transitions without ever returning `VK_ERROR_OUT_OF_DATE_KHR`, and the change is verified passive on X11/XWayland, Windows 11, and macOS. The likely mechanism is KWin's direct-scanout promotion of fullscreen surfaces invalidating the swapchain. Per spec, however, `VK_ERROR_OUT_OF_DATE_KHR` from `vkAcquireNextImageKHR` is legal on any platform, so the recovery is generally applicable.

## Environment

- master @ 95306db, Linux release build (`cmake-linux-release.sh`, GCC 16.1.1)
- CachyOS (Arch), KDE Plasma on Wayland, KWin 6.7.2
- NVIDIA proprietary driver 610.43.02 (RTX 3070), Vulkan loader 1.4.350
- SDL2 API via sdl2-compat on SDL3 (reproduced identically on SDL3 3.4.10 and 3.4.12)

## Reproduction (deterministic)

```
./RBDoom3BFG +set r_fullscreen 0 +wait 120 +set r_fullscreen 1 +vid_restart +wait 240 +set r_fullscreen 0 +vid_restart +wait 120 +quit
```

On unpatched master under KDE/KWin + NVIDIA this deadlocks every run; with this PR it completes every run, with the recovery path firing exactly once per transition cycle.

## Root cause

After `VKimp_SetScreenParms()` switches the window mode, KWin invalidates the swap chain. On the next frame, `vkAcquireNextImageKHR` in `DeviceManager_VK::BeginFrame()` returns `VK_ERROR_OUT_OF_DATE_KHR`. Instrumented trace:

```
[trace] BeginFrame: acquire result=0 image=1        <- last good frame
[trace] Present:    presentKHR result=0
[trace] BeginFrame: acquire result=-1000001004      <- VK_ERROR_OUT_OF_DATE_KHR
[trace] Present:    presentKHR result=-1000001004
[trace] BeginFrame: acquire result=-1000001004      <- second failed acquire
[trace] Present:    waitEventQuery (sync3)...       <- deadlock, never returns
```

The only guard on the acquire result is an `assert`, which is compiled out in release builds. The engine then:

1. proceeds with the failed acquire — per spec a failed `vkAcquireNextImageKHR` leaves the acquire semaphore **unsignaled**;
2. `queueWaitForSemaphore( m_PresentSemaphore )` makes the frame's command-list submission wait on that never-signaled semaphore, permanently wedging the graphics queue;
3. the next frame's `Present()` blocks forever in `waitEventQuery( m_FrameWaitQuery )` → `nvrhi::vulkan::Queue::waitCommandList` inside the driver, because the event query sits behind the wedged submission.

Stack at hang (main thread):

```
poll ()                                   <- libnvidia-glcore
nvrhi::vulkan::Queue::waitCommandList()
DeviceManager_VK::Present()
idRenderBackend::GL_BlockingSwapBuffers()
idRenderSystemLocal::SwapCommandBuffers()
idCommonLocal::Frame()
```

The existing size-based recreate path (`DeviceManager::UpdateWindowSize` → `ResizeSwapChain`) does not cover this: the compositor can invalidate the swap chain before the SDL resize event is seen, and for transitions at identical resolution there is no size change at all. X11 gets away with it because the driver reports `VK_SUBOPTIMAL_KHR` there, which still signals the semaphore.

## Fix

Handle `VK_ERROR_OUT_OF_DATE_KHR` in `BeginFrame()` by recreating the swap chain and re-acquiring before any work is queued on the unsignaled semaphore. The present-semaphore pool is created once in `CreateDeviceAndSwapChain()` and survives `ResizeSwapChain()`, so no semaphore management changes are needed. `Present()` needs no change: per spec a failed `vkQueuePresentKHR` still executes its semaphore wait.

## Verification

- KDE/KWin + NVIDIA (bare metal): deterministic repro deadlocks on master, completes cleanly with the fix, every run
- Full windowed → exclusive → windowed → borderless → windowed cycles: clean
- `r_useValidationLayers 2`: no validation errors introduced by the recovery path
- Compositor matrix (KWin nested, Weston, Sway, Mutter, Hyprland): change is passive — transitions verified, `VK_ERROR_OUT_OF_DATE_KHR` never returned
- X11/XWayland: passive; also verified passive on Windows 11 and macOS by @SRSaunders (thanks!)
- Composes cleanly with #1081 (tested combined, functionally and under validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
