### PR TITLE
Fix Vulkan command list timeouts on macOS + AMD GPUs when shadow mapping

### DIFF
--- a/neo/renderer/RenderBackend.cpp
+++ b/neo/renderer/RenderBackend.cpp
@@ -53,6 +53,9 @@ idCVar r_useStencilShadowPreload( "r_useStencilShadowPreload", "0", CVAR_RENDERE
 idCVar r_skipShaderPasses( "r_skipShaderPasses", "0", CVAR_RENDERER | CVAR_BOOL, "" );
 idCVar r_skipInteractionFastPath( "r_skipInteractionFastPath", "1", CVAR_RENDERER | CVAR_BOOL, "" );
 idCVar r_useLightStencilSelect( "r_useLightStencilSelect", "0", CVAR_RENDERER | CVAR_BOOL, "use stencil select pass" );
+#if defined(__APPLE__) && !USE_OPTICK
+idCVar r_mvkAMDShadowMappingFix( "r_mvkAMDShadowMappingFix", "1", CVAR_RENDERER | CVAR_BOOL | CVAR_NEW, "Use one command list per light when shadow mapping on macOS/MoltenVK + AMD" );
+#endif
 
 extern idCVar stereoRender_swapEyes;
 
@@ -3320,6 +3323,23 @@ void idRenderBackend::ShadowMapPassFast( const drawSurf_t* drawSurfs, viewLight_
 		return;
 	}
 
+#if defined(__APPLE__) && !USE_OPTICK
+	if( glConfig.vendor == VENDOR_AMD && r_mvkAMDShadowMappingFix.GetBool() )
+	{
+		// SRS - On AMD GPUs, break up commandList to avoid Vulkan driver command buffer overload/timeout issues seen on macOS/MoltenVK
+		//     - ShadowMapPassFast() is a command buffer hot spot and can generate approximately 75% of all GPU draw calls in a frame
+		//     - Breaking up command buffers on a per-light basis seems to be the correct chunking without causing too many submits
+		//     - Note: Optick depends on a single command buffer, so disable this stability fix when building with Optick enabled
+		if( prevViewLight && vLight != prevViewLight )
+		{
+			commandList->close();
+			deviceManager->GetDevice()->executeCommandList( commandList );
+			commandList->open();
+		}
+		prevViewLight = vLight;
+	}
+#endif
+
 	renderLog.OpenBlock( "Render_ShadowMaps", colorBrown );
 
 	renderProgManager.BindShader_Depth();
@@ -3699,6 +3719,7 @@ void idRenderBackend::ShadowAtlasPass( const viewDef_t* _viewDef )
 	shadowIndex = 0;
 	int failedNum = 0;
 
+	prevViewLight = NULL;
 	for( viewLight_t* vLight = viewDef->viewLights; vLight != NULL; vLight = vLight->next )
 	{
 		if( vLight->lightShader->IsFogLight() )
@@ -3856,6 +3877,7 @@ void idRenderBackend::DrawInteractions( const viewDef_t* _viewDef )
 	//
 	// for each light, perform shadowing and adding
 	//
+	prevViewLight = NULL;
 	for( const viewLight_t* vLight = viewDef->viewLights; vLight != NULL; vLight = vLight->next )
 	{
 		// do fogging later

--- a/neo/renderer/RenderBackend.h
+++ b/neo/renderer/RenderBackend.h
@@ -348,6 +348,7 @@ private:
 
 	idRenderMatrix		prevMVP[2];				// world MVP from previous frame for motion blur
 	bool				prevViewsValid;
+	viewLight_t*		prevViewLight;			// SRS - for AMD shadow mapping fix in ShadowMapPassFast()
 
 	// RB begin
 	// TODO remove

--- a/neo/renderer/RenderProgs.cpp
+++ b/neo/renderer/RenderProgs.cpp
@@ -40,6 +40,10 @@ If you have questions concerning this license or the applicable additional terms
 #include <nvrhi/utils.h>
 extern DeviceManager* deviceManager;
 
+#if defined(__APPLE__) && !USE_OPTICK
+extern idCVar r_mvkAMDShadowMappingFix;
+#endif
+
 idRenderProgManager renderProgManager;
 
 /*
@@ -400,16 +404,27 @@ void idRenderProgManager::Init( nvrhi::IDevice* device )
 	layoutTypeAttributes[BINDING_LAYOUT_HISTOGRAM].pcEnabled = sizeof( ToneMappingConstants ) <= deviceManager->GetMaxPushConstantSize();
 	layoutTypeAttributes[BINDING_LAYOUT_EXPOSURE].pcEnabled = sizeof( ToneMappingConstants ) <= deviceManager->GetMaxPushConstantSize();
 
-	// SRS - Apply push constant workarounds for Vulkan running on AMD vs. other GPUs (and also needs to work for Universal Binaries on macOS)
-	if( deviceManager->GetGraphicsAPI() == nvrhi::GraphicsAPI::VULKAN && glConfig.vendor == VENDOR_AMD )
+#if defined(__APPLE__)
+	// SRS - Apply push constant workarounds for Vulkan running on macOS/MoltenVK + AMD (also needs to work for Universal Binaries on macOS)
+	if( glConfig.vendor == VENDOR_AMD )
 	{
-		// SRS - FIXME: Workaround - Disable push constants for select shaders to reduce GPU Timeout Errors (seen on Linux+AMD and macOS+AMD)
-		//     - Possibly due to exceeding push constant resource limits or perhaps a driver sync problem with AMD GPUs
-		//     - Note this may not be required on Windows Vulkan+AMD, but being conservative with minimal impact
-		layoutTypeAttributes[BINDING_LAYOUT_GBUFFER].pcEnabled = false;
-		layoutTypeAttributes[BINDING_LAYOUT_TEXTURE].pcEnabled = false;
-		layoutTypeAttributes[BINDING_LAYOUT_CONSTANT_BUFFER_ONLY].pcEnabled = false;
+#if !USE_OPTICK
+		// SRS - We can skip these push constant workarounds if using the AMD shadow mapping fix (see idRenderBackend::ShadowMapPassFast)
+		//     - Note: Optick is not compatible with the AMD shadow mapping fix, so don't skip these when building with Optick enabled
+		if( !r_mvkAMDShadowMappingFix.GetBool() )
+#endif
+		{
+			// SRS - FIXME: Workaround - Disable push constants for select shaders to reduce GPU Timeout Errors (seen on macOS+AMD)
+			//     - Possibly due to exceeding push constant resource limits or perhaps a driver sync problem on macOS + AMD GPUs
+			layoutTypeAttributes[BINDING_LAYOUT_GBUFFER].pcEnabled = false;
+			layoutTypeAttributes[BINDING_LAYOUT_GBUFFER_SKINNED].pcEnabled = false;
+			layoutTypeAttributes[BINDING_LAYOUT_TEXTURE].pcEnabled = false;
+			layoutTypeAttributes[BINDING_LAYOUT_TEXTURE_SKINNED].pcEnabled = false;
+			layoutTypeAttributes[BINDING_LAYOUT_CONSTANT_BUFFER_ONLY].pcEnabled = false;
+			layoutTypeAttributes[BINDING_LAYOUT_CONSTANT_BUFFER_ONLY_SKINNED].pcEnabled = false;
+		}
 	}
+#endif
 
 	auto defaultLayoutDesc = nvrhi::BindingLayoutDesc()
 							 .setVisibility( nvrhi::ShaderType::Pixel )


### PR DESCRIPTION
This PR fixes a long standing stability issue observed on macOS / MoltenVK on x86_64 + AMD GPUs.  Command buffer timeouts can occur with this combination, resulting in game freezes followed by VK_ERROR_DEVICE_LOST.

See the following:

_Execution of the command buffer was aborted due to an error during execution. Caused GPU Timeout Error (00000002:kIOAccelCommandBufferCallbackErrorTimeout)
[mvk-error] VK_TIMEOUT: Lost VkDevice after MTLCommandBuffer "vkQueueSubmit MTLCommandBuffer on Queue 0-0" execution failed (code 2): Caused GPU Timeout Error (00000002:kIOAccelCommandBufferCallbackErrorTimeout)
WARNING: idSessionLocal::Pump was not called for 11 seconds
Assertion failed: (res == vk::Result::eSuccess || res == vk::Result::eNotReady), function pollTimerQuery, file vulkan-queries.cpp, line 166._

The cause of the problem appears to an issue in the processing of a single large command buffer per frame on macOS/MoltenVK with AMD GPU hardware.  These timeouts do not occur on macOS + Apple Silicon, nor are they seen on Linux or Windows.  There was already a workaround in place which disables push constants for the most frequent binding layout types on AMD GPUs, which does help limit command buffer size.  However, this does not completely eliminate the timeout problem which can still be observed even with push constants fully disabled.

The proposed solution in this PR splits the command buffer into multiple submits per frame. The shadow mapping pass represents approximately 75% of all draw calls within a frame, so it naturally becomes the point of focus.  This PR breaks up the command buffer on a per-light basis while doing shadow mapping (Atlas on or off).  This results in a reasonable chunk size per command buffer, and a reasonable number of additional submits per frame (number of lights in scene).

This change only applies to macOS/MoltenVK when running on x86_64 + AMD GPU hardware.  The result is the elimination of timeouts seen above, at least with my AMD RX6600 XT card.  Note this stability fix is only appropriate when Optick is disabled, since Optick depends on a single command buffer to work properly.  When Optick is enabled in the build, the fix in this PR is disabled.  A new cvar (`r_mvkAMDShadowMappingFix`) is also available to control the fix based on config (default = ON, or fix enabled).

A further optimization disables the previous push constant workarounds when the shadow mapping fix is active, and reenables them when the fix is inactive. In addition, these push constant workarounds are now limited to macOS + AMD GPUs.  Previously they applied to AMD GPUs on all platforms - this turned out to be unnecessary during testing.

Tested on macOS Sequoia on x86_64 + AMD GPU (RX 6600XT).  Regression tested on all other platforms: Apple Silicon, Linux x86_64, and Windows 11 x86_64.

Note: Interestingly, in scenes with significant lighting, performance when `r_mvkAMDShadowMappingFix = 1 ` (enabled) can be slightly better (5-10%) than with it off.  I suspect this is due to splitting up Metal encoding and reducing latency by getting started on Vulkan-to-Metal conversion and AMD GPU rendering earlier in the frame.  This improvement is not applicable to macOS + Apple Silicon, nor on other platforms (Windows & Linux).